### PR TITLE
fix(formatting): allow when bundled

### DIFF
--- a/client/src/formatter/index.ts
+++ b/client/src/formatter/index.ts
@@ -1,6 +1,7 @@
 import * as prettier from "prettier";
 import * as vscode from "vscode";
 import * as path from "path";
+import * as prettierPluginSolidity from "prettier-plugin-solidity";
 
 export function formatDocument(
   document: vscode.TextDocument,
@@ -31,18 +32,11 @@ export function formatDocument(
 
   const source = document.getText();
 
-  const pluginPath = path.join(
-    context.extensionPath,
-    "client",
-    "node_modules",
-    "prettier-plugin-solidity"
-  );
-
   const options = {
     useCache: false,
     parser: "solidity-parse",
     pluginSearchDirs: [context.extensionPath],
-    plugins: [pluginPath],
+    plugins: [prettierPluginSolidity],
   };
 
   const config =

--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -13,6 +13,7 @@ const SOLIDITY_LEXER_TOKENS = "SolidityLexer.tokens";
 
 const clientOutDir = "./client/out";
 const serverOutDir = "./server/out";
+const clientAntlrDir = path.join(clientOutDir, "antlr");
 const serverAntlrDir = path.join(serverOutDir, "antlr");
 
 function ensureDirExists(dir) {
@@ -25,11 +26,21 @@ async function main() {
   // Ensure output directories exist
   ensureDirExists(clientOutDir);
   ensureDirExists(serverOutDir);
+  ensureDirExists(clientAntlrDir);
   ensureDirExists(serverAntlrDir);
 
   // Copy across the two token files that
   // solidity-parser pulls via readFile (is there
   // a way of doing this with the bundler?)
+  // We have to do this for both server and client
+  fs.copyFileSync(
+    path.join(ANTLR_MODULE_PATH, SOLIDITY_TOKENS),
+    path.join(clientAntlrDir, SOLIDITY_TOKENS)
+  );
+  fs.copyFileSync(
+    path.join(ANTLR_MODULE_PATH, SOLIDITY_LEXER_TOKENS),
+    path.join(clientAntlrDir, SOLIDITY_LEXER_TOKENS)
+  );
   fs.copyFileSync(
     path.join(ANTLR_MODULE_PATH, SOLIDITY_TOKENS),
     path.join(serverAntlrDir, SOLIDITY_TOKENS)


### PR DESCRIPTION
This is a bug fix for formatting not working when using the bundled extension.

We were previously accessing the `node_modules` for the `prettier-solidity-plugin` from within the extension directory. With bundling that is no longer an option. Instead we use an import to get the plugin and pass it that way.