### PR TITLE
switch performance telemetry to sentry

### DIFF
--- a/.changeset/quick-numbers-sleep.md
+++ b/.changeset/quick-numbers-sleep.md
@@ -1,0 +1,5 @@
+---
+"hardhat-solidity": patch
+---
+
+improve performance telemetry

--- a/server/package.json
+++ b/server/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "1.0.2",
+    "@sentry/types": "6.19.1",
     "@types/chai": "4.3.0",
     "@types/fs-extra": "^9.0.13",
     "@types/js-yaml": "^4.0.5",
@@ -48,8 +49,8 @@
     "typescript": "4.5.4"
   },
   "dependencies": {
-    "@sentry/node": "^6.17.9",
-    "@sentry/tracing": "^6.17.9",
+    "@sentry/node": "6.19.1",
+    "@sentry/tracing": "6.19.1",
     "@solidity-parser/parser": "^0.14.0",
     "@types/prettier": "2.4.3",
     "c3-linearization": "0.3.0",

--- a/server/src/analytics/GoogleAnalytics.ts
+++ b/server/src/analytics/GoogleAnalytics.ts
@@ -36,19 +36,7 @@ export class GoogleAnalytics implements Analytics {
     this.serverState = serverState;
   }
 
-  public trackTiming<T>(taskName: string, action: () => T): T {
-    const startTime = Date.now();
-
-    const result = action();
-
-    this.sendTaskHit(taskName, {
-      plt: Date.now() - startTime,
-    });
-
-    return result;
-  }
-
-  public async sendTaskHit(
+  public async sendPageView(
     taskName: string,
     more?: RawAnalyticsPayload
   ): Promise<void> {
@@ -92,7 +80,7 @@ export class GoogleAnalytics implements Analytics {
       cid: machineId,
 
       // Hit type, we're only using timing for now.
-      t: "timing",
+      t: "pageview",
 
       // Document page
       dp: `/${taskName}`,

--- a/server/src/analytics/types.ts
+++ b/server/src/analytics/types.ts
@@ -36,7 +36,5 @@ export interface Analytics {
     serverState: ServerState
   ): void;
 
-  sendTaskHit(taskName: string, more?: RawAnalyticsPayload): Promise<void>;
-
-  trackTiming<T>(taskName: string, action: () => T): T;
+  sendPageView(taskName: string, more?: RawAnalyticsPayload): Promise<void>;
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -12,13 +12,16 @@ const GOOGLE_TRACKING_ID = "UA-117668706-4";
 const SENTRY_DSN =
   "https://9d1e887190db400791c77d9bb5a154fd@o385026.ingest.sentry.io/5469451";
 
+// every 10 mins (ga sessions stop with 30mins inactivty)
+const HEARTBEAT_PERIOD = 10 * 60 * 1000;
+
 // Create a connection for the server, using Node's IPC as a transport.
 // Also include all preview / proposed LSP features.
 const connection = createConnection(ProposedFeatures.all);
 
 const workspaceFileRetriever = new WorkspaceFileRetriever();
-const telemetry = new SentryTelemetry(SENTRY_DSN);
 const analytics = new GoogleAnalytics(GOOGLE_TRACKING_ID);
+const telemetry = new SentryTelemetry(SENTRY_DSN, HEARTBEAT_PERIOD, analytics);
 const logger = new ConnectionLogger(connection, telemetry);
 
 setupServer(

--- a/server/src/parser/services/codeactions/onCodeAction.ts
+++ b/server/src/parser/services/codeactions/onCodeAction.ts
@@ -24,7 +24,7 @@ export function onCodeAction(serverState: ServerState) {
         return [];
       }
 
-      return serverState.analytics.trackTiming("onCodeAction", () =>
+      return serverState.telemetry.trackTimingSync("onCodeAction", () =>
         quickFixResolver.resolve(
           params.textDocument.uri,
           document,

--- a/server/src/telemetry/SentryTelemetry.ts
+++ b/server/src/telemetry/SentryTelemetry.ts
@@ -1,17 +1,30 @@
 import * as Sentry from "@sentry/node";
+import { Transaction } from "@sentry/types";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import * as tracing from "@sentry/tracing";
 import { isTelemetryEnabled } from "@utils/serverStateUtils";
 import { ServerState } from "../types";
 import { Telemetry } from "./types";
+import { Analytics } from "analytics/types";
 
 const SENTRY_CLOSE_TIMEOUT = 2000;
 
 export class SentryTelemetry implements Telemetry {
   dsn: string;
   serverState: ServerState | null;
+  analytics: Analytics;
+  actionTaken: boolean;
+  heartbeatInterval: NodeJS.Timeout | null;
+  heartbeatPeriod: number;
 
-  constructor(dsn: string) {
+  constructor(dsn: string, heartbeatPeriod: number, analytics: Analytics) {
     this.dsn = dsn;
+    this.heartbeatPeriod = 5;
     this.serverState = null;
+    this.analytics = analytics;
+
+    this.actionTaken = true;
+    this.heartbeatInterval = null;
   }
 
   init(
@@ -22,9 +35,14 @@ export class SentryTelemetry implements Telemetry {
   ) {
     this.serverState = serverState;
 
+    if (!tracing) {
+      // eslint-disable-next-line no-console
+      console.error("Tracing not enabled");
+    }
+
     Sentry.init({
       dsn: this.dsn,
-      tracesSampleRate: 0.1,
+      tracesSampleRate: serverState.env === "development" ? 1 : 0.01,
       release:
         extensionName && extensionVersion
           ? `${extensionName}@${extensionVersion}`
@@ -35,13 +53,65 @@ export class SentryTelemetry implements Telemetry {
       },
       beforeSend: (event) => (isTelemetryEnabled(serverState) ? event : null),
     });
+
+    this.analytics.init(machineId, extensionVersion, serverState);
   }
 
   captureException(err: unknown) {
     Sentry.captureException(err);
   }
 
+  public trackTimingSync<T>(taskName: string, action: () => T): T {
+    const transaction = this.startTransaction({ op: "task", name: taskName });
+    this.actionTaken = true;
+
+    const result = action();
+
+    transaction.finish();
+
+    return result;
+  }
+
+  public startTransaction({
+    op,
+    name,
+  }: {
+    op: string;
+    name: string;
+  }): Transaction {
+    const transaction = Sentry.startTransaction({
+      op,
+      name,
+    });
+
+    Sentry.getCurrentHub().configureScope((scope) =>
+      scope.setSpan(transaction)
+    );
+
+    return transaction;
+  }
+
+  public enableHeartbeat(): void {
+    this.heartbeatInterval = setInterval(
+      () => this.pulse(),
+      this.heartbeatPeriod
+    );
+  }
+
+  private async pulse(): Promise<void> {
+    if (!this.actionTaken) {
+      return;
+    }
+
+    this.actionTaken = false;
+    return this.analytics.sendPageView("heartbeat");
+  }
+
   close(): Promise<boolean> {
+    if (this.heartbeatInterval) {
+      clearInterval(this.heartbeatInterval);
+    }
+
     return Sentry.close(SENTRY_CLOSE_TIMEOUT);
   }
 }

--- a/server/src/telemetry/types.ts
+++ b/server/src/telemetry/types.ts
@@ -1,3 +1,4 @@
+import { Transaction } from "@sentry/types";
 import { ServerState } from "../types";
 
 export interface Telemetry {
@@ -8,5 +9,8 @@ export interface Telemetry {
     serverState: ServerState
   ): void;
   captureException(err: unknown): void;
+  trackTimingSync<T>(taskName: string, action: () => T): T;
+  startTransaction({ op, name }: { op: string; name: string }): Transaction;
+  enableHeartbeat(): void;
   close(): Promise<boolean>;
 }

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -3,7 +3,6 @@ import { Connection } from "vscode-languageserver";
 import { TextDocuments } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { Telemetry } from "telemetry/types";
-import { Analytics } from "./analytics/types";
 import { LanguageService } from "./parser";
 import { Logger } from "@utils/Logger";
 
@@ -18,7 +17,6 @@ export type ServerState = {
   documents: TextDocuments<TextDocument>;
   em: events.EventEmitter;
   languageServer: LanguageService;
-  analytics: Analytics;
   telemetry: Telemetry;
   logger: Logger;
 };

--- a/server/test/helpers/setupMockAnalytics.ts
+++ b/server/test/helpers/setupMockAnalytics.ts
@@ -4,9 +4,6 @@ import { Analytics } from "../../src/analytics/types";
 export function setupMockAnalytics(): Analytics {
   return {
     init: sinon.spy(),
-    sendTaskHit: sinon.spy(),
-    trackTiming: (_taskName: string, action) => {
-      return action();
-    },
+    sendPageView: sinon.spy(),
   };
 }

--- a/server/test/helpers/setupMockTelemetry.ts
+++ b/server/test/helpers/setupMockTelemetry.ts
@@ -1,3 +1,4 @@
+import { Transaction } from "@sentry/types";
 import * as sinon from "sinon";
 import { Telemetry } from "../../src/telemetry/types";
 
@@ -5,6 +6,23 @@ export function setupMockTelemetry(): Telemetry {
   return {
     init: sinon.spy(),
     captureException: sinon.spy(),
+    trackTimingSync: (_taskName: string, action) => {
+      return action();
+    },
+    startTransaction: (): Transaction => {
+      return {
+        startChild: () => {
+          return {
+            setStatus: sinon.spy(),
+            finish: sinon.spy(),
+          };
+        },
+        setStatus: sinon.spy(),
+        finish: sinon.spy(),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+    },
+    enableHeartbeat: sinon.spy(),
     close: sinon.spy(),
   };
 }

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -512,15 +512,15 @@
     "@sentry/utils" "5.30.0"
     tslib "^1.9.3"
 
-"@sentry/core@6.18.1":
-  version "6.18.1"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.18.1.tgz#6d09c4f59b30b62d5d288b5f3f3af56f1f7e6336"
-  integrity sha512-9V8Q+3Asi+3RL67CSIMMZ9mjMsu2/hrpQszYStX7hPPpAZIlAKk2MT5B+na/r80iWKhy+3Ts6aDFF218QtnsVw==
+"@sentry/core@6.19.1":
+  version "6.19.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.19.1.tgz#9672d0d19d4fe438be6e186b2b10a79826f19a03"
+  integrity sha512-ZSIFnwYCzABK1jX1iMwUbaAoWbbJear0wM+gSZvJpSUJ1dAXV1OZyL7kXtEJRtATahIlcrMou5ewIoeJizeWAw==
   dependencies:
-    "@sentry/hub" "6.18.1"
-    "@sentry/minimal" "6.18.1"
-    "@sentry/types" "6.18.1"
-    "@sentry/utils" "6.18.1"
+    "@sentry/hub" "6.19.1"
+    "@sentry/minimal" "6.19.1"
+    "@sentry/types" "6.19.1"
+    "@sentry/utils" "6.19.1"
     tslib "^1.9.3"
 
 "@sentry/hub@5.30.0":
@@ -532,13 +532,13 @@
     "@sentry/utils" "5.30.0"
     tslib "^1.9.3"
 
-"@sentry/hub@6.18.1":
-  version "6.18.1"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.18.1.tgz#fcfb8cb84515efefaf4e48472305ea5a71455abb"
-  integrity sha512-+zGzgc/xX3an/nKA3ELMn9YD9VmqbNaNwWZ5/SjNUvzsYHh2UNZ7YzT8WawQsRVOXLljyCKxkWpFB4EchiYGbw==
+"@sentry/hub@6.19.1":
+  version "6.19.1"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.19.1.tgz#bff9ed5885b6e0eb4280774b653fa05edec6ed07"
+  integrity sha512-BgUwdxxXntGohAYrXtYrYBA6QzOeRz3NINuS838n7SRTkGf9gBJ/Rd3dyOWUrzJciKty7rmvYIwTA0oo91AMkw==
   dependencies:
-    "@sentry/types" "6.18.1"
-    "@sentry/utils" "6.18.1"
+    "@sentry/types" "6.19.1"
+    "@sentry/utils" "6.19.1"
     tslib "^1.9.3"
 
 "@sentry/minimal@5.30.0":
@@ -550,13 +550,27 @@
     "@sentry/types" "5.30.0"
     tslib "^1.9.3"
 
-"@sentry/minimal@6.18.1":
-  version "6.18.1"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.18.1.tgz#eac73d2262589930aa0bb33e0e12380ac5b766a9"
-  integrity sha512-dm+0MuasWNi/LASvHX+09oCo8IBZY5WpMK8qXvQMnwQ9FVfklrjcfEI3666WORDCmeUhDCSeL2MbjPDm+AmPLg==
+"@sentry/minimal@6.19.1":
+  version "6.19.1"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.19.1.tgz#d6fc92bd683ae7db207ad9666084307311881dcb"
+  integrity sha512-Xre3J6mjWEcQhDmQ3j4g71J8f0nDgg2p7K41SngibfZVYSOe8jAowxSI9JuWD7juuwT5GVRVCqLs+Y6mWDBaoQ==
   dependencies:
-    "@sentry/hub" "6.18.1"
-    "@sentry/types" "6.18.1"
+    "@sentry/hub" "6.19.1"
+    "@sentry/types" "6.19.1"
+    tslib "^1.9.3"
+
+"@sentry/node@6.19.1":
+  version "6.19.1"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-6.19.1.tgz#807f9011dbac37370b49759c6d803c6026b4adfb"
+  integrity sha512-ipPWFY+1gNZlt99QHInP+Z70W7nYeBEEiVDtpxSMid5zFzPJ/k9QOZtUzyelyiSCBvIIeTzVX9Fyri17fay1Pw==
+  dependencies:
+    "@sentry/core" "6.19.1"
+    "@sentry/hub" "6.19.1"
+    "@sentry/types" "6.19.1"
+    "@sentry/utils" "6.19.1"
+    cookie "^0.4.1"
+    https-proxy-agent "^5.0.0"
+    lru_map "^0.3.3"
     tslib "^1.9.3"
 
 "@sentry/node@^5.18.1":
@@ -574,21 +588,6 @@
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
-"@sentry/node@^6.17.9":
-  version "6.18.1"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-6.18.1.tgz#8eddc80226bda77dd91100eb522e1e7d88963461"
-  integrity sha512-aTb2gwfZUq0lGDRGH5zNOYDfFMOQZu6E0QcAsvH2ZBcEj3rUWZz3r25COFrHmfzHLUV1KcF2AmnWo1QU1jmm0g==
-  dependencies:
-    "@sentry/core" "6.18.1"
-    "@sentry/hub" "6.18.1"
-    "@sentry/tracing" "6.18.1"
-    "@sentry/types" "6.18.1"
-    "@sentry/utils" "6.18.1"
-    cookie "^0.4.1"
-    https-proxy-agent "^5.0.0"
-    lru_map "^0.3.3"
-    tslib "^1.9.3"
-
 "@sentry/tracing@5.30.0":
   version "5.30.0"
   resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-5.30.0.tgz#501d21f00c3f3be7f7635d8710da70d9419d4e1f"
@@ -600,15 +599,15 @@
     "@sentry/utils" "5.30.0"
     tslib "^1.9.3"
 
-"@sentry/tracing@6.18.1", "@sentry/tracing@^6.17.9":
-  version "6.18.1"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.18.1.tgz#7cc54b328dd051102900ade53e907e7441426f83"
-  integrity sha512-OxozmSfxGx246Ae1XhO01I7ZWxO3briwMBh55E5KyjQb8fuS9gVE7Uy8ZRs5hhNjDutFAU7nMtC0zipfVxP6fg==
+"@sentry/tracing@6.19.1":
+  version "6.19.1"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.19.1.tgz#2fc710c57bc157748539cdec3bbd5dcd41f7f2a0"
+  integrity sha512-o34+h0j70dszcIwpCIbmO4UauPurpqLvcPO3JsFhRdxQhwQaQgMwhFklbAt7al9oEDYkjlS0gzhhlOCz4IS9kA==
   dependencies:
-    "@sentry/hub" "6.18.1"
-    "@sentry/minimal" "6.18.1"
-    "@sentry/types" "6.18.1"
-    "@sentry/utils" "6.18.1"
+    "@sentry/hub" "6.19.1"
+    "@sentry/minimal" "6.19.1"
+    "@sentry/types" "6.19.1"
+    "@sentry/utils" "6.19.1"
     tslib "^1.9.3"
 
 "@sentry/types@5.30.0":
@@ -616,10 +615,10 @@
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.30.0.tgz#19709bbe12a1a0115bc790b8942917da5636f402"
   integrity sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw==
 
-"@sentry/types@6.18.1":
-  version "6.18.1"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.18.1.tgz#e2de38dd0da8096a5d22f8effc6756c919266ede"
-  integrity sha512-wp741NoBKnXE/4T9L723sWJ8EcNMxeTIT1smgNJOfbPwrsDICoYmGEt6JFa05XHpWBGI66WuNvnDjoHVeh6zhA==
+"@sentry/types@6.19.1":
+  version "6.19.1"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.19.1.tgz#684a231f8fe10c9cf14f9552f5da0a4492e6fdbc"
+  integrity sha512-ovmNYdqD2MKLmru4calxetX1xjJdYim+HEI/GzwvVUYshsaXRq4EiQ17h3DAy90MV7JH279PmMoPGDTOpufq+Q==
 
 "@sentry/utils@5.30.0":
   version "5.30.0"
@@ -629,12 +628,12 @@
     "@sentry/types" "5.30.0"
     tslib "^1.9.3"
 
-"@sentry/utils@6.18.1":
-  version "6.18.1"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.18.1.tgz#1aa819502b042540612f4db7bcb86c7b176f5a6b"
-  integrity sha512-IFZmuvA+c5lDGlZEri13JSyUP0BHelzY0S4dcKxAzskPW+BtBdQDgYGV90iED1y+IRMLawWb34GF7HyJSouN1Q==
+"@sentry/utils@6.19.1":
+  version "6.19.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.19.1.tgz#9d5f50a0ceb60b63631de88b4abed07253568209"
+  integrity sha512-mWcQbQ1yO7PooLpJpQK84+wOfxGeb8iUKRb8inO+2Eg6VksDbXRuJ89Yd4APBTRxBj5Wihy48bPuVfKtovtm8g==
   dependencies:
-    "@sentry/types" "6.18.1"
+    "@sentry/types" "6.19.1"
     tslib "^1.9.3"
 
 "@sindresorhus/is@^4.0.0":


### PR DESCRIPTION
Sentry has added extensive performance tracking. We are currently hacking GA to provide a rough version. We should switch to sentry to take advantage of its inbuilt sampling and richer features. This involves:

## TODO

* [x] switching the tracking from ga to sentry
* [x] adding context to leverage sentry
* [x] reducing ga to a heartbeat call every x mins

Linear: HHVSC-119
