### PR TITLE
chore: improve clientside formatting

### DIFF
--- a/.changeset/heavy-lamps-attack.md
+++ b/.changeset/heavy-lamps-attack.md
@@ -2,4 +2,4 @@
 "hardhat-solidity": patch
 ---
 
-Fix - don't throw on hh error objects with no source location
+Fix - don't throw on hh error objects with no source location ((#147)[https://github.com/NomicFoundation/hardhat-vscode/issues/147])

--- a/.changeset/tall-ghosts-push.md
+++ b/.changeset/tall-ghosts-push.md
@@ -1,0 +1,5 @@
+---
+"hardhat-solidity": patch
+---
+
+Change - remove unnecessary setting for turning off formatting ((#102)[https://github.com/NomicFoundation/hardhat-vscode/issues/102])

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -2,8 +2,4 @@
 module.exports = {
   root: true,
   extends: [`../.eslintrc.js`],
-  parserOptions: {
-    project: `./tsconfig.json`,
-    sourceType: "module",
-  },
 };

--- a/client/package.json
+++ b/client/package.json
@@ -13,11 +13,13 @@
     "clean": "rimraf out tsconfig.tsbuildinfo"
   },
   "devDependencies": {
+    "@sentry/types": "6.19.1",
     "@types/vscode": "^1.63.0",
     "eslint": "^7.23.0",
     "rimraf": "3.0.2"
   },
   "dependencies": {
+    "@sentry/node": "6.19.1",
     "prettier": "2.5.1",
     "prettier-plugin-solidity": "^1.0.0-beta.19",
     "vscode-languageclient": "^7.0.0"

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,411 +1,47 @@
-import * as path from "path";
-import * as events from "events";
-import {
-  workspace,
-  window,
-  languages,
-  ExtensionContext,
-  TextDocument,
-  OutputChannel,
-  WorkspaceFolder,
-  Uri,
-  ProgressLocation,
-  TextEdit,
-  extensions,
-  env,
-  ConfigurationTarget,
-} from "vscode";
-import {
-  Disposable,
-  LanguageClient,
-  LanguageClientOptions,
-  ServerOptions,
-  TransportKind,
-} from "vscode-languageclient/node";
+import { ExtensionContext } from "vscode";
+import { warnOnOtherSolidityExtensions } from "./popups/warnOnOtherSolidityExtensions";
+import { setupExtensionState } from "./setup/setupExtensionState";
+import { setupFormatterHook } from "./setup/setupFormatterHook";
+import { setupLanguageServerHooks } from "./setup/setupLanguageServerHooks";
+import { ExtensionState } from "./types";
 
-import { formatDocument } from "./formatter";
-import { Logger } from "./Logger";
-import { HardhatVSCodeConfig } from "./types";
+let extensionState: ExtensionState | null = null;
 
-const CONFLICTING_EXTENSION_ID = "juanblanco.solidity";
-const CONFLICTING_EXTENSION_NAME = "solidity";
-
-type IndexFileData = {
-  path: string;
-  current: number;
-  total: number;
-};
-
-const clients: Map<string, LanguageClient> = new Map();
-const listenerDisposables: Disposable[] = [];
-
-let _sortedWorkspaceFolders: string[] | undefined;
-function sortedWorkspaceFolders(): string[] {
-  if (_sortedWorkspaceFolders === void 0) {
-    _sortedWorkspaceFolders = workspace.workspaceFolders
-      ? workspace.workspaceFolders
-          .map((folder) => {
-            let result = folder.uri.toString();
-
-            if (result.charAt(result.length - 1) !== "/") {
-              result = result + "/";
-            }
-
-            return result;
-          })
-          .sort((a, b) => {
-            return a.length - b.length;
-          })
-      : [];
-  }
-
-  return _sortedWorkspaceFolders;
-}
-
-workspace.onDidChangeWorkspaceFolders(
-  () => (_sortedWorkspaceFolders = undefined)
-);
-
-function getOuterMostWorkspaceFolder(folder: WorkspaceFolder): WorkspaceFolder {
-  const sorted = sortedWorkspaceFolders();
-
-  for (const element of sorted) {
-    let uri = folder.uri.toString();
-
-    if (uri.charAt(uri.length - 1) !== "/") {
-      uri = uri + "/";
-    }
-
-    if (uri.startsWith(element)) {
-      return workspace.getWorkspaceFolder(Uri.parse(element));
-    }
-  }
-
-  return folder;
-}
-
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function getUnsavedDocuments(): TextDocument[] {
-  return workspace.textDocuments.filter((i) => i.isDirty);
-}
-
-/**
- * Sends a no-op change notification to the server, this allows the
- * triggering of validation.
- * @param client the language client
- * @param textDoc the open text file to trigger validation on
- */
-function notifyOfNoopChange(client: LanguageClient, textDoc: TextDocument) {
-  client.sendNotification("textDocument/didChange", {
-    textDocument: {
-      version: textDoc.version,
-      uri: textDoc.uri.toString(),
-    },
-    contentChanges: [
-      {
-        range: {
-          start: { line: 0, character: 0 },
-          end: { line: 0, character: 0 },
-        },
-        rangeLength: 1,
-        text: "",
-      },
-    ],
-  });
-}
-
-/**
- * If the doc is open, trigger a noop change on the server to start validation.
- */
-function triggerValidationForOpenDoc(client: LanguageClient, path: string) {
-  const textDoc = workspace.textDocuments.find((d) => d.uri.path === path);
-
-  if (!textDoc) {
-    return;
-  }
-
-  notifyOfNoopChange(client, textDoc);
-}
-
-function showFileIndexingProgress(client: LanguageClient): void {
-  const em = new events.EventEmitter();
-
-  client.onReady().then(() => {
-    client.onNotification("custom/indexing-file", (data: IndexFileData) => {
-      em.emit("indexing-file", data);
-    });
-  });
-
-  // Progress bar
-  window.withProgress(
-    {
-      cancellable: true,
-      location: ProgressLocation.Notification,
-      title: "Indexing Project",
-    },
-    async (progress) => {
-      progress.report({
-        increment: 0,
-        message: "Start indexing...",
-      });
-
-      const promise = new Promise<void>((resolve) => {
-        em.on("indexing-file", (data: IndexFileData) => {
-          progress.report({
-            increment: Math.round(data.total / data.current),
-            message: `Indexing ${data.path}`,
-          });
-
-          // Files that were open on vscode load, will
-          // have swallowed the `didChange` event as the
-          // language server wasn't intialized yet. We
-          // revalidate open editor files after indexing
-          // to ensure warning and errors appear on startup.
-          triggerValidationForOpenDoc(client, data.path);
-
-          if (data.total === data.current) {
-            resolve();
-          }
-        });
-      });
-
-      await promise;
-
-      progress.report({
-        increment: 100,
-        message: `Project indexing is complete.`,
-      });
-
-      await sleep(3000);
-    }
-  );
-}
-
-async function warnOnOtherSolidityExtensions(logger: Logger) {
-  const conflictingExtension = extensions.getExtension(
-    CONFLICTING_EXTENSION_ID
-  );
-
-  if (conflictingExtension === undefined) {
-    return;
-  }
-
-  try {
-    await window.showWarningMessage(
-      `Both this extension and the \`${CONFLICTING_EXTENSION_NAME}\` (${CONFLICTING_EXTENSION_ID}) extension are enabled. They have conflicting functionality. Disable one of them.`,
-      "Okay"
-    );
-  } catch (err) {
-    logger.error(err);
-  }
-}
-
-async function showAnalyticsAllowPopup(
-  context: ExtensionContext
-): Promise<void> {
-  const shownTelemetryMessage = context.globalState.get<boolean>(
-    "shownTelemetryMessage"
-  );
-
-  if (shownTelemetryMessage) {
-    return;
-  }
-
-  const item = await window.showInformationMessage(
-    "Help us improve the Hardhat for Visual Studio Code extension with anonymous crash reports & basic usage data?",
-    { modal: true },
-    "Accept",
-    "Decline"
-  );
-
-  const isAccepted = item === "Accept" ? true : false;
-
-  const config = workspace.getConfiguration("hardhat");
-
-  config.update("telemetry", isAccepted, ConfigurationTarget.Global);
-
-  context.globalState.update("shownTelemetryMessage", true);
-}
+const SENTRY_DSN =
+  "https://9d1e887190db400791c77d9bb5a154fd@o385026.ingest.sentry.io/5469451";
 
 export function activate(context: ExtensionContext) {
-  const config: HardhatVSCodeConfig = {
-    env:
-      process.env.NODE_ENV === "development"
-        ? process.env.NODE_ENV
-        : "production",
-    version: context.extension.packageJSON.version,
-    name: context.extension.packageJSON.name,
-    hardhatTelemetryEnabled: workspace
-      .getConfiguration("hardhat")
-      .get<boolean>("telemetry"),
-  };
+  extensionState = setupExtensionState(context, { sentryDsn: SENTRY_DSN });
 
-  const module = context.asAbsolutePath(path.join("server", "out", "index.js"));
-
-  const outputChannel: OutputChannel = window.createOutputChannel("Hardhat");
-
-  const logger = new Logger(outputChannel);
+  const { logger } = extensionState;
 
   logger.info("Hardhat for Visual Studio Code Starting ...");
-  logger.info(`env: ${config.env}`);
+  logger.info(`env: ${extensionState.env}`);
 
-  warnOnOtherSolidityExtensions(logger);
+  warnOnOtherSolidityExtensions(extensionState);
 
-  context.subscriptions.push(
-    languages.registerDocumentFormattingEditProvider("solidity", {
-      provideDocumentFormattingEdits(document: TextDocument): TextEdit[] {
-        return formatDocument(document, context);
-      },
-    })
-  );
-
-  function didOpenTextDocument(document: TextDocument): void {
-    // We are only interested in solidity files
-    if (document.languageId !== "solidity" || document.uri.scheme !== "file") {
-      return;
-    }
-
-    const uri = document.uri;
-    let folder = workspace.getWorkspaceFolder(uri);
-
-    // Files outside a folder can't be handled. This might depend on the language.
-    // Single file languages like JSON might handle files outside the workspace folders.
-    if (!folder) {
-      return;
-    }
-
-    // If we have nested workspace folders we only start a server on the outer most workspace folder.
-    folder = getOuterMostWorkspaceFolder(folder);
-
-    if (!clients.has(folder.uri.toString())) {
-      // The debug options for the server.
-      // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging.
-      const debugOptions = {
-        execArgv: ["--nolazy", `--inspect=${6009 + clients.size}`],
-      };
-
-      // If the extension is launched in debug mode then the debug server options are used.
-      // Otherwise the run options are used.
-      const serverOptions: ServerOptions = {
-        run: {
-          module,
-          transport: TransportKind.ipc,
-        },
-        debug: {
-          module,
-          transport: TransportKind.ipc,
-          options: debugOptions,
-        },
-      };
-
-      // Options to control the language client.
-      const clientOptions: LanguageClientOptions = {
-        // Register the server for solidity text documents.
-        documentSelector: [
-          { scheme: "file", language: "solidity", pattern: `**/*.sol` },
-        ],
-        diagnosticCollectionName: "hardhat-language-server",
-        workspaceFolder: folder,
-        outputChannel: outputChannel,
-        initializationOptions: {
-          extensionName: config.name,
-          extensionVersion: config.version,
-          env: config.env,
-          globalTelemetryEnabled: env.isTelemetryEnabled,
-          hardhatTelemetryEnabled: config.hardhatTelemetryEnabled,
-          machineId: env.machineId,
-        },
-      };
-
-      logger.info(`[LS: ${folder.name}] Client starting`);
-
-      // Create the language client and start the client.
-      // Start the client. This will also launch the server
-      const client = new LanguageClient(
-        "hardhat-language-server",
-        "Hardhat Language Server",
-        serverOptions,
-        clientOptions
-      );
-
-      showAnalyticsAllowPopup(context);
-
-      client.onReady().then(() => {
-        logger.info(`[LS: ${folder.name}] Client ready`);
-
-        client.onNotification("custom/get-unsaved-documents", () => {
-          const unsavedDocuments = getUnsavedDocuments();
-
-          client.sendNotification(
-            "custom/get-unsaved-documents",
-            unsavedDocuments.map((unsavedDocument) => {
-              return {
-                uri: unsavedDocument.uri,
-                languageId: unsavedDocument.languageId,
-                version: unsavedDocument.version,
-                content: unsavedDocument.getText(),
-              };
-            })
-          );
-        });
-      });
-
-      showFileIndexingProgress(client);
-
-      const telemetryChangeDisposable = env.onDidChangeTelemetryEnabled(
-        (enabled: boolean) => {
-          client.sendNotification("custom/didChangeGlobalTelemetryEnabled", {
-            enabled,
-          });
-        }
-      );
-
-      const hardhatTelemetryChangeDisposable =
-        workspace.onDidChangeConfiguration((e) => {
-          if (!e.affectsConfiguration("hardhat.telemetry")) {
-            return;
-          }
-
-          client.sendNotification("custom/didChangeHardhatTelemetryEnabled", {
-            enabled: workspace
-              .getConfiguration("hardhat")
-              .get<boolean>("telemetry"),
-          });
-        });
-
-      listenerDisposables.push(telemetryChangeDisposable);
-      listenerDisposables.push(hardhatTelemetryChangeDisposable);
-
-      client.start();
-      clients.set(folder.uri.toString(), client);
-    }
-  }
-
-  workspace.onDidOpenTextDocument(didOpenTextDocument);
-  workspace.textDocuments.forEach(didOpenTextDocument);
-  workspace.onDidChangeWorkspaceFolders((event) => {
-    for (const folder of event.removed) {
-      const client = clients.get(folder.uri.toString());
-
-      if (client) {
-        clients.delete(folder.uri.toString());
-        client.stop();
-      }
-    }
-  });
+  setupFormatterHook(extensionState);
+  setupLanguageServerHooks(extensionState);
 }
 
 export function deactivate(): Thenable<void> {
+  if (!extensionState) {
+    return;
+  }
+
+  extensionState.listenerDisposables.forEach((disposable) =>
+    disposable.dispose()
+  );
+
   const promises: Thenable<void>[] = [];
 
-  listenerDisposables.forEach((disposable) => disposable.dispose());
-
-  for (const client of clients.values()) {
+  for (const client of extensionState.clients.values()) {
     promises.push(client.stop());
   }
 
-  return Promise.all(promises).then(() => undefined);
+  const telemetryClosePromise = extensionState.telemetry.close();
+
+  return Promise.all([...promises, telemetryClosePromise]).then(
+    () => undefined
+  );
 }

--- a/client/src/formatter/index.ts
+++ b/client/src/formatter/index.ts
@@ -7,14 +7,6 @@ export function formatDocument(
   document: vscode.TextDocument,
   context: vscode.ExtensionContext
 ): vscode.TextEdit[] {
-  const formatter = vscode.workspace
-    .getConfiguration("solidity")
-    .get<string>("formatter");
-
-  if (formatter !== "prettier") {
-    return null;
-  }
-
   const rootPath = getCurrentWorkspaceRootFsPath();
 
   const ignoreOptions = {

--- a/client/src/popups/showAnalyticsAllowPopup.ts
+++ b/client/src/popups/showAnalyticsAllowPopup.ts
@@ -1,0 +1,35 @@
+import {
+  workspace,
+  window,
+  ExtensionContext,
+  ConfigurationTarget,
+} from "vscode";
+
+export async function showAnalyticsAllowPopup({
+  context,
+}: {
+  context: ExtensionContext;
+}): Promise<void> {
+  const shownTelemetryMessage = context.globalState.get<boolean>(
+    "shownTelemetryMessage"
+  );
+
+  if (shownTelemetryMessage) {
+    return;
+  }
+
+  const item = await window.showInformationMessage(
+    "Help us improve the Hardhat for Visual Studio Code extension with anonymous crash reports & basic usage data?",
+    { modal: true },
+    "Accept",
+    "Decline"
+  );
+
+  const isAccepted = item === "Accept" ? true : false;
+
+  const config = workspace.getConfiguration("hardhat");
+
+  config.update("telemetry", isAccepted, ConfigurationTarget.Global);
+
+  context.globalState.update("shownTelemetryMessage", true);
+}

--- a/client/src/popups/showFileIndexingProgress.ts
+++ b/client/src/popups/showFileIndexingProgress.ts
@@ -1,0 +1,105 @@
+import * as events from "events";
+import { workspace, window, TextDocument, ProgressLocation } from "vscode";
+import { LanguageClient } from "vscode-languageclient/node";
+
+type IndexFileData = {
+  path: string;
+  current: number;
+  total: number;
+};
+
+export function showFileIndexingProgress(client: LanguageClient): void {
+  const em = new events.EventEmitter();
+
+  client.onReady().then(() => {
+    client.onNotification("custom/indexing-file", (data: IndexFileData) => {
+      em.emit("indexing-file", data);
+    });
+  });
+
+  // Progress bar
+  window.withProgress(
+    {
+      cancellable: true,
+      location: ProgressLocation.Notification,
+      title: "Indexing Project",
+    },
+    async (progress) => {
+      progress.report({
+        increment: 0,
+        message: "Start indexing...",
+      });
+
+      const promise = new Promise<void>((resolve) => {
+        em.on("indexing-file", (data: IndexFileData) => {
+          progress.report({
+            increment: Math.round(data.total / data.current),
+            message: `Indexing ${data.path}`,
+          });
+
+          // Files that were open on vscode load, will
+          // have swallowed the `didChange` event as the
+          // language server wasn't intialized yet. We
+          // revalidate open editor files after indexing
+          // to ensure warning and errors appear on startup.
+          triggerValidationForOpenDoc(client, data.path);
+
+          if (data.total === data.current) {
+            resolve();
+          }
+        });
+      });
+
+      await promise;
+
+      progress.report({
+        increment: 100,
+        message: `Project indexing is complete.`,
+      });
+
+      await sleep(3000);
+    }
+  );
+}
+
+/**
+ * If the doc is open, trigger a noop change on the server to start validation.
+ */
+function triggerValidationForOpenDoc(client: LanguageClient, path: string) {
+  const textDoc = workspace.textDocuments.find((d) => d.uri.path === path);
+
+  if (!textDoc) {
+    return;
+  }
+
+  notifyOfNoopChange(client, textDoc);
+}
+
+/**
+ * Sends a no-op change notification to the server, this allows the
+ * triggering of validation.
+ * @param client the language client
+ * @param textDoc the open text file to trigger validation on
+ */
+function notifyOfNoopChange(client: LanguageClient, textDoc: TextDocument) {
+  client.sendNotification("textDocument/didChange", {
+    textDocument: {
+      version: textDoc.version,
+      uri: textDoc.uri.toString(),
+    },
+    contentChanges: [
+      {
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+        },
+        rangeLength: 1,
+        text: "",
+      },
+    ],
+  });
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/client/src/popups/warnOnOtherSolidityExtensions.ts
+++ b/client/src/popups/warnOnOtherSolidityExtensions.ts
@@ -1,0 +1,28 @@
+import { window, extensions } from "vscode";
+import { Logger } from "../utils/Logger";
+
+const CONFLICTING_EXTENSION_ID = "juanblanco.solidity";
+const CONFLICTING_EXTENSION_NAME = "solidity";
+
+export async function warnOnOtherSolidityExtensions({
+  logger,
+}: {
+  logger: Logger;
+}) {
+  const conflictingExtension = extensions.getExtension(
+    CONFLICTING_EXTENSION_ID
+  );
+
+  if (conflictingExtension === undefined) {
+    return;
+  }
+
+  try {
+    await window.showWarningMessage(
+      `Both this extension and the \`${CONFLICTING_EXTENSION_NAME}\` (${CONFLICTING_EXTENSION_ID}) extension are enabled. They have conflicting functionality. Disable one of them.`,
+      "Okay"
+    );
+  } catch (err) {
+    logger.error(err);
+  }
+}

--- a/client/src/setup/setupExtensionState.ts
+++ b/client/src/setup/setupExtensionState.ts
@@ -1,0 +1,52 @@
+import * as path from "path";
+import {
+  window,
+  workspace,
+  env,
+  ExtensionContext,
+  OutputChannel,
+} from "vscode";
+import { SentryClientTelemetry } from "../telemetry/SentryClientTelemetry";
+
+import { ExtensionState } from "../types";
+import { Logger } from "../utils/Logger";
+
+export function setupExtensionState(
+  context: ExtensionContext,
+  { sentryDsn }: { sentryDsn: string }
+): ExtensionState {
+  const serverModulePath = context.asAbsolutePath(
+    path.join("server", "out", "index.js")
+  );
+
+  const outputChannel: OutputChannel = window.createOutputChannel("Hardhat");
+  const telemetry = new SentryClientTelemetry(sentryDsn);
+  const logger = new Logger(outputChannel, telemetry);
+
+  const extensionState: ExtensionState = {
+    context: context,
+    env:
+      process.env.NODE_ENV === "development"
+        ? process.env.NODE_ENV
+        : "production",
+    version: context.extension.packageJSON.version,
+    name: context.extension.packageJSON.name,
+    serverModulePath,
+    machineId: env.machineId,
+
+    clients: new Map(),
+    listenerDisposables: [],
+    hardhatTelemetryEnabled: workspace
+      .getConfiguration("hardhat")
+      .get<boolean>("telemetry"),
+    globalTelemetryEnabled: env.isTelemetryEnabled,
+
+    telemetry,
+    outputChannel,
+    logger,
+  };
+
+  telemetry.init(extensionState);
+
+  return extensionState;
+}

--- a/client/src/setup/setupFormatterHook.ts
+++ b/client/src/setup/setupFormatterHook.ts
@@ -1,0 +1,24 @@
+import { languages, ExtensionContext, TextDocument, TextEdit } from "vscode";
+import { formatDocument } from "../formatter";
+import { Logger } from "../utils/Logger";
+
+export function setupFormatterHook({
+  context,
+  logger,
+}: {
+  context: ExtensionContext;
+  logger: Logger;
+}) {
+  context.subscriptions.push(
+    languages.registerDocumentFormattingEditProvider("solidity", {
+      provideDocumentFormattingEdits(document: TextDocument): TextEdit[] {
+        try {
+          return formatDocument(document, context);
+        } catch (err: unknown) {
+          logger.error(err);
+          return [];
+        }
+      },
+    })
+  );
+}

--- a/client/src/setup/setupLanguageServerHooks.ts
+++ b/client/src/setup/setupLanguageServerHooks.ts
@@ -1,0 +1,168 @@
+import { workspace, TextDocument, env } from "vscode";
+import {
+  LanguageClient,
+  LanguageClientOptions,
+  ServerOptions,
+  TransportKind,
+} from "vscode-languageclient/node";
+import { ExtensionState } from "../types";
+import { getOuterMostWorkspaceFolder } from "../utils/getOuterMostWorkspaceFolder";
+import { getUnsavedDocuments } from "../utils/getUnsavedDocuments";
+import { showAnalyticsAllowPopup } from "../popups/showAnalyticsAllowPopup";
+import { showFileIndexingProgress } from "../popups/showFileIndexingProgress";
+
+export function setupLanguageServerHooks(extensionState: ExtensionState) {
+  const didOpenTextDocument = buildDidOpenTextDocument(extensionState);
+
+  workspace.onDidOpenTextDocument(didOpenTextDocument);
+  workspace.textDocuments.forEach(didOpenTextDocument);
+  workspace.onDidChangeWorkspaceFolders((event) => {
+    const { clients } = extensionState;
+
+    for (const folder of event.removed) {
+      const client = clients.get(folder.uri.toString());
+
+      if (client) {
+        clients.delete(folder.uri.toString());
+        client.stop();
+      }
+    }
+  });
+}
+
+function buildDidOpenTextDocument(
+  extensionState: ExtensionState
+): (document: TextDocument) => void {
+  const { logger } = extensionState;
+
+  const didOpenTextDocument = (document: TextDocument): void => {
+    // We are only interested in solidity files
+    if (document.languageId !== "solidity" || document.uri.scheme !== "file") {
+      return;
+    }
+
+    const uri = document.uri;
+    let folder = workspace.getWorkspaceFolder(uri);
+
+    // Files outside a folder can't be handled. This might depend on the language.
+    // Single file languages like JSON might handle files outside the workspace folders.
+    if (!folder) {
+      return;
+    }
+
+    // If we have nested workspace folders we only start a server on the outer most workspace folder.
+    folder = getOuterMostWorkspaceFolder(folder);
+
+    if (!extensionState.clients.has(folder.uri.toString())) {
+      // The debug options for the server.
+      // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging.
+      const debugOptions = {
+        execArgv: [
+          "--nolazy",
+          `--inspect=${6009 + extensionState.clients.size}`,
+        ],
+      };
+
+      // If the extension is launched in debug mode then the debug server options are used.
+      // Otherwise the run options are used.
+      const serverOptions: ServerOptions = {
+        run: {
+          module: extensionState.serverModulePath,
+          transport: TransportKind.ipc,
+        },
+        debug: {
+          module: extensionState.serverModulePath,
+          transport: TransportKind.ipc,
+          options: debugOptions,
+        },
+      };
+
+      // Options to control the language client.
+      const clientOptions: LanguageClientOptions = {
+        // Register the server for solidity text documents.
+        documentSelector: [
+          { scheme: "file", language: "solidity", pattern: `**/*.sol` },
+        ],
+        diagnosticCollectionName: "hardhat-language-server",
+        workspaceFolder: folder,
+        outputChannel: extensionState.outputChannel,
+        initializationOptions: {
+          extensionName: extensionState.name,
+          extensionVersion: extensionState.version,
+          env: extensionState.env,
+          globalTelemetryEnabled: extensionState.globalTelemetryEnabled,
+          hardhatTelemetryEnabled: extensionState.hardhatTelemetryEnabled,
+          machineId: extensionState.machineId,
+        },
+      };
+
+      logger.info(`[LS: ${folder.name}] Client starting`);
+
+      // Create the language client and start the client.
+      // Start the client. This will also launch the server
+      const client = new LanguageClient(
+        "hardhat-language-server",
+        "Hardhat Language Server",
+        serverOptions,
+        clientOptions
+      );
+
+      showAnalyticsAllowPopup(extensionState);
+
+      client.onReady().then(() => {
+        logger.info(`[LS: ${folder.name}] Client ready`);
+
+        client.onNotification("custom/get-unsaved-documents", () => {
+          const unsavedDocuments = getUnsavedDocuments();
+
+          client.sendNotification(
+            "custom/get-unsaved-documents",
+            unsavedDocuments.map((unsavedDocument) => {
+              return {
+                uri: unsavedDocument.uri,
+                languageId: unsavedDocument.languageId,
+                version: unsavedDocument.version,
+                content: unsavedDocument.getText(),
+              };
+            })
+          );
+        });
+      });
+
+      showFileIndexingProgress(client);
+
+      const telemetryChangeDisposable = env.onDidChangeTelemetryEnabled(
+        (enabled: boolean) => {
+          extensionState.globalTelemetryEnabled = enabled;
+
+          client.sendNotification("custom/didChangeGlobalTelemetryEnabled", {
+            enabled,
+          });
+        }
+      );
+
+      const hardhatTelemetryChangeDisposable =
+        workspace.onDidChangeConfiguration((e) => {
+          if (!e.affectsConfiguration("hardhat.telemetry")) {
+            return;
+          }
+
+          extensionState.hardhatTelemetryEnabled = workspace
+            .getConfiguration("hardhat")
+            .get<boolean>("telemetry");
+
+          client.sendNotification("custom/didChangeHardhatTelemetryEnabled", {
+            enabled: extensionState.hardhatTelemetryEnabled,
+          });
+        });
+
+      extensionState.listenerDisposables.push(telemetryChangeDisposable);
+      extensionState.listenerDisposables.push(hardhatTelemetryChangeDisposable);
+
+      client.start();
+      extensionState.clients.set(folder.uri.toString(), client);
+    }
+  };
+
+  return didOpenTextDocument;
+}

--- a/client/src/telemetry/SentryClientTelemetry.ts
+++ b/client/src/telemetry/SentryClientTelemetry.ts
@@ -1,0 +1,47 @@
+import * as Sentry from "@sentry/node";
+import { ExtensionState } from "../types";
+import { Telemetry } from "./types";
+
+const SENTRY_CLOSE_TIMEOUT = 2000;
+
+export class SentryClientTelemetry implements Telemetry {
+  private dsn: string;
+  private extensionState: ExtensionState | null;
+
+  constructor(dsn: string) {
+    this.dsn = dsn;
+    this.extensionState = null;
+  }
+
+  init(extensionState: ExtensionState) {
+    this.extensionState = extensionState;
+
+    Sentry.init({
+      dsn: this.dsn,
+      tracesSampleRate: this.extensionState.env === "development" ? 1 : 0.01,
+      release: `${this.extensionState.name}@${this.extensionState.version}`,
+      environment: this.extensionState.env,
+      initialScope: {
+        user: { id: this.extensionState.machineId },
+      },
+      beforeSend: (event) =>
+        isTelemetryEnabled(this.extensionState) ? event : null,
+    });
+  }
+
+  captureException(err: unknown): void {
+    Sentry.captureException(err);
+  }
+
+  close(): Promise<boolean> {
+    return Sentry.close(SENTRY_CLOSE_TIMEOUT);
+  }
+}
+
+function isTelemetryEnabled(extensionState: ExtensionState | undefined | null) {
+  return (
+    extensionState &&
+    extensionState.globalTelemetryEnabled &&
+    extensionState.hardhatTelemetryEnabled
+  );
+}

--- a/client/src/telemetry/types.ts
+++ b/client/src/telemetry/types.ts
@@ -1,0 +1,7 @@
+import { ExtensionState } from "../types";
+
+export interface Telemetry {
+  init(extensionState: ExtensionState): void;
+  captureException(err: unknown): void;
+  close(): Promise<boolean>;
+}

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,8 +1,26 @@
+import { ExtensionContext, OutputChannel } from "vscode";
+import { Disposable, LanguageClient } from "vscode-languageclient/node";
+import { Telemetry } from "./telemetry/types";
+import { Logger } from "./utils/Logger";
+
 export type Environment = "development" | "production";
 
-export type HardhatVSCodeConfig = {
+export type ExtensionState = {
+  context: ExtensionContext;
+
   name: string;
   version: string;
   env: Environment;
+  machineId: string;
+  serverModulePath: string;
+
+  clients: Map<string, LanguageClient>;
+  listenerDisposables: Disposable[];
+
+  globalTelemetryEnabled: boolean;
   hardhatTelemetryEnabled: boolean;
+
+  telemetry: Telemetry;
+  outputChannel: OutputChannel;
+  logger: Logger;
 };

--- a/client/src/utils/Logger.ts
+++ b/client/src/utils/Logger.ts
@@ -1,10 +1,13 @@
 import { OutputChannel } from "vscode";
+import { Telemetry } from "../telemetry/types";
 
 export class Logger {
   private outputChannel: OutputChannel;
+  private telemetry: Telemetry;
 
-  constructor(outputChannel: OutputChannel) {
+  constructor(outputChannel: OutputChannel, telemetry: Telemetry) {
     this.outputChannel = outputChannel;
+    this.telemetry = telemetry;
   }
 
   log(text: string) {
@@ -18,6 +21,8 @@ export class Logger {
   }
 
   error(err: unknown) {
+    this.telemetry.captureException(err);
+
     const message = err instanceof Error ? err.message : String(err);
 
     this.outputChannel.appendLine(

--- a/client/src/utils/getOuterMostWorkspaceFolder.ts
+++ b/client/src/utils/getOuterMostWorkspaceFolder.ts
@@ -1,0 +1,49 @@
+import { workspace, WorkspaceFolder, Uri } from "vscode";
+
+let _sortedWorkspaceFolders: string[] | undefined;
+
+workspace.onDidChangeWorkspaceFolders(
+  () => (_sortedWorkspaceFolders = undefined)
+);
+
+export function getOuterMostWorkspaceFolder(
+  folder: WorkspaceFolder
+): WorkspaceFolder {
+  const sorted = sortedWorkspaceFolders();
+
+  for (const element of sorted) {
+    let uri = folder.uri.toString();
+
+    if (uri.charAt(uri.length - 1) !== "/") {
+      uri = uri + "/";
+    }
+
+    if (uri.startsWith(element)) {
+      return workspace.getWorkspaceFolder(Uri.parse(element));
+    }
+  }
+
+  return folder;
+}
+
+function sortedWorkspaceFolders(): string[] {
+  if (_sortedWorkspaceFolders === void 0) {
+    _sortedWorkspaceFolders = workspace.workspaceFolders
+      ? workspace.workspaceFolders
+          .map((folder) => {
+            let result = folder.uri.toString();
+
+            if (result.charAt(result.length - 1) !== "/") {
+              result = result + "/";
+            }
+
+            return result;
+          })
+          .sort((a, b) => {
+            return a.length - b.length;
+          })
+      : [];
+  }
+
+  return _sortedWorkspaceFolders;
+}

--- a/client/src/utils/getUnsavedDocuments.ts
+++ b/client/src/utils/getUnsavedDocuments.ts
@@ -1,0 +1,5 @@
+import { workspace, TextDocument } from "vscode";
+
+export function getUnsavedDocuments(): TextDocument[] {
+  return workspace.textDocuments.filter((i) => i.isDirty);
+}

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -52,6 +52,62 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@sentry/core@6.19.1":
+  version "6.19.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.19.1.tgz#9672d0d19d4fe438be6e186b2b10a79826f19a03"
+  integrity sha512-ZSIFnwYCzABK1jX1iMwUbaAoWbbJear0wM+gSZvJpSUJ1dAXV1OZyL7kXtEJRtATahIlcrMou5ewIoeJizeWAw==
+  dependencies:
+    "@sentry/hub" "6.19.1"
+    "@sentry/minimal" "6.19.1"
+    "@sentry/types" "6.19.1"
+    "@sentry/utils" "6.19.1"
+    tslib "^1.9.3"
+
+"@sentry/hub@6.19.1":
+  version "6.19.1"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.19.1.tgz#bff9ed5885b6e0eb4280774b653fa05edec6ed07"
+  integrity sha512-BgUwdxxXntGohAYrXtYrYBA6QzOeRz3NINuS838n7SRTkGf9gBJ/Rd3dyOWUrzJciKty7rmvYIwTA0oo91AMkw==
+  dependencies:
+    "@sentry/types" "6.19.1"
+    "@sentry/utils" "6.19.1"
+    tslib "^1.9.3"
+
+"@sentry/minimal@6.19.1":
+  version "6.19.1"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.19.1.tgz#d6fc92bd683ae7db207ad9666084307311881dcb"
+  integrity sha512-Xre3J6mjWEcQhDmQ3j4g71J8f0nDgg2p7K41SngibfZVYSOe8jAowxSI9JuWD7juuwT5GVRVCqLs+Y6mWDBaoQ==
+  dependencies:
+    "@sentry/hub" "6.19.1"
+    "@sentry/types" "6.19.1"
+    tslib "^1.9.3"
+
+"@sentry/node@6.19.1":
+  version "6.19.1"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-6.19.1.tgz#807f9011dbac37370b49759c6d803c6026b4adfb"
+  integrity sha512-ipPWFY+1gNZlt99QHInP+Z70W7nYeBEEiVDtpxSMid5zFzPJ/k9QOZtUzyelyiSCBvIIeTzVX9Fyri17fay1Pw==
+  dependencies:
+    "@sentry/core" "6.19.1"
+    "@sentry/hub" "6.19.1"
+    "@sentry/types" "6.19.1"
+    "@sentry/utils" "6.19.1"
+    cookie "^0.4.1"
+    https-proxy-agent "^5.0.0"
+    lru_map "^0.3.3"
+    tslib "^1.9.3"
+
+"@sentry/types@6.19.1":
+  version "6.19.1"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.19.1.tgz#684a231f8fe10c9cf14f9552f5da0a4492e6fdbc"
+  integrity sha512-ovmNYdqD2MKLmru4calxetX1xjJdYim+HEI/GzwvVUYshsaXRq4EiQ17h3DAy90MV7JH279PmMoPGDTOpufq+Q==
+
+"@sentry/utils@6.19.1":
+  version "6.19.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.19.1.tgz#9d5f50a0ceb60b63631de88b4abed07253568209"
+  integrity sha512-mWcQbQ1yO7PooLpJpQK84+wOfxGeb8iUKRb8inO+2Eg6VksDbXRuJ89Yd4APBTRxBj5Wihy48bPuVfKtovtm8g==
+  dependencies:
+    "@sentry/types" "6.19.1"
+    tslib "^1.9.3"
+
 "@solidity-parser/parser@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.14.0.tgz#d51f074efb0acce0e953ec48133561ed710cebc0"
@@ -73,6 +129,13 @@ acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
 
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
@@ -199,6 +262,11 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
+cookie@^0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+
 cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -207,6 +275,13 @@ cross-spawn@^7.0.2:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+debug@4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
 
 debug@^4.0.1, debug@^4.1.1:
   version "4.3.3"
@@ -449,6 +524,14 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
+https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
@@ -554,6 +637,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lru_map@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
+  integrity sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=
 
 minimatch@^3.0.4:
   version "3.0.4"
@@ -750,6 +838,11 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+tslib@^1.9.3:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"

--- a/package.json
+++ b/package.json
@@ -84,15 +84,6 @@
       "type": "object",
       "title": "Hardhat",
       "properties": {
-        "solidity.formatter": {
-          "type": "string",
-          "default": "prettier",
-          "enum": [
-            "none",
-            "prettier"
-          ],
-          "description": "Enables / disables the solidity formatter (prettier solidity default)"
-        },
         "hardhat-language-server.trace.server.verbosity": {
           "type": "string",
           "description": "Traces the communication between VS Code and the solidity language server.",

--- a/server/src/telemetry/SentryTelemetry.ts
+++ b/server/src/telemetry/SentryTelemetry.ts
@@ -19,7 +19,7 @@ export class SentryTelemetry implements Telemetry {
 
   constructor(dsn: string, heartbeatPeriod: number, analytics: Analytics) {
     this.dsn = dsn;
-    this.heartbeatPeriod = 5;
+    this.heartbeatPeriod = heartbeatPeriod;
     this.serverState = null;
     this.analytics = analytics;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,12 @@
     "resolveJsonModule": true
   },
   "include": ["./client", "./server", "./test", "./test/**/*.json"],
-  "exclude": ["node_modules", ".vscode-test", "./server/test"],
+  "exclude": [
+    "node_modules",
+    ".vscode-test",
+    "./server/test",
+    "./client/out",
+    "./server/out"
+  ],
   "references": [{ "path": "./client" }, { "path": "./server" }]
 }


### PR DESCRIPTION
We have reports of issues with formatting on linux. For some users the issue with a misconfiguration on the formatter setting inside of hardhat vscode, for others we just don't know.

This PR does two things:
* remove the formatter setting as unnecessary
* improve logging around formatting within the client

To do the above, sentry had to be setup and configured for the client part of the extension.

Linear: HHVSC-128 HHVSC-124
