### PR TITLE
fix(navigation): fn nav based on param cardinality

### DIFF
--- a/server/src/parser/analyzer/utils/typeGuards.ts
+++ b/server/src/parser/analyzer/utils/typeGuards.ts
@@ -1,6 +1,14 @@
-import { ASTNode, ContractDefinition, Node } from "@common/types";
+import {
+  ASTNode,
+  ContractDefinition,
+  FunctionDefinition,
+  FunctionCall,
+  Node,
+} from "@common/types";
 import { ContractDefinitionNode } from "../nodes/ContractDefinitionNode";
 import { FunctionDefinitionNode } from "../nodes/FunctionDefinitionNode";
+import { MemberAccessNode } from "../nodes/MemberAccessNode";
+import { FunctionCallNode } from "../nodes/FunctionCallNode";
 
 export function isContractDefinition(
   node: ASTNode
@@ -14,8 +22,26 @@ export function isContractDefinitionNode(
   return node.type === "ContractDefinition";
 }
 
+export function isFunctionDefinition(
+  node: ASTNode
+): node is FunctionDefinition {
+  return node.type === "FunctionDefinition";
+}
+
 export function isFunctionDefinitionNode(
   node: Node
 ): node is FunctionDefinitionNode {
   return node.type === "FunctionDefinition";
+}
+
+export function isMemberAccessNode(node: Node): node is MemberAccessNode {
+  return node.type === "MemberAccess";
+}
+
+export function isFunctionCall(node: ASTNode): node is FunctionCall {
+  return node.type === "FunctionCall";
+}
+
+export function isFunctionCallNode(node: Node): node is FunctionCallNode {
+  return node.type === "FunctionCall";
 }

--- a/server/test/parser/services/navigation/definition.ts
+++ b/server/test/parser/services/navigation/definition.ts
@@ -15,28 +15,27 @@ describe("Parser", () => {
           "testData",
           "Definition.sol"
         );
+
         const twoContractUri = path.join(
           __dirname,
           "testData",
           "TwoContracts.sol"
         );
+
         let definition: OnDefinition;
 
-        before(async () => {
-          ({
-            server: { definition },
-          } = await setupMockLanguageServer({
-            documents: [
-              { uri: definitionUri, analyze: true },
-              { uri: twoContractUri, analyze: true },
-            ],
-            errors: [],
-          }));
-
-          await new Promise((resolve) => setTimeout(resolve, 500));
-        });
-
         describe("within contract", () => {
+          before(async () => {
+            ({
+              server: { definition },
+            } = await setupMockLanguageServer({
+              documents: [{ uri: definitionUri, analyze: true }],
+              errors: [],
+            }));
+
+            await new Promise((resolve) => setTimeout(resolve, 500));
+          });
+
           it("should navigate to the attribute", () =>
             assertDefinitionNavigation(
               definition,
@@ -91,9 +90,57 @@ describe("Parser", () => {
                 end: { line: 33, character: 12 },
               }
             ));
+
+          describe("function overloads", () => {
+            it("should navigate to function with overloads", () =>
+              assertDefinitionNavigation(
+                definition,
+                definitionUri,
+                { line: 70, character: 9 },
+                {
+                  start: { line: 39, character: 11 },
+                  end: { line: 39, character: 22 },
+                }
+              ));
+
+            it("should distinguish between overloads based on parameter cardinality", () =>
+              assertDefinitionNavigation(
+                definition,
+                definitionUri,
+                { line: 71, character: 9 },
+                {
+                  start: { line: 43, character: 11 },
+                  end: { line: 43, character: 22 },
+                }
+              ));
+
+            // Differentiating functions based on parameter list types has
+            // still to be done
+            it.skip("should distinguish between overloads based on parameter types", () =>
+              assertDefinitionNavigation(
+                definition,
+                definitionUri,
+                { line: 72, character: 9 },
+                {
+                  start: { line: 51, character: 11 },
+                  end: { line: 51, character: 22 },
+                }
+              ));
+          });
         });
 
         describe("between inheriting contracts", () => {
+          before(async () => {
+            ({
+              server: { definition },
+            } = await setupMockLanguageServer({
+              documents: [{ uri: twoContractUri, analyze: true }],
+              errors: [],
+            }));
+
+            await new Promise((resolve) => setTimeout(resolve, 500));
+          });
+
           it("should navigate from constructor extension to contract declaration if underlying constructor does not exist", () =>
             assertDefinitionNavigation(
               definition,
@@ -131,6 +178,17 @@ describe("Parser", () => {
         });
 
         describe("between unrelated contracts", () => {
+          before(async () => {
+            ({
+              server: { definition },
+            } = await setupMockLanguageServer({
+              documents: [{ uri: twoContractUri, analyze: true }],
+              errors: [],
+            }));
+
+            await new Promise((resolve) => setTimeout(resolve, 500));
+          });
+
           it("should navigate from constructor invocation to contract declaration if constructor does not exist", () =>
             assertDefinitionNavigation(
               definition,

--- a/server/test/parser/services/navigation/testData/Definition.sol
+++ b/server/test/parser/services/navigation/testData/Definition.sol
@@ -35,3 +35,43 @@ contract Test {
     bytes32 name;
   }
 }
+
+contract Overloaded {
+  function forOverload() public pure returns (string memory) {
+    return "first";
+  }
+
+  function forOverload(string memory input)
+    public
+    pure
+    returns (string memory)
+  {
+    return input;
+  }
+
+  function forOverload(uint120 input) public pure returns (string memory) {
+    if (input == 1) {
+      return "third";
+    }
+
+    return "third";
+  }
+}
+
+contract User {
+  Overloaded base;
+
+  constructor(address o) {
+    base = Overloaded(o);
+  }
+
+  function getString() public view returns (string memory) {
+    uint120 aNumber = 5;
+
+    base.forOverload();
+    base.forOverload("example2");
+    base.forOverload(aNumber);
+
+    return "a string";
+  }
+}


### PR DESCRIPTION
When linking member accesses to a function in analyzing the AST, we now take into account the cardinality of the parameter list, so a function call will be linked with function that has same number of parameters as it is called with.

We do not yet take into account the types of parameters, so there can be a miss navigation to a function with the same name and parameter number but different parameters.

Fixes #63

## Preview
![overloads](https://user-images.githubusercontent.com/24030/154659752-91919098-8b53-41ea-b72a-5b7b6c00fc30.gif)

