### PR TITLE
Fix clear error on typing

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -377,10 +377,7 @@ export default function setupServer(
     }
 
     if (!debounceAnalyzeDocument[change.document.uri]) {
-      debounceAnalyzeDocument[change.document.uri] = debounce(
-        analyzeFunc,
-        500,
-      );
+      debounceAnalyzeDocument[change.document.uri] = debounce(analyzeFunc, 500);
     }
 
     debounceAnalyzeDocument[change.document.uri](
@@ -395,7 +392,7 @@ export default function setupServer(
     if (!debounceValidateDocument[change.document.uri]) {
       debounceValidateDocument[change.document.uri] = debounce(
         validateTextDocument,
-        500,
+        500
       );
     }
 


### PR DESCRIPTION
In the current version, the error happens an error message will stay for 60sec before gone. These fix will clear errors when someone starts typing.

How does it work?
It depends on our custom debounce function that checks if every first argument have `close` function and if they have they will call it when another job comes into debounce queue

Need to see how this will impact quick-fix warnings feature