### PR TITLE
fix(analyzer): emit `indexing-file` on no files

### DIFF
--- a/server/src/parser/analyzer/index.ts
+++ b/server/src/parser/analyzer/index.ts
@@ -1,10 +1,10 @@
+import * as events from "events";
 import * as fs from "fs";
-import * as path from "path";
 import * as parser from "@solidity-parser/parser";
 import * as matcher from "@analyzer/matcher";
 import { Searcher } from "@analyzer/searcher";
 import { BROWNIE_PACKAGE_PATH } from "@analyzer/resolver";
-import { IndexFileData, eventEmitter as em } from "@common/event";
+import { IndexFileData } from "@common/event";
 import {
   Node,
   SourceUnitNode,
@@ -19,15 +19,21 @@ import { Logger } from "@utils/Logger";
 
 export class Analyzer {
   rootPath: string | null;
-  logger: Logger;
+  em: events.EventEmitter;
   workspaceFileRetriever: WorkspaceFileRetriever;
+  logger: Logger;
 
   documentsAnalyzer: DocumentsAnalyzerMap = {};
 
-  constructor(workspaceFileRetriever: WorkspaceFileRetriever, logger: Logger) {
+  constructor(
+    workspaceFileRetriever: WorkspaceFileRetriever,
+    em: events.EventEmitter,
+    logger: Logger
+  ) {
     this.rootPath = null;
-    this.logger = logger;
+    this.em = em;
     this.workspaceFileRetriever = workspaceFileRetriever;
+    this.logger = logger;
   }
 
   public init(rootPath: string): Analyzer {
@@ -44,8 +50,16 @@ export class Analyzer {
       this.logger.info("Starting workspace indexing ...");
 
       this.logger.info("Scanning workspace for sol files");
-      this.findSolFiles(rootPath, documentsUri);
-      this.findSolFiles(BROWNIE_PACKAGE_PATH, documentsUri);
+      this.workspaceFileRetriever.findSolFiles(
+        rootPath,
+        documentsUri,
+        this.logger
+      );
+      this.workspaceFileRetriever.findSolFiles(
+        BROWNIE_PACKAGE_PATH,
+        documentsUri,
+        this.logger
+      );
       this.logger.info(`Scan complete, ${documentsUri.length} sol files found`);
 
       // Init all documentAnalyzers
@@ -58,34 +72,46 @@ export class Analyzer {
       }
 
       this.logger.info("File indexing starting");
-      // We will initialize all DocumentAnalizers first, because when we analyze documents we enter to their imports and
-      // if they are not analyzed we analyze them, in order to be able to analyze imports we need to have DocumentAnalizer and
-      // therefore we initiate everything first. The isAnalyzed serves to check if the document was analyzed so we don't analyze the document twice.
-      for (let i = 0; i < documentsUri.length; i++) {
-        const documentUri = documentsUri[i];
 
-        try {
-          const documentAnalyzer = this.getDocumentAnalyzer(documentUri);
-          // if (documentAnalyzer.uri.includes("node_modules")) {
-          //     continue;
-          // }
+      if (documentsUri.length > 0) {
+        // We will initialize all DocumentAnalizers first, because when we analyze documents we enter to their imports and
+        // if they are not analyzed we analyze them, in order to be able to analyze imports we need to have DocumentAnalizer and
+        // therefore we initiate everything first. The isAnalyzed serves to check if the document was analyzed so we don't analyze the document twice.
+        for (let i = 0; i < documentsUri.length; i++) {
+          const documentUri = documentsUri[i];
 
-          const data: IndexFileData = {
-            path: documentUri,
-            current: i + 1,
-            total: documentsUri.length,
-          };
+          try {
+            const documentAnalyzer = this.getDocumentAnalyzer(documentUri);
+            // if (documentAnalyzer.uri.includes("node_modules")) {
+            //     continue;
+            // }
 
-          em.emit("indexing-file", data);
-          this.logger.trace("Indexing file", data);
+            const data: IndexFileData = {
+              path: documentUri,
+              current: i + 1,
+              total: documentsUri.length,
+            };
 
-          if (!documentAnalyzer.isAnalyzed) {
-            documentAnalyzer.analyze(this.documentsAnalyzer);
+            this.em.emit("indexing-file", data);
+            this.logger.trace("Indexing file", data);
+
+            if (!documentAnalyzer.isAnalyzed) {
+              documentAnalyzer.analyze(this.documentsAnalyzer);
+            }
+          } catch (err) {
+            this.logger.error(err);
+            this.logger.trace("Analysis of file failed", { documentUri });
           }
-        } catch (err) {
-          this.logger.error(err);
-          this.logger.trace("Analysis of file failed", { documentUri });
         }
+      } else {
+        const data: IndexFileData = {
+          path: "",
+          current: 0,
+          total: 0,
+        };
+
+        this.em.emit("indexing-file", data);
+        this.logger.trace("No files to index", data);
       }
 
       this.logger.info("File indexing complete");
@@ -123,40 +149,6 @@ export class Analyzer {
   public analyzeDocument(document: string, uri: string): Node | undefined {
     const documentAnalyzer = this.getDocumentAnalyzer(uri);
     return documentAnalyzer.analyze(this.documentsAnalyzer, document);
-  }
-
-  private findSolFiles(base: string | undefined, documentsUri: string[]): void {
-    if (!base) {
-      return;
-    }
-
-    try {
-      if (!fs.existsSync(base)) {
-        this.logger.trace("Sol file scan could not find directory", {
-          directory: base,
-        });
-
-        return;
-      }
-
-      const files = fs.readdirSync(base);
-
-      files.forEach((file) => {
-        const newBase = path.join(base || "", file);
-
-        if (fs.statSync(newBase).isDirectory()) {
-          this.findSolFiles(newBase, documentsUri);
-        } else if (
-          newBase.slice(-4) === ".sol" &&
-          newBase.split("node_modules").length < 3 &&
-          !documentsUri.includes(newBase)
-        ) {
-          documentsUri.push(newBase);
-        }
-      });
-    } catch (err) {
-      this.logger.error(err);
-    }
   }
 }
 

--- a/server/src/parser/common/event/index.ts
+++ b/server/src/parser/common/event/index.ts
@@ -1,9 +1,5 @@
-import * as events from "events";
-
 export type IndexFileData = {
   path: string;
   current: number;
   total: number;
 };
-
-export const eventEmitter = new events.EventEmitter();

--- a/server/src/parser/index.ts
+++ b/server/src/parser/index.ts
@@ -1,3 +1,4 @@
+import * as events from "events";
 import { Analyzer } from "@analyzer/index";
 import { SolidityNavigation } from "@services/navigation/SolidityNavigation";
 import { SolidityCompletion } from "@services/completion/SolidityCompletion";
@@ -17,9 +18,10 @@ export class LanguageService {
   constructor(
     compProcessFactory: typeof compilerProcessFactory,
     workspaceFileRetriever: WorkspaceFileRetriever,
+    em: events.EventEmitter,
     logger: Logger
   ) {
-    this.analyzer = new Analyzer(workspaceFileRetriever, logger);
+    this.analyzer = new Analyzer(workspaceFileRetriever, em, logger);
     this.solidityNavigation = new SolidityNavigation(this.analyzer);
     this.solidityCompletion = new SolidityCompletion(this.analyzer);
     this.solidityValidation = new SolidityValidation(

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,3 +1,4 @@
+import * as events from "events";
 import { Connection } from "vscode-languageserver";
 import { TextDocuments } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
@@ -15,6 +16,7 @@ export type ServerState = {
 
   connection: Connection;
   documents: TextDocuments<TextDocument>;
+  em: events.EventEmitter;
   languageServer: LanguageService;
   analytics: Analytics;
   telemetry: Telemetry;

--- a/server/test/parser/analyzer.ts
+++ b/server/test/parser/analyzer.ts
@@ -1,0 +1,103 @@
+import * as events from "events";
+import * as path from "path";
+import { Analyzer } from "@analyzer/index";
+import { assert } from "chai";
+import { setupMockLogger } from "../helpers/setupMockLogger";
+import { IndexFileData } from "@common/event";
+
+describe("Analyzer", () => {
+  describe("indexing", () => {
+    const exampleRootPath = __dirname;
+    let collectedData: IndexFileData[];
+    let foundSolFiles: string[];
+
+    describe("with multiple files", () => {
+      beforeEach(() => {
+        collectedData = [];
+        foundSolFiles = ["example1.sol", "example2.sol", "example3.sol"];
+
+        const analyzer = setupAnalyzer(
+          exampleRootPath,
+          foundSolFiles,
+          collectedData
+        );
+
+        // trigger the indexing
+        analyzer.init(exampleRootPath);
+      });
+
+      it("should emit an indexing event for each", () => {
+        assert.equal(collectedData.length, foundSolFiles.length);
+        assert.deepEqual(collectedData, [
+          {
+            path: path.join(__dirname, "example1.sol"),
+            current: 1,
+            total: 3,
+          },
+          {
+            path: path.join(__dirname, "example2.sol"),
+            current: 2,
+            total: 3,
+          },
+          {
+            path: path.join(__dirname, "example3.sol"),
+            current: 3,
+            total: 3,
+          },
+        ]);
+      });
+    });
+
+    describe("with no files found", () => {
+      beforeEach(() => {
+        collectedData = [];
+        foundSolFiles = [];
+
+        const analyzer = setupAnalyzer(
+          exampleRootPath,
+          foundSolFiles,
+          collectedData
+        );
+
+        // trigger the indexing
+        analyzer.init(exampleRootPath);
+      });
+
+      it("should emit an indexing event for each", () => {
+        assert.equal(collectedData.length, 1);
+        assert.deepEqual(collectedData, [
+          {
+            path: "",
+            current: 0,
+            total: 0,
+          },
+        ]);
+      });
+    });
+  });
+});
+
+function setupAnalyzer(
+  rootPath: string,
+  foundSolFiles: string[],
+  collectedData: IndexFileData[]
+): Analyzer {
+  const em = new events.EventEmitter();
+  const logger = setupMockLogger();
+
+  em.on("indexing-file", (data) => collectedData.push(data));
+
+  const mockWorkspaceFileRetriever = {
+    findSolFiles: (base: string | undefined, documentsUri: string[]) => {
+      if (base !== rootPath) {
+        return;
+      }
+
+      for (const foundSolFile of foundSolFiles) {
+        documentsUri.push(path.join(base ?? "", foundSolFile));
+      }
+    },
+  };
+
+  return new Analyzer(mockWorkspaceFileRetriever, em, logger);
+}

--- a/server/test/parser/services/codeactions/asserts/assertCodeAction.ts
+++ b/server/test/parser/services/codeactions/asserts/assertCodeAction.ts
@@ -1,3 +1,4 @@
+import * as events from "events";
 import { assert } from "chai";
 import { Diagnostic, TextEdit } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
@@ -25,9 +26,13 @@ export function assertCodeAction(
   const mockLogger = setupMockLogger();
   const mockWorkspaceFileRetriever = setupMockWorkspaceFileRetriever();
 
-  const analyzer = new Analyzer(mockWorkspaceFileRetriever, mockLogger).init(
-    exampleUri
-  );
+  const em = new events.EventEmitter();
+
+  const analyzer = new Analyzer(
+    mockWorkspaceFileRetriever,
+    em,
+    mockLogger
+  ).init(exampleUri);
 
   const documentURI = getUriFromDocument(document);
   analyzer.analyzeDocument(document.getText(), documentURI);

--- a/server/test/parser/services/codeactions/markContractAbstract.ts
+++ b/server/test/parser/services/codeactions/markContractAbstract.ts
@@ -1,3 +1,4 @@
+import * as events from "events";
 import { assert } from "chai";
 import * as fs from "fs";
 import * as path from "path";
@@ -138,8 +139,11 @@ describe("Code Actions", () => {
           const mockWorkspaceFileRetriever = setupMockWorkspaceFileRetriever();
           const mockLogger = setupMockLogger();
 
+          const em = new events.EventEmitter();
+
           const analyzer = new Analyzer(
             mockWorkspaceFileRetriever,
+            em,
             mockLogger
           ).init(exampleUri);
 


### PR DESCRIPTION
This is a fix for the `indexing` popup not clearing when no sol files where found. The bug was found during manual testing on windows.

The popup on the front-end needs at least one event to test whether all files are indexed. The analyzere was failing to emit an event to trigger the front-end in the case where there were no files to index. We now
emit the event even in the case where there are no files.

A fix was put in to access the workspaceFileRetriever (a wrapper around the previous local functionality) within the analyzer. This wrapper gives more control in tests, but had become unhooked in a merge at some
point.

The event emitter has been refactored to come from the central `serverState` rather than shared via a module (easier for testing).

## Preview

![preview](https://user-images.githubusercontent.com/24030/156544953-3c45b585-891d-4f8c-8a88-18c042dfb950.gif)

