### PR TITLE
feat(formatter): update default formatting rules

### DIFF
--- a/client/src/formatter/index.ts
+++ b/client/src/formatter/index.ts
@@ -71,29 +71,22 @@ function getCurrentWorkspaceRootFolder(): vscode.WorkspaceFolder | undefined {
 
 function defaultConfig() {
   return {
-    bracketSpacing: true,
-    explicitTypes: "always",
-    "newline-before-return": true,
-    "no-duplicate-variable": [true, "check-parameters"],
-    "no-var-keyword": true,
-    printWidth: 120,
-    semi: true,
-    singleQuote: true,
+    printWidth: 80,
     tabWidth: 4,
-    trailingComma: "es5",
-    useTabs: true,
+    useTabs: false,
+    singleQuote: false,
+    bracketSpacing: false,
+    explicitTypes: "preserve",
     overrides: [
       {
         files: "*.sol",
         options: {
-          singleQuote: false,
-          tabWidth: 4,
-        },
-      },
-      {
-        files: "*.md",
-        options: {
           printWidth: 80,
+          tabWidth: 4,
+          useTabs: false,
+          singleQuote: false,
+          bracketSpacing: false,
+          explicitTypes: "preserve",
         },
       },
     ],

--- a/server/src/utils/PrettyPrinter.ts
+++ b/server/src/utils/PrettyPrinter.ts
@@ -66,21 +66,21 @@ export class PrettyPrinter {
   private defaultConfig() {
     return {
       printWidth: 80,
-      tabWidth: 2,
+      tabWidth: 4,
       useTabs: false,
       singleQuote: false,
       bracketSpacing: false,
-      explicitTypes: "always",
+      explicitTypes: "preserve",
       overrides: [
         {
           files: "*.sol",
           options: {
             printWidth: 80,
-            tabWidth: 2,
+            tabWidth: 4,
             useTabs: false,
             singleQuote: false,
             bracketSpacing: false,
-            explicitTypes: "always",
+            explicitTypes: "preserve",
           },
         },
       ],

--- a/server/test/parser/services/codeactions/markContractAbstract.ts
+++ b/server/test/parser/services/codeactions/markContractAbstract.ts
@@ -92,7 +92,7 @@ describe("Code Actions", () => {
                 edits: [
                   {
                     newText:
-                      "contract Counter is ICounter {\n  function increment() external pure override {}\n}",
+                      "contract Counter is ICounter {\n    function increment() external pure override {}\n}",
                     range: {
                       start: {
                         line: 7,
@@ -195,7 +195,7 @@ describe("Code Actions", () => {
                 edits: [
                   {
                     newText:
-                      "contract ImplementingContract is ExtendingInterface {\n  //   function inBase() external override {}\n  //   function inExtender() external override {}\n  function inBase() external override {}\n\n  function inExtender() external override {}\n}",
+                      "contract ImplementingContract is ExtendingInterface {\n    //   function inBase() external override {}\n    //   function inExtender() external override {}\n    function inBase() external override {}\n\n    function inExtender() external override {}\n}",
                     range: {
                       start: {
                         line: 11,
@@ -256,7 +256,7 @@ describe("Code Actions", () => {
                 edits: [
                   {
                     newText:
-                      "contract DiamondCounter is IDiamondIncrement, IDiamondDecrement {\n  uint120 public balance = 0;\n\n  function getBalance()\n    external\n    view\n    override(IDiamondCounter, IDiamondIncrement)\n    returns (uint120)\n  {}\n\n  function increment()\n    external\n    view\n    override(IDiamondDecrement, IDiamondIncrement)\n  {}\n\n  function decrement() external override {}\n}",
+                      "contract DiamondCounter is IDiamondIncrement, IDiamondDecrement {\n    uint120 public balance = 0;\n\n    function getBalance()\n        external\n        view\n        override(IDiamondCounter, IDiamondIncrement)\n        returns (uint120)\n    {}\n\n    function increment()\n        external\n        view\n        override(IDiamondDecrement, IDiamondIncrement)\n    {}\n\n    function decrement() external override {}\n}",
                     range: {
                       start: {
                         line: 19,
@@ -317,7 +317,7 @@ describe("Code Actions", () => {
                 edits: [
                   {
                     newText:
-                      "contract I is D, E, F, G, H {\n  function getBalance() external override(B, D, F) returns (uint120) {}\n}",
+                      "contract I is D, E, F, G, H {\n    function getBalance() external override(B, D, F) returns (uint120) {}\n}",
                     range: {
                       start: {
                         line: 33,
@@ -380,7 +380,7 @@ describe("Code Actions", () => {
                 edits: [
                   {
                     newText:
-                      "contract Child is IExample, Parent {\n  //   function first() public virtual override(IExample, Parent) {}\n  //   function second() external override {}\n  function first() public override(IExample, Parent) {}\n\n  function second() external override {}\n}",
+                      "contract Child is IExample, Parent {\n    //   function first() public virtual override(IExample, Parent) {}\n    //   function second() external override {}\n    function first() public override(IExample, Parent) {}\n\n    function second() external override {}\n}",
                     range: {
                       start: {
                         line: 13,
@@ -443,7 +443,7 @@ describe("Code Actions", () => {
                 edits: [
                   {
                     newText:
-                      "contract Child is IExample, Parent {\n  // function second() external override {}\n  function second() external override {}\n}",
+                      "contract Child is IExample, Parent {\n    // function second() external override {}\n    function second() external override {}\n}",
                     range: {
                       start: {
                         line: 13,
@@ -506,7 +506,7 @@ describe("Code Actions", () => {
                 edits: [
                   {
                     newText:
-                      "contract C is ID, CH {\n  // function top() external override(CE, IA) returns (uint120) {}\n  // function topFromInterface() external override returns (uint120) {}\n  // function left() external override(CF, IB) returns (uint120) {}\n  // function right() external override(CG, IC) returns (uint120) {}\n  // function bottom() external override(CH, ID) returns (uint120) {}\n  function top() external override(CE, IA) returns (uint120) {}\n\n  function topFromInterface() external override returns (uint120) {}\n\n  function left() external override(CF, IB) returns (uint120) {}\n\n  function right() external override(CG, IC) returns (uint120) {}\n\n  function bottom() external override(CH, ID) returns (uint120) {}\n}",
+                      "contract C is ID, CH {\n    // function top() external override(CE, IA) returns (uint120) {}\n    // function topFromInterface() external override returns (uint120) {}\n    // function left() external override(CF, IB) returns (uint120) {}\n    // function right() external override(CG, IC) returns (uint120) {}\n    // function bottom() external override(CH, ID) returns (uint120) {}\n    function top() external override(CE, IA) returns (uint120) {}\n\n    function topFromInterface() external override returns (uint120) {}\n\n    function left() external override(CF, IB) returns (uint120) {}\n\n    function right() external override(CG, IC) returns (uint120) {}\n\n    function bottom() external override(CH, ID) returns (uint120) {}\n}",
                     range: {
                       start: {
                         line: 45,


### PR DESCRIPTION
The rules have been taken from the solidity lang style guide, see https://docs.soliditylang.org/en/latest/style-guide.html.

The default now look like:

```javascript
function defaultConfig() {
  return {
    printWidth: 80,
    tabWidth: 4,
    useTabs: false,
    singleQuote: false,
    bracketSpacing: false,
    explicitTypes: "always",
    overrides: [
      {
        files: "*.sol",
        options: {
          printWidth: 80,
          tabWidth: 4,
          useTabs: false,
          singleQuote: false,
          bracketSpacing: false,
          explicitTypes: "always",
        },
      },
    ],
  };
}
```

The key parts are:

* use spaces not tabs
* use a 4 spaces as the indentation increment
* prefer `"` over `'`
* be explicit about types rather than using simple aliases
* wrap at 80 characters

## Preview

![image](https://user-images.githubusercontent.com/24030/157438909-b8fffa8b-8aa4-49dc-a323-0669cb0369fa.png)

