### PR TITLE
fix(quickfixes): swallow parser errors

### DIFF
--- a/.changeset/fair-emus-tap.md
+++ b/.changeset/fair-emus-tap.md
@@ -1,0 +1,5 @@
+---
+"hardhat-solidity": patch
+---
+
+Fix to suppress parser errors in quickfixes ((#146)[https://github.com/NomicFoundation/hardhat-vscode/issues/146])

--- a/server/src/compilerDiagnostics/diagnostics/parsing/parseContractDefinition.ts
+++ b/server/src/compilerDiagnostics/diagnostics/parsing/parseContractDefinition.ts
@@ -32,11 +32,16 @@ export function parseContractDefinition(
       )
     );
 
-    const ast = parser.parse(contractText, {
-      range: true,
-      tolerant: true,
-      tokens: true,
-    });
+    let ast: ReturnType<typeof parser.parse>;
+    try {
+      ast = parser.parse(contractText, {
+        range: true,
+        tolerant: true,
+        tokens: true,
+      });
+    } catch {
+      return null;
+    }
 
     if (
       ast.tokens === undefined ||

--- a/server/src/compilerDiagnostics/diagnostics/parsing/parseFunctionDefinition.ts
+++ b/server/src/compilerDiagnostics/diagnostics/parsing/parseFunctionDefinition.ts
@@ -30,11 +30,16 @@ export function parseFunctionDefinition(
       )
     );
 
-    const ast = parser.parse(functionText, {
-      range: true,
-      tolerant: true,
-      tokens: true,
-    });
+    let ast: ReturnType<typeof parser.parse>;
+    try {
+      ast = parser.parse(functionText, {
+        range: true,
+        tolerant: true,
+        tokens: true,
+      });
+    } catch {
+      return null;
+    }
 
     if (
       ast.tokens === undefined ||


### PR DESCRIPTION
Parser errors on changing code are to be expected, so lets not report them via telemetry.

Linear: HHVSC-132




