### PR TITLE
fix: exclude interface functions in find impl

### DIFF
--- a/server/test/helpers/setupMockLanguageServer.ts
+++ b/server/test/helpers/setupMockLanguageServer.ts
@@ -13,6 +13,7 @@ import {
   SignatureHelpParams,
   TextDocumentItem,
   ReferenceParams,
+  ImplementationParams,
   Location,
 } from "vscode-languageserver/node";
 import setupServer from "../../src/server";
@@ -34,6 +35,9 @@ export type OnTypeDefinition = (
 ) => Definition | DefinitionLink[] | null;
 export type OnReferences = (
   params: ReferenceParams
+) => Location[] | undefined | null;
+export type OnImplementation = (
+  params: ImplementationParams
 ) => Location[] | undefined | null;
 
 export async function setupMockLanguageServer({
@@ -78,6 +82,8 @@ export async function setupMockLanguageServer({
     mockConnection.onTypeDefinition.getCall(0).firstArg;
   const references: OnReferences =
     mockConnection.onReferences.getCall(0).firstArg;
+  const implementation: OnImplementation =
+    mockConnection.onImplementation.getCall(0).firstArg;
 
   const didOpenTextDocument =
     mockConnection.onDidOpenTextDocument.getCall(0).firstArg;
@@ -132,6 +138,7 @@ export async function setupMockLanguageServer({
       definition,
       typeDefinition,
       references,
+      implementation,
     },
   };
 }

--- a/server/test/parser/services/navigation/implementation.ts
+++ b/server/test/parser/services/navigation/implementation.ts
@@ -1,0 +1,90 @@
+import { assert } from "chai";
+import * as path from "path";
+import { VSCodePosition } from "@common/types";
+import {
+  OnImplementation,
+  setupMockLanguageServer,
+} from "../../../helpers/setupMockLanguageServer";
+
+describe("Parser", () => {
+  describe("Navigation", () => {
+    describe("Implementation", () => {
+      const implementationUri = path.join(
+        __dirname,
+        "testData",
+        "Implementation.sol"
+      );
+      let implementation: OnImplementation;
+
+      before(async () => {
+        ({
+          server: { implementation },
+        } = await setupMockLanguageServer({
+          documents: [{ uri: implementationUri, analyze: true }],
+          errors: [],
+        }));
+      });
+
+      describe("on functions", () => {
+        describe("in interfaces", () => {
+          it("should navigate from interface declaration to implementing functions", () =>
+            assertImplementationNavigation(
+              implementation,
+              implementationUri,
+              { line: 8, character: 11 },
+              [
+                {
+                  start: { line: 12, character: 11 },
+                  end: { line: 12, character: 21 },
+                },
+                {
+                  start: { line: 18, character: 11 },
+                  end: { line: 18, character: 21 },
+                },
+              ]
+            ));
+        });
+
+        describe("in abstract classes", () => {
+          it("should navigate from abstract function declaration to implementing functions", () =>
+            assertImplementationNavigation(
+              implementation,
+              implementationUri,
+              { line: 28, character: 11 },
+              [
+                {
+                  start: { line: 32, character: 11 },
+                  end: { line: 32, character: 21 },
+                },
+                {
+                  start: { line: 38, character: 11 },
+                  end: { line: 38, character: 21 },
+                },
+              ]
+            ));
+        });
+      });
+    });
+  });
+});
+
+const assertImplementationNavigation = async (
+  implementation: OnImplementation,
+  uri: string,
+  position: VSCodePosition,
+  expectedRanges: { start: VSCodePosition; end: VSCodePosition }[]
+) => {
+  const response = await implementation({ textDocument: { uri }, position });
+
+  if (!response || !Array.isArray(response)) {
+    assert.fail();
+  }
+
+  assert.exists(response);
+
+  assert.deepStrictEqual(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    response.map((elem: any) => elem.range).filter((x) => !!x),
+    expectedRanges
+  );
+};

--- a/server/test/parser/services/navigation/testData/Implementation.sol
+++ b/server/test/parser/services/navigation/testData/Implementation.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.7.0 <0.9.0;
+
+interface IFooBase {
+  function baseFunction() external;
+}
+
+interface IFoo is IFooBase {
+  function myFunction() external;
+}
+
+contract Foo is IFoo {
+  function myFunction() public override {}
+
+  function baseFunction() external override {}
+}
+
+contract Bar is IFoo {
+  function myFunction() public override {}
+
+  function baseFunction() external override {}
+}
+
+abstract contract BazBase {
+  function baseFunction() external virtual;
+}
+
+abstract contract Baz is BazBase {
+  function myFunction() external virtual;
+}
+
+contract Bof is Baz {
+  function myFunction() public override {}
+
+  function baseFunction() external virtual override {}
+}
+
+contract Bif is Baz {
+  function myFunction() public override {}
+
+  function baseFunction() external virtual override {}
+}


### PR DESCRIPTION
Find implementation for functions now excludes function definitions that are on interfaces or are
abstract in an abstract class. The test for this is that their bodies are null in the AST.

Fixes #44

## Preview

![Feb-11-2022 11-11-00](https://user-images.githubusercontent.com/24030/153581750-3c7a604f-2ddd-4047-bd8d-c172384437a7.gif)

