### PR TITLE
feat(client): warn on a user having a conflicting solidity extension

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -138,10 +138,11 @@ async function warnOnOtherSolidityExtensions() {
 
 	try {
 		await window.showWarningMessage(
-			`Both this extension and the \`${CONFLICTING_EXTENSION_NAME}\` (${CONFLICTING_EXTENSION_ID}) extension are enabled. They have conflicting functionality. Disable one of them.`, "Okay"
+			`Both this extension and the \`${CONFLICTING_EXTENSION_NAME}\` (${CONFLICTING_EXTENSION_ID}) extension are enabled. They have conflicting functionality. Disable one of them.`,
+			"Okay"
 		);
-	} catch(error: unknown) {
-		console.error(error);
+	} catch (err) {
+		console.error(err);
 	}
 }
 
@@ -151,9 +152,9 @@ export function activate(context: ExtensionContext) {
 	warnOnOtherSolidityExtensions();
 
 	context.subscriptions.push(
-        languages.registerDocumentFormattingEditProvider('solidity', {
-            provideDocumentFormattingEdits(document: TextDocument): TextEdit[] {
-                return formatDocument(document, context);
+		languages.registerDocumentFormattingEditProvider('solidity', {
+			provideDocumentFormattingEdits(document: TextDocument): TextEdit[] {
+				return formatDocument(document, context);
 			}
 		})
 	);


### PR DESCRIPTION
The hardhat extension and the solidity extension (juanblanco.solidity) have overlapping functionality, we warn the user to disable one of them to get the best experience.

The warning takes the form of a popup, checked for on extension activation.

## Preview

![warning](https://user-images.githubusercontent.com/24030/146415644-eba2a671-e5e1-4ab4-b9e3-ddb886b644c9.gif)

### Static

![image](https://user-images.githubusercontent.com/24030/146415852-80afc095-1684-454e-a11d-7fad75809549.png)

## Implementation

* on extension activation check the installed plugins for `juanblanco.solidity`, show a warning message if so
* the id and extension name of the hardhat plugin is derived from the package.json via extension context

