### PR TITLE
fix(syntaxes): remove comment todo tags

### DIFF
--- a/syntaxes/solidity.json
+++ b/syntaxes/solidity.json
@@ -70,9 +70,6 @@
     "natspec-tags": {
       "patterns": [
         {
-          "include": "#comment-todo"
-        },
-        {
           "include": "#natspec-tag-title"
         },
         {


### PR DESCRIPTION
We have opted not to highlight the todo tag keywords in comments. See the discussion in #51 for more details.

Fixes #51

## Testing

Testing is manual only, but as evidence, before:

![Screenshot 2022-02-09 at 16 01 06](https://user-images.githubusercontent.com/24030/153241541-49cb51cf-9958-47d1-a50b-aeb32aa094e3.png)

After:

![Screenshot 2022-02-09 at 16 07 05](https://user-images.githubusercontent.com/24030/153241579-785330c2-cd40-45bb-8c81-77c6f79fbc9d.png)


