### PR TITLE
feat(hover): add hover text

### DIFF
--- a/.changeset/shiny-spoons-reply.md
+++ b/.changeset/shiny-spoons-reply.md
@@ -1,0 +1,5 @@
+---
+"hardhat-solidity": minor
+---
+
+added - Hovers for variables, function calls, error reverts and event emits ([#62](https://github.com/NomicFoundation/hardhat-vscode/issues/62))

--- a/EXTENSION.md
+++ b/EXTENSION.md
@@ -7,6 +7,7 @@ This extension adds language support for [Solidity](https://soliditylang.org/) t
 - Symbol renames
 - Solidity code formatting through [prettier-plugin-solidity](https://github.com/prettier-solidity/prettier-plugin-solidity)
 - Inline code validation from compiler errors/warnings for Hardhat projects
+- Hover help for variables, function calls, errors, events etc.
 - Code actions (quickfixes) suggested from compiler errors/warnings for Hardhat projects
   - Implement missing functions on interface with stubs
   - Constrain mutability by adding `view`/`pure` to function signature
@@ -17,7 +18,7 @@ Built by the [Nomic Foundation](https://nomic.foundation/). [We’re hiring](htt
 
 ## Installation
 
-**Hardhat for Visual Studio Code** can be installed by searching for `hardhat` within the `visual studio code` extension tab or via the [marketplace](https://marketplace.visualstudio.com/items?itemName=NomicFoundation.hardhat-solidity).
+**Hardhat for Visual Studio Code** can be installed by [using the Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=NomicFoundation.hardhat-solidity).
 
 Some features (e.g. inline validation) are still experimental and are only enabled within a [Hardhat](https://hardhat.org/) project, this is a limitation that will be lifted with future releases.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Join our [Hardhat Support Discord server](https://hardhat.org/discord) to stay u
 - Symbol renames
 - Solidity code formatting through [prettier-plugin-solidity](https://github.com/prettier-solidity/prettier-plugin-solidity)
 - Inline validation for Hardhat projects
+- Hover help for variables, function calls, errors, events etc.
 - Code actions (quickfixes) suggested from compiler errors/warnings
   - Implement missing functions on interface with stubs
   - Constrain mutability by adding `view`/`pure` to function signature

--- a/server/src/parser/analyzer/utils/typeGuards.ts
+++ b/server/src/parser/analyzer/utils/typeGuards.ts
@@ -5,11 +5,25 @@ import {
   FunctionCall,
   ImportDirectiveNode,
   Node,
+  IdentifierNode,
+  VariableDeclarationNode,
+  Mapping,
+  EmptyNodeType,
 } from "@common/types";
 import { ContractDefinitionNode } from "../nodes/ContractDefinitionNode";
 import { FunctionDefinitionNode } from "../nodes/FunctionDefinitionNode";
 import { MemberAccessNode } from "../nodes/MemberAccessNode";
 import { FunctionCallNode } from "../nodes/FunctionCallNode";
+import {
+  ArrayTypeName,
+  BaseASTNode,
+  CustomErrorDefinition,
+  ElementaryTypeName,
+  EventDefinition,
+  UserDefinedTypeName,
+  VariableDeclaration,
+} from "@solidity-parser/parser/dist/src/ast-types";
+import { ElementaryTypeNameNode } from "@analyzer/nodes/ElementaryTypeNameNode";
 
 export function isContractDefinition(
   node: ASTNode
@@ -24,7 +38,7 @@ export function isContractDefinitionNode(
 }
 
 export function isFunctionDefinition(
-  node: ASTNode
+  node: BaseASTNode | EmptyNodeType
 ): node is FunctionDefinition {
   return node.type === "FunctionDefinition";
 }
@@ -49,4 +63,62 @@ export function isMemberAccessNode(node: Node): node is MemberAccessNode {
 
 export function isImportDirectiveNode(node: Node): node is ImportDirectiveNode {
   return node.type === "ImportDirective";
+}
+
+export function isIdentifierNode(node: Node): node is IdentifierNode {
+  return node.type === "Identifier";
+}
+
+export function isVariableDeclarationNode(
+  node: Node
+): node is VariableDeclarationNode {
+  return node.type === "VariableDeclaration";
+}
+
+export function isVariableDeclaration(
+  node: BaseASTNode | EmptyNodeType
+): node is VariableDeclaration {
+  return node.type === "VariableDeclaration";
+}
+
+export function isEventDefinition(
+  node: BaseASTNode | EmptyNodeType
+): node is EventDefinition {
+  return node.type === "EventDefinition";
+}
+
+export function isCustomErrorDefinition(
+  node: BaseASTNode | EmptyNodeType
+): node is CustomErrorDefinition {
+  return node.type === "CustomErrorDefinition";
+}
+
+export function isMapping(
+  node: ASTNode | BaseASTNode | EmptyNodeType
+): node is Mapping {
+  return node.type === "Mapping";
+}
+
+export function isElementaryTypeNameNode(
+  node: Node
+): node is ElementaryTypeNameNode {
+  return node.type === "ElementaryTypeName";
+}
+
+export function isElementaryTypeName(
+  node: BaseASTNode | EmptyNodeType
+): node is ElementaryTypeName {
+  return node.type === "ElementaryTypeName";
+}
+
+export function isUserDefinedTypeName(
+  node: BaseASTNode | EmptyNodeType
+): node is UserDefinedTypeName {
+  return node.type === "UserDefinedTypeName";
+}
+
+export function isArrayTypeName(
+  node: BaseASTNode | EmptyNodeType
+): node is ArrayTypeName {
+  return node.type === "ArrayTypeName";
 }

--- a/server/src/parser/services/hover/onHover.ts
+++ b/server/src/parser/services/hover/onHover.ts
@@ -1,0 +1,87 @@
+import {
+  isIdentifierNode,
+  isMemberAccessNode,
+} from "@analyzer/utils/typeGuards";
+import { getParserPositionFromVSCodePosition } from "@common/utils";
+import { getUriFromDocument } from "../../../utils/index";
+import { HoverParams, Hover } from "vscode-languageserver/node";
+import { ServerState } from "../../../types";
+import {
+  DocumentAnalyzer,
+  IdentifierNode,
+  MemberAccessNode,
+} from "@common/types";
+import { astToText } from "./utils/astToText";
+import { textToHover } from "./utils/textTohover";
+
+export function onHover(serverState: ServerState) {
+  return (params: HoverParams): Hover | null => {
+    const { languageServer, logger } = serverState;
+
+    logger.trace("onHover");
+
+    try {
+      if (!languageServer) {
+        return null;
+      }
+
+      const document = serverState.documents.get(params.textDocument.uri);
+
+      if (!document) {
+        return null;
+      }
+
+      const documentURI = getUriFromDocument(document);
+      const documentAnalyzer =
+        serverState.languageServer.analyzer.getDocumentAnalyzer(documentURI);
+
+      if (!documentAnalyzer.isAnalyzed) {
+        return null;
+      }
+
+      return serverState.telemetry.trackTimingSync("onHover", () =>
+        findHoverForNodeAtPosition(documentAnalyzer, documentURI, params)
+      );
+    } catch (err) {
+      logger.error(err);
+
+      return null;
+    }
+  };
+}
+
+function findHoverForNodeAtPosition(
+  documentAnalyzer: DocumentAnalyzer,
+  documentURI: string,
+  params: HoverParams
+) {
+  const node = documentAnalyzer.searcher.findNodeByPosition(
+    documentURI,
+    getParserPositionFromVSCodePosition(params.position),
+    documentAnalyzer.analyzerTree.tree
+  );
+
+  if (node === undefined) {
+    return null;
+  }
+
+  if (!isIdentifierNode(node) && !isMemberAccessNode(node)) {
+    return null;
+  }
+
+  return convertNodeToHover(node);
+}
+
+export function convertNodeToHover(
+  node: IdentifierNode | MemberAccessNode
+): Hover | null {
+  const typeNode = node.typeNodes[0];
+
+  if (typeNode === undefined) {
+    return null;
+  }
+
+  const hoverText = astToText(typeNode.astNode);
+
+  return textToHover(hoverText);
+}

--- a/server/src/parser/services/hover/utils/astToText.ts
+++ b/server/src/parser/services/hover/utils/astToText.ts
@@ -1,0 +1,202 @@
+import {
+  isArrayTypeName,
+  isCustomErrorDefinition,
+  isElementaryTypeName,
+  isEventDefinition,
+  isFunctionDefinition,
+  isMapping,
+  isUserDefinedTypeName,
+  isVariableDeclaration,
+} from "@analyzer/utils/typeGuards";
+import { EmptyNodeType } from "@common/types";
+import {
+  BaseASTNode,
+  CustomErrorDefinition,
+  EventDefinition,
+  FunctionDefinition,
+  ModifierInvocation,
+  UserDefinedTypeName,
+  VariableDeclaration,
+} from "@solidity-parser/parser/dist/src/ast-types";
+
+export function astToText(astNode: BaseASTNode | EmptyNodeType): string | null {
+  if (isFunctionDefinition(astNode)) {
+    return functionDefinitionToText(astNode);
+  }
+
+  if (isVariableDeclaration(astNode)) {
+    return variableDeclarationToText(astNode);
+  }
+
+  if (isCustomErrorDefinition(astNode)) {
+    return customErrorDefinitionToText(astNode);
+  }
+
+  if (isEventDefinition(astNode)) {
+    return eventDefinitionToText(astNode);
+  }
+
+  return null;
+}
+
+export function variableDeclarationToText(variable: VariableDeclaration) {
+  if (variable.typeName === null) {
+    return null;
+  }
+
+  const typeText = resolveTypeTextFromAst(variable.typeName);
+
+  if (typeText === null) {
+    return null;
+  }
+
+  const visibility =
+    variable.visibility === "default" ? null : variable.visibility;
+
+  const constant = variable.isDeclaredConst ? "constant" : null;
+
+  const storageLocation = variable.storageLocation;
+
+  const identifierName = variable.name;
+
+  const hoverText = [
+    typeText,
+    visibility,
+    constant,
+    storageLocation,
+    identifierName,
+  ]
+    .filter((text: string | null | undefined): text is string => Boolean(text))
+    .map((text) => text.trim())
+    .join(" ");
+
+  return hoverText;
+}
+
+export function customErrorDefinitionToText(
+  customErrorDefinition: CustomErrorDefinition
+): string | null {
+  const params = parameterListToText(customErrorDefinition.parameters);
+
+  return `error ${customErrorDefinition.name}${params ?? "()"}`;
+}
+
+export function eventDefinitionToText(
+  eventDefinition: EventDefinition
+): string | null {
+  const params = parameterListToText(eventDefinition.parameters);
+
+  return `event ${eventDefinition.name}${params ?? "()"}`;
+}
+
+export function functionDefinitionToText(
+  astFunctionDef: FunctionDefinition
+): string | null {
+  const introKeyword = astFunctionDef.isConstructor
+    ? "constructor"
+    : "function";
+
+  const functionName = astFunctionDef.name;
+  const params = parameterListToText(astFunctionDef.parameters);
+  const paramsList = `${functionName}${params ?? "()"}`;
+
+  const visibility =
+    astFunctionDef.visibility === "default" ? null : astFunctionDef.visibility;
+
+  const mutability = astFunctionDef.stateMutability;
+
+  const virtual = astFunctionDef.isVirtual ? "virtual" : null;
+
+  const override = overrideToText(astFunctionDef.override);
+
+  const modifierList = astFunctionDef.modifiers.map((m) =>
+    modifierInvocationToText(m)
+  );
+
+  const returns = parameterListToText(astFunctionDef.returnParameters);
+  const returnsList = returns === null ? null : `returns ${returns}`;
+
+  const hoverText = [
+    introKeyword, // what about constructor
+    paramsList,
+    visibility,
+    mutability,
+    virtual,
+    override,
+    ...modifierList,
+    returnsList,
+  ]
+    .filter(
+      (text: string | null | undefined): text is string =>
+        text !== null && text !== undefined
+    )
+    .map((text) => (text === " " ? " " : text.trim()))
+    .join(" ");
+
+  return hoverText;
+}
+
+function overrideToText(overrides: UserDefinedTypeName[] | null) {
+  if (overrides === null) {
+    return null;
+  }
+
+  if (overrides.length === 0) {
+    return "override";
+  }
+
+  const names = overrides.map((o) => o.namePath);
+
+  return `override(${names.join(", ")})`;
+}
+
+function modifierInvocationToText(
+  invocation: ModifierInvocation
+): string | null {
+  if (invocation.arguments === null) {
+    return invocation.name;
+  }
+
+  // TODO: display the arguments
+  return invocation.name;
+}
+
+function parameterListToText(parameterList: VariableDeclaration[] | null) {
+  if (parameterList === null || parameterList.length === 0) {
+    return null;
+  }
+
+  const params = parameterList.map((p) => variableDeclarationToText(p));
+
+  return `(${params.join(", ")})`;
+}
+
+export function resolveTypeTextFromAst(
+  typeAstNode: BaseASTNode | EmptyNodeType
+): string | null {
+  if (isElementaryTypeName(typeAstNode)) {
+    return typeAstNode.name ?? null;
+  }
+
+  if (isUserDefinedTypeName(typeAstNode)) {
+    return typeAstNode.namePath ?? null;
+  }
+
+  if (isArrayTypeName(typeAstNode)) {
+    const baseTypeText = resolveTypeTextFromAst(typeAstNode.baseTypeName);
+    return `${baseTypeText}[]`;
+  }
+
+  if (isMapping(typeAstNode)) {
+    const keyText = resolveTypeTextFromAst(typeAstNode.keyType);
+    const valueText = resolveTypeTextFromAst(typeAstNode.valueType);
+
+    if (keyText === null || valueText === null) {
+      return "mapping";
+    }
+
+    return `mapping(${keyText} => ${valueText})`;
+  }
+
+  return null;
+}

--- a/server/src/parser/services/hover/utils/textTohover.ts
+++ b/server/src/parser/services/hover/utils/textTohover.ts
@@ -1,0 +1,14 @@
+import { MarkupKind } from "vscode-languageserver/node";
+
+export function textToHover(hoverText: string | null) {
+  if (hoverText === null) {
+    return null;
+  }
+
+  return {
+    contents: {
+      kind: MarkupKind.Markdown,
+      value: ["```solidity", hoverText, "```"].join("\n"),
+    },
+  };
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -23,6 +23,7 @@ import { Logger } from "@utils/Logger";
 import { Analytics } from "./analytics/types";
 import { Telemetry } from "./telemetry/types";
 import { ServerState } from "./types";
+import { onHover } from "@services/hover/onHover";
 
 const debounceAnalyzeDocument: {
   [uri: string]: (
@@ -351,6 +352,8 @@ export default function setupServer(
 
   connection.onCodeAction(onCodeAction(serverState));
 
+  connection.onHover(onHover(serverState));
+
   telemetry.enableHeartbeat();
 
   connection.onExit(() => {
@@ -610,6 +613,7 @@ const resolveOnInitialize = (serverState: ServerState) => {
         implementationProvider: true,
         renameProvider: true,
         codeActionProvider: true,
+        hoverProvider: true,
       },
     };
 

--- a/server/test/helpers/setupMockConnection.ts
+++ b/server/test/helpers/setupMockConnection.ts
@@ -21,6 +21,7 @@ export function setupMockConnection() {
     onWillSaveTextDocument: sinon.spy(),
     onWillSaveTextDocumentWaitUntil: sinon.spy(),
     onDidSaveTextDocument: sinon.spy(),
+    onHover: sinon.spy(),
     sendNotification: sinon.spy(),
     onCodeAction: sinon.spy(),
     onNotification: sinon.fake(

--- a/server/test/helpers/setupMockLanguageServer.ts
+++ b/server/test/helpers/setupMockLanguageServer.ts
@@ -18,6 +18,8 @@ import {
   Location,
   RenameParams,
   WorkspaceEdit,
+  HoverParams,
+  Hover,
 } from "vscode-languageserver/node";
 import setupServer from "../../src/server";
 import { setupMockCompilerProcessFactory } from "./setupMockCompilerProcessFactory";
@@ -50,6 +52,7 @@ export type OnImplementation = (
 export type OnRenameRequest = (
   params: RenameParams
 ) => WorkspaceEdit | undefined | null;
+export type OnHover = (params: HoverParams) => Hover | null;
 
 export async function setupMockLanguageServer({
   documents,
@@ -105,6 +108,7 @@ export async function setupMockLanguageServer({
     mockConnection.onImplementation.getCall(0).firstArg;
   const renameRequest: OnRenameRequest =
     mockConnection.onRenameRequest.getCall(0).firstArg;
+  const hover: OnHover = mockConnection.onHover.getCall(0).firstArg;
 
   const didOpenTextDocument =
     mockConnection.onDidOpenTextDocument.getCall(0).firstArg;
@@ -162,6 +166,7 @@ export async function setupMockLanguageServer({
       references,
       implementation,
       renameRequest,
+      hover,
     },
   };
 }

--- a/server/test/parser/services/hover/assertOnServerHover.ts
+++ b/server/test/parser/services/hover/assertOnServerHover.ts
@@ -1,0 +1,19 @@
+import { assert } from "chai";
+import { VSCodePosition } from "@common/types";
+import { OnHover } from "../../../helpers/setupMockLanguageServer";
+import { MarkupContent } from "vscode-languageserver/node";
+
+export async function assertOnServerHover(
+  hover: OnHover,
+  uri: string,
+  position: VSCodePosition,
+  expectedContent: MarkupContent
+): Promise<void> {
+  const response = await hover({ textDocument: { uri }, position });
+
+  if (!response) {
+    assert.fail();
+  }
+
+  assert.deepStrictEqual(response.contents, expectedContent);
+}

--- a/server/test/parser/services/hover/error.ts
+++ b/server/test/parser/services/hover/error.ts
@@ -1,0 +1,53 @@
+import * as path from "path";
+import { VSCodePosition } from "@common/types";
+import { setupMockLanguageServer } from "../../../helpers/setupMockLanguageServer";
+import { forceToUnixStyle } from "../../../helpers/forceToUnixStyle";
+import { MarkupKind } from "vscode-languageserver/node";
+import { assertOnServerHover } from "./assertOnServerHover";
+
+describe("Parser", () => {
+  describe("Hover", () => {
+    describe("Error", () => {
+      const errorUri = forceToUnixStyle(
+        path.join(__dirname, "testData", "Error.sol")
+      );
+
+      let assertHover: (
+        position: VSCodePosition,
+        expectedHoverText: string
+      ) => Promise<void>;
+
+      before(async () => {
+        const {
+          server: { hover },
+        } = await setupMockLanguageServer({
+          documents: [{ uri: errorUri, analyze: true }],
+          errors: [],
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 500));
+
+        assertHover = (position: VSCodePosition, expectedHoverText: string) =>
+          assertOnServerHover(hover, errorUri, position, {
+            kind: MarkupKind.Markdown,
+            value: ["```solidity", expectedHoverText, "```"].join("\n"),
+          });
+      });
+
+      it("should display details for parameterless error", () =>
+        assertHover({ line: 40, character: 19 }, "error SimpleError()"));
+
+      it("should display details for an error with parameters", () =>
+        assertHover(
+          { line: 44, character: 19 },
+          "error ArgError(uint first, TodoStruct second, AuctionBase third, Status fourth)"
+        ));
+
+      it("should display details for an error inherited from a parent contract", () =>
+        assertHover(
+          { line: 48, character: 19 },
+          "error BaseError(uint first)"
+        ));
+    });
+  });
+});

--- a/server/test/parser/services/hover/event.ts
+++ b/server/test/parser/services/hover/event.ts
@@ -1,0 +1,53 @@
+import * as path from "path";
+import { VSCodePosition } from "@common/types";
+import { setupMockLanguageServer } from "../../../helpers/setupMockLanguageServer";
+import { forceToUnixStyle } from "../../../helpers/forceToUnixStyle";
+import { MarkupKind } from "vscode-languageserver/node";
+import { assertOnServerHover } from "./assertOnServerHover";
+
+describe("Parser", () => {
+  describe("Hover", () => {
+    describe("Event", () => {
+      const eventUri = forceToUnixStyle(
+        path.join(__dirname, "testData", "Event.sol")
+      );
+
+      let assertHover: (
+        position: VSCodePosition,
+        expectedHoverText: string
+      ) => Promise<void>;
+
+      before(async () => {
+        const {
+          server: { hover },
+        } = await setupMockLanguageServer({
+          documents: [{ uri: eventUri, analyze: true }],
+          errors: [],
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 500));
+
+        assertHover = (position: VSCodePosition, expectedHoverText: string) =>
+          assertOnServerHover(hover, eventUri, position, {
+            kind: MarkupKind.Markdown,
+            value: ["```solidity", expectedHoverText, "```"].join("\n"),
+          });
+      });
+
+      it("should display details for parameterless event", () =>
+        assertHover({ line: 38, character: 13 }, "event SimpleEvent()"));
+
+      it("should display details for an event with parameters", () =>
+        assertHover(
+          { line: 39, character: 13 },
+          "event ArgEvent(uint first, TodoStruct second, AuctionBase third, Status fourth)"
+        ));
+
+      it("should display details for an event inherited from a parent contract", () =>
+        assertHover(
+          { line: 40, character: 13 },
+          "event BaseEvent(uint first)"
+        ));
+    });
+  });
+});

--- a/server/test/parser/services/hover/function.ts
+++ b/server/test/parser/services/hover/function.ts
@@ -1,0 +1,65 @@
+import * as path from "path";
+import { VSCodePosition } from "@common/types";
+import { setupMockLanguageServer } from "../../../helpers/setupMockLanguageServer";
+import { forceToUnixStyle } from "../../../helpers/forceToUnixStyle";
+import { MarkupKind } from "vscode-languageserver/node";
+import { assertOnServerHover } from "./assertOnServerHover";
+
+describe("Parser", () => {
+  describe("Hover", () => {
+    describe("Function", () => {
+      const functionUri = forceToUnixStyle(
+        path.join(__dirname, "testData", "Function.sol")
+      );
+
+      let assertHover: (
+        position: VSCodePosition,
+        expectedHoverText: string
+      ) => Promise<void>;
+
+      before(async () => {
+        const {
+          server: { hover },
+        } = await setupMockLanguageServer({
+          documents: [{ uri: functionUri, analyze: true }],
+          errors: [],
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 500));
+
+        assertHover = (position: VSCodePosition, expectedHoverText: string) =>
+          assertOnServerHover(hover, functionUri, position, {
+            kind: MarkupKind.Markdown,
+            value: ["```solidity", expectedHoverText, "```"].join("\n"),
+          });
+      });
+
+      it("should display details for a minimal function", () =>
+        assertHover({ line: 113, character: 13 }, "function minimal() public"));
+
+      it("should display details for a function with returns", () =>
+        assertHover(
+          { line: 114, character: 13 },
+          "function withReturn() public view returns (string memory output)"
+        ));
+
+      it("should display details for a function with a parameter list", () =>
+        assertHover(
+          { line: 116, character: 13 },
+          "function withBasicParams(string calldata paramString, bool paramBool, uint112 paramInt, address paramAddr, UserType paramUserType, Status paramEnum, TodoStruct memory paramStruct) public view"
+        ));
+
+      it("should display details for a function with a parameter list with arrays", () =>
+        assertHover(
+          { line: 126, character: 13 },
+          "function withArrayParams(uint256[] memory paramIntArray, Status[] calldata paramEnumArray, UserType[] memory paramUserTypeArray, TodoStruct[] calldata paramStructArray) public view returns (string memory output)"
+        ));
+
+      it("should display details for a function pulled from a parent contract", () =>
+        assertHover(
+          { line: 133, character: 13 },
+          "function fromBase() public view virtual override onlyExample validAddress returns (uint112 first, uint112 second)"
+        ));
+    });
+  });
+});

--- a/server/test/parser/services/hover/identifier.ts
+++ b/server/test/parser/services/hover/identifier.ts
@@ -1,0 +1,261 @@
+import * as path from "path";
+import { VSCodePosition } from "@common/types";
+import { setupMockLanguageServer } from "../../../helpers/setupMockLanguageServer";
+import { forceToUnixStyle } from "../../../helpers/forceToUnixStyle";
+import { MarkupKind } from "vscode-languageserver/node";
+import { assertOnServerHover } from "./assertOnServerHover";
+
+describe("Parser", () => {
+  describe("Hover", () => {
+    describe("Identifier", () => {
+      const identifierUri = forceToUnixStyle(
+        path.join(__dirname, "testData", "Identifier.sol")
+      );
+
+      let assertHover: (
+        position: VSCodePosition,
+        expectedHoverText: string
+      ) => Promise<void>;
+
+      before(async () => {
+        const {
+          server: { hover },
+        } = await setupMockLanguageServer({
+          documents: [{ uri: identifierUri, analyze: true }],
+          errors: [],
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 500));
+
+        assertHover = (position: VSCodePosition, expectedHoverText: string) =>
+          assertOnServerHover(hover, identifierUri, position, {
+            kind: MarkupKind.Markdown,
+            value: ["```solidity", expectedHoverText, "```"].join("\n"),
+          });
+      });
+
+      describe("Local variable", () => {
+        it("should display details for string", () =>
+          assertHover(
+            { line: 68, character: 20 },
+            "string memory localString"
+          ));
+
+        it("should display details for a bool", () =>
+          assertHover({ line: 69, character: 20 }, "bool localBool"));
+
+        it("should display details for an int", () =>
+          assertHover({ line: 70, character: 20 }, "uint256 localInt"));
+
+        it("should display details for an address", () =>
+          assertHover({ line: 71, character: 20 }, "address localAddr"));
+
+        it("should display details for a user defined type", () =>
+          assertHover({ line: 72, character: 36 }, "UserType localUserType"));
+
+        it("should display details for an enum", () =>
+          assertHover({ line: 73, character: 20 }, "Status localEnum"));
+
+        it("should display details for a struct", () =>
+          assertHover(
+            { line: 74, character: 20 },
+            "TodoStruct memory localStruct"
+          ));
+
+        describe("Arrays", () => {
+          it("should display details for an int array", () =>
+            assertHover(
+              { line: 76, character: 20 },
+              "uint[] memory localIntArray"
+            ));
+
+          it("should display details for an enum array", () =>
+            assertHover(
+              { line: 77, character: 20 },
+              "Status[] memory localEnumArray"
+            ));
+
+          it("should display details for a user type array", () =>
+            assertHover(
+              { line: 78, character: 20 },
+              "UserType[] memory localUserTypeArray"
+            ));
+
+          it("should display details for a struct array", () =>
+            assertHover(
+              { line: 79, character: 20 },
+              "TodoStruct[] memory localStructArray"
+            ));
+        });
+      });
+
+      describe("Parameter", () => {
+        it("should display details for string", () =>
+          assertHover(
+            { line: 106, character: 20 },
+            "string calldata paramString"
+          ));
+
+        it("should display details for a bool", () =>
+          assertHover({ line: 107, character: 20 }, "bool paramBool"));
+
+        it("should display details for an int", () =>
+          assertHover({ line: 108, character: 20 }, "uint112 paramInt"));
+
+        it("should display details for an address", () =>
+          assertHover({ line: 109, character: 20 }, "address paramAddr"));
+
+        it("should display details for a user defined type", () =>
+          assertHover({ line: 110, character: 36 }, "UserType paramUserType"));
+
+        it("should display details for an enum", () =>
+          assertHover({ line: 111, character: 20 }, "Status paramEnum"));
+
+        it("should display details for a struct", () =>
+          assertHover(
+            { line: 112, character: 20 },
+            "TodoStruct memory paramStruct"
+          ));
+
+        describe("Arrays", () => {
+          it("should display details for an int array", () =>
+            assertHover(
+              { line: 114, character: 20 },
+              "uint144[] storage paramIntArray"
+            ));
+
+          it("should display details for an enum array", () =>
+            assertHover(
+              { line: 115, character: 20 },
+              "Status[] memory paramEnumArray"
+            ));
+
+          it("should display details for a user type array", () =>
+            assertHover(
+              { line: 116, character: 20 },
+              "UserType[] calldata paramUserTypeArray"
+            ));
+
+          it("should display details for a struct array", () =>
+            assertHover(
+              { line: 117, character: 20 },
+              "TodoStruct[] storage paramStructArray"
+            ));
+        });
+
+        describe("Mappings", () => {
+          it("should display details for a simple mapping", () =>
+            assertHover(
+              { line: 119, character: 20 },
+              "mapping(address => uint) storage paramSimpleMapping"
+            ));
+
+          it("should display details for a simple mapping", () =>
+            assertHover(
+              { line: 120, character: 36 },
+              "mapping(UserType => UserType) storage paramUserTypeMapping"
+            ));
+
+          it("should display details for a nested array mapping", () =>
+            assertHover(
+              { line: 121, character: 20 },
+              "mapping(address => string[]) storage paramNestedArrayMapping"
+            ));
+
+          it("should display details for a nested map mapping", () =>
+            assertHover(
+              { line: 122, character: 20 },
+              "mapping(address => mapping(address => uint)) storage paramNestedMapMapping"
+            ));
+        });
+      });
+
+      describe("State Variable", () => {
+        it("should display details for string", () =>
+          assertHover(
+            { line: 129, character: 20 },
+            "string internal stateString"
+          ));
+
+        it("should display details for a bool", () =>
+          assertHover({ line: 130, character: 20 }, "bool private stateBool"));
+
+        it("should display details for an int", () =>
+          assertHover({ line: 131, character: 20 }, "uint public stateInt"));
+
+        it("should display details for an address", () =>
+          assertHover(
+            { line: 132, character: 20 },
+            "address public stateAddr"
+          ));
+
+        it("should display details for a user defined type", () =>
+          assertHover(
+            { line: 133, character: 36 },
+            "UserType public stateUserType"
+          ));
+
+        it("should display details for an enum", () =>
+          assertHover(
+            { line: 134, character: 20 },
+            "Status internal stateEnum"
+          ));
+
+        it("should display details for a struct", () =>
+          assertHover({ line: 135, character: 20 }, "TodoStruct stateStruct"));
+
+        describe("Arrays", () => {
+          it("should display details for an int array", () =>
+            assertHover(
+              { line: 137, character: 20 },
+              "uint256[] public stateIntArray"
+            ));
+
+          it("should display details for an enum array", () =>
+            assertHover(
+              { line: 138, character: 20 },
+              "Status[] public stateEnumArray"
+            ));
+
+          it("should display details for a user type array", () =>
+            assertHover(
+              { line: 139, character: 20 },
+              "UserType[] public stateUserTypeArray"
+            ));
+
+          it("should display details for a struct array", () =>
+            assertHover(
+              { line: 140, character: 20 },
+              "TodoStruct[] public stateStructArray"
+            ));
+        });
+
+        describe("Mappings", () => {
+          it("should display details for a simple mapping", () =>
+            assertHover(
+              { line: 142, character: 20 },
+              "mapping(address => uint) stateSimpleMapping"
+            ));
+
+          it("should display details for a simple mapping", () =>
+            assertHover(
+              { line: 143, character: 36 },
+              "mapping(UserType => UserType) stateUserTypeMapping"
+            ));
+
+          it("should display details for a nested array mapping", () =>
+            assertHover(
+              { line: 144, character: 20 },
+              "mapping(address => string[]) stateNestedArrayMapping"
+            ));
+
+          it("should display details for a nested map mapping", () =>
+            assertHover(
+              { line: 145, character: 20 },
+              "mapping(address => mapping(address => uint)) stateNestedMapMapping"
+            ));
+        });
+      });
+    });
+  });
+});

--- a/server/test/parser/services/hover/testData/Error.sol
+++ b/server/test/parser/services/hover/testData/Error.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.2 <0.9.0;
+
+import "hardhat/console.sol";
+
+contract AuctionBase {
+    error BaseError(uint first);
+}
+
+contract Auction is AuctionBase {
+    type UserType is uint256;
+
+    enum Status {
+        Pending,
+        Shipped,
+        Accepted,
+        Rejected,
+        Canceled
+    }
+
+    struct TodoStruct {
+        string text;
+        bool completed;
+        Status status;
+    }
+
+    error SimpleError();
+    error ArgError(
+        uint first,
+        TodoStruct second,
+        AuctionBase third,
+        Status fourth
+    );
+
+    function errors() public {
+        TodoStruct memory localStruct;
+
+        AuctionBase b = new AuctionBase();
+
+        if (1 < 2) {
+            revert SimpleError();
+        }
+
+        if (1 < 2) {
+            revert ArgError(1, localStruct, b, Status.Canceled);
+        }
+
+        if (1 < 2) {
+            revert BaseError(1);
+        }
+    }
+}

--- a/server/test/parser/services/hover/testData/Event.sol
+++ b/server/test/parser/services/hover/testData/Event.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.2 <0.9.0;
+
+import "hardhat/console.sol";
+
+contract AuctionBase {
+    event BaseEvent(uint first);
+}
+
+contract Auction is AuctionBase {
+    type UserType is uint256;
+
+    enum Status {
+        Pending,
+        Shipped,
+        Accepted,
+        Rejected,
+        Canceled
+    }
+
+    struct TodoStruct {
+        string text;
+        bool completed;
+        Status status;
+    }
+
+    event SimpleEvent();
+    event ArgEvent(
+        uint first,
+        TodoStruct second,
+        AuctionBase third,
+        Status fourth
+    );
+
+    function events() public {
+        TodoStruct memory localStruct;
+        AuctionBase b = new AuctionBase();
+
+        emit SimpleEvent();
+        emit ArgEvent(1, localStruct, b, Status.Canceled);
+        emit BaseEvent(1);
+    }
+}

--- a/server/test/parser/services/hover/testData/Function.sol
+++ b/server/test/parser/services/hover/testData/Function.sol
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.2 <0.9.0;
+
+import "hardhat/console.sol";
+
+contract BaseHoverFunctions {
+    bool internal stateBool = true;
+
+    constructor(bool paramBool) {
+        stateBool = paramBool;
+    }
+
+    function fromBase()
+        public
+        view
+        virtual
+        returns (uint112 first, uint112 second)
+    {
+        return (1, 2);
+    }
+}
+
+contract HoverFunctions is BaseHoverFunctions {
+    type UserType is uint256;
+
+    enum Status {
+        Pending,
+        Shipped,
+        Accepted,
+        Rejected,
+        Canceled
+    }
+
+    struct TodoStruct {
+        string text;
+        bool completed;
+        Status status;
+    }
+
+    string internal stateString = "Hello";
+
+    constructor(string memory paramName) BaseHoverFunctions(false) {
+        stateString = paramName;
+        stateBool = false;
+    }
+
+    function minimal() public {}
+
+    function withReturn() public view returns (string memory output) {
+        return stateString;
+    }
+
+    function withBasicParams(
+        string calldata paramString,
+        bool paramBool,
+        uint112 paramInt,
+        address paramAddr,
+        UserType paramUserType,
+        Status paramEnum,
+        TodoStruct memory paramStruct
+    ) public view {
+        console.log(paramString);
+        console.log(paramBool);
+        console.log(paramInt);
+        console.log(paramAddr);
+        console.log(UserType.unwrap(paramUserType));
+        console.log(paramEnum == Status.Pending);
+        console.log(paramStruct.text);
+    }
+
+    function withArrayParams(
+        uint256[] memory paramIntArray,
+        Status[] calldata paramEnumArray,
+        UserType[] memory paramUserTypeArray,
+        TodoStruct[] calldata paramStructArray
+    ) public view returns (string memory output) {
+        console.log(paramIntArray.length);
+        console.log(paramEnumArray.length);
+        console.log(paramUserTypeArray.length);
+        console.log(paramStructArray.length);
+
+        return stateString;
+    }
+
+    function fromBase()
+        public
+        view
+        virtual
+        override
+        onlyExample
+        validAddress(msg.sender, 34)
+        returns (uint112 first, uint112 second)
+    {
+        return (1, 2);
+    }
+
+    modifier onlyExample() {
+        _;
+    }
+
+    modifier validAddress(address _addr, uint256 balance) {
+        require(_addr != address(0), "Not valid address");
+        require(balance > 0, "Not an allowed balance");
+        _;
+    }
+
+    function main() private {
+        TodoStruct memory localStruct;
+        uint[] memory localArray = new uint[](5);
+        Status[] memory localEnumArray = new Status[](5);
+        UserType[] memory localUserTypeArray = new UserType[](5);
+        TodoStruct[] memory localStructArray = new TodoStruct[](5);
+
+        this.minimal();
+        this.withReturn();
+
+        this.withBasicParams(
+            "hello",
+            false,
+            1,
+            msg.sender,
+            UserType.wrap(12),
+            Status.Canceled,
+            localStruct
+        );
+
+        this.withArrayParams(
+            localArray,
+            localEnumArray,
+            localUserTypeArray,
+            localStructArray
+        );
+
+        this.fromBase();
+    }
+}

--- a/server/test/parser/services/hover/testData/Identifier.sol
+++ b/server/test/parser/services/hover/testData/Identifier.sol
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.2 <0.9.0;
+
+import "hardhat/console.sol";
+
+contract Auction {
+    type UserType is uint256;
+
+    enum Status {
+        Pending,
+        Shipped,
+        Accepted,
+        Rejected,
+        Canceled
+    }
+
+    struct TodoStruct {
+        string text;
+        bool completed;
+        Status status;
+    }
+
+    string internal stateString = "Hello";
+    bool private stateBool = true;
+    uint public stateInt = 123;
+    address payable public stateAddr;
+    UserType public stateUserType;
+    Status internal stateEnum = Status.Rejected;
+    TodoStruct stateStruct;
+
+    uint256[] public stateIntArray;
+    Status[] public stateEnumArray;
+    UserType[] public stateUserTypeArray;
+    TodoStruct[] public stateStructArray;
+
+    mapping(address => uint) stateSimpleMapping;
+    mapping(UserType => UserType) stateUserTypeMapping;
+    mapping(address => string[]) stateNestedArrayMapping;
+    mapping(address => mapping(address => uint)) stateNestedMapMapping;
+
+    event SimpleEvent();
+    event ArgEvent(address first, uint second);
+
+    error SimpleError();
+    error ArgError(uint first, TodoStruct second, Auction third, Status fourth);
+
+    function getText() external view virtual returns (string memory output) {
+        return "output";
+    }
+
+    function locals() external view virtual returns (uint256) {
+        string memory localString = this.getText();
+        bool localBool = true;
+        uint256 localInt = 456;
+        address localAddr = msg.sender;
+        UserType localUserType = UserType.wrap(uint256(456));
+        Status localEnum = Status.Pending;
+        TodoStruct memory localStruct;
+
+        uint[] memory localIntArray = new uint[](5);
+        Status[] memory localEnumArray = new Status[](5);
+        UserType[] memory localUserTypeArray = new UserType[](5);
+        TodoStruct[] memory localStructArray = new TodoStruct[](5);
+
+        // mapping(address => uint) memory localMapping;
+
+        // Local Accesses
+
+        console.log(localString);
+        console.log(localBool);
+        console.log(localInt);
+        console.log(localAddr);
+        console.log(UserType.unwrap(localUserType));
+        console.log(localEnum == Status.Pending);
+        console.log(localStruct.text);
+
+        console.log(localIntArray.length);
+        console.log(localEnumArray.length);
+        console.log(localUserTypeArray.length);
+        console.log(localStructArray.length);
+
+        // console.log(localMapping);
+
+        return 0;
+    }
+
+    function parameters(
+        string calldata paramString,
+        bool paramBool,
+        uint112 paramInt,
+        address paramAddr,
+        UserType paramUserType,
+        Status paramEnum,
+        TodoStruct memory paramStruct,
+        uint144[] storage paramIntArray,
+        Status[] memory paramEnumArray,
+        UserType[] calldata paramUserTypeArray,
+        TodoStruct[] storage paramStructArray,
+        mapping(address => uint) storage paramSimpleMapping,
+        mapping(UserType => UserType) storage paramUserTypeMapping,
+        mapping(address => string[]) storage paramNestedArrayMapping,
+        mapping(address => mapping(address => uint))
+            storage paramNestedMapMapping
+    ) internal view virtual returns (uint256) {
+        // Param Accesses
+
+        console.log(paramString);
+        console.log(paramBool);
+        console.log(paramInt);
+        console.log(paramAddr);
+        console.log(UserType.unwrap(paramUserType));
+        console.log(paramEnum == Status.Pending);
+        console.log(paramStruct.text);
+
+        console.log(paramIntArray.length);
+        console.log(paramEnumArray.length);
+        console.log(paramUserTypeArray.length);
+        console.log(paramStructArray.length);
+
+        console.log(paramSimpleMapping[msg.sender]);
+        console.log(UserType.unwrap(paramUserTypeMapping[UserType.wrap(123)]));
+        console.log(paramNestedArrayMapping[msg.sender].length);
+        console.log(paramNestedMapMapping[msg.sender][msg.sender]);
+
+        return 0;
+    }
+
+    function stateVariables() external view virtual returns (uint256) {
+        // State variable accesses
+        console.log(stateString);
+        console.log(stateBool);
+        console.log(stateInt);
+        console.log(stateAddr);
+        console.log(UserType.unwrap(stateUserType));
+        console.log(stateEnum == Status.Pending);
+        console.log(stateStruct.text);
+
+        console.log(stateIntArray.length);
+        console.log(stateEnumArray.length);
+        console.log(stateUserTypeArray.length);
+        console.log(stateStructArray.length);
+
+        console.log(stateSimpleMapping[msg.sender]);
+        console.log(UserType.unwrap(stateUserTypeMapping[UserType.wrap(123)]));
+        console.log(stateNestedArrayMapping[msg.sender].length);
+        console.log(stateNestedMapMapping[msg.sender][msg.sender]);
+
+        return 0;
+    }
+}

--- a/test/integration/tests/configuration/configuration.test.json
+++ b/test/integration/tests/configuration/configuration.test.json
@@ -9,6 +9,7 @@
       "triggerCharacters": ["(", ","]
     },
     "definitionProvider": true,
+    "hoverProvider": true,
     "typeDefinitionProvider": true,
     "referencesProvider": true,
     "implementationProvider": true,


### PR DESCRIPTION
This implements the `onHover` functionality of the LSP.

It does this for identifiers in local functions, and will give type and other information from local variables, parameters and state variables.

It adds hover for functions invocations, events and errors as well.

Comments are not included in the display (they are not in the ast).

Relates to https://github.com/NomicFoundation/hardhat-vscode/issues/62

## Preview

![Mar-23-2022 17-34-01](https://user-images.githubusercontent.com/24030/159761081-2c2bac34-e954-43aa-a463-d8c9c982de8c.gif)

## TODO

- [x] hover for local variables
- [x] hover for function invocations
- [x] hover for event emits
- [x] hover for error reverts

## Considerations

* we on display hovers for variable accesses, function calls, event emits and error reverts
* we do not display the related comments (natspec or otherwise)
* display is conditional on the parser (if it errors, no hover)

Linear: HHVSC-49