### PR TITLE
fix(validation): explicit exit in compilation

### DIFF
--- a/server/src/parser/services/validation/helper.ts
+++ b/server/src/parser/services/validation/helper.ts
@@ -176,7 +176,9 @@ export const HARDHAT_CONFIG_FILE_EXIST_EVENT = "hardhat_config_file_exist";
         compilationJobIndex: 0,
       });
 
-      process.send({ type: SOLIDITY_COMPILE_EVENT, output });
+      process.send({ type: SOLIDITY_COMPILE_EVENT, output }, () => {
+        process.exit();
+      });
     }
   } catch (err) {
     process.exit(1);


### PR DESCRIPTION
The explicit `process.exit()` was removed as it was stopping the final
`process.send` from completing. However, this stopped the process from
being cleaned up, and deallocating the memory associated with the
thread.

The fix is to exit on the send message callback.

Fixes #79