### PR TITLE
fix: stop passing pid to kill

### DIFF
--- a/.changeset/strong-hats-deny.md
+++ b/.changeset/strong-hats-deny.md
@@ -1,0 +1,5 @@
+---
+"hardhat-solidity": patch
+---
+
+Fixes - fix for validation child_process cancelling ((#89)[https://github.com/NomicFoundation/hardhat-vscode/issues/89])

--- a/server/src/parser/services/validation/HardhatProcess.ts
+++ b/server/src/parser/services/validation/HardhatProcess.ts
@@ -98,9 +98,7 @@ export class HardhatProcess implements CompilerProcess {
   }
 
   kill() {
-    // Then using process.kill(pid) method on main process we can kill all processes that are in
-    // the same group of a child process with the same pid group.
-    this.child?.kill(this.child.pid);
+    this.child?.kill();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
To kill the child compilation process we pass in the pid. The docs suggest we can leave it and take the default signal of `SIGTERM`.

Fixes #89.

## Testing

I have done a round of manual tests. Validation appears unaffected.

Linear: HHVSC-111