### PR TITLE
fix(syntaxes): include missing operators

### DIFF
--- a/syntaxes/solidity.json
+++ b/syntaxes/solidity.json
@@ -177,7 +177,7 @@
       ]
     },
     "operator-logic": {
-      "match": "(==|<(?!<)|<=|>(?!>)|>=|\\&\\&|\\|\\||\\:(?!=)|\\?)",
+      "match": "(!|==|!=|<(?!<)|<=|>(?!>)|>=|\\&\\&|\\|\\||\\:(?!=)|\\?)",
       "name": "keyword.operator.logic"
     },
     "operator-mapping": {
@@ -185,7 +185,7 @@
       "name": "keyword.operator.mapping"
     },
     "operator-arithmetic": {
-      "match": "(\\+|\\-|\\/|\\*)",
+      "match": "(\\+|\\-|\\/|\\%|\\*)",
       "name": "keyword.operator.arithmetic"
     },
     "operator-binary": {


### PR DESCRIPTION
`Modulo` (`%`), `not equal` (`!=`) and `not` (`!`) have been included in the syntax highlighting.

Fixes #64

# Testing

Testing has been done manually, as evidence, before:

![image](https://user-images.githubusercontent.com/24030/153237677-f5e32487-a6b3-4fb1-aef5-fb0dd98b2c46.png)

After:

![image](https://user-images.githubusercontent.com/24030/153237850-7f1240b2-6536-465c-81d7-85bfdde32432.png)
