### PR TITLE
fix: catch for undefined in isNodePosition

### DIFF
--- a/server/src/parser/common/utils/index.ts
+++ b/server/src/parser/common/utils/index.ts
@@ -80,7 +80,10 @@ export function getRange(loc: Location): Range {
  */
 export function isNodePosition(node: Node, position: Position): boolean {
   if (
+    position &&
     node.nameLoc &&
+    node.nameLoc.start &&
+    node.nameLoc.end &&
     node.nameLoc.start.line === position.line &&
     node.nameLoc.end.line === position.line &&
     node.nameLoc.start.column <= position.column &&


### PR DESCRIPTION
Stop import completion throwing on failed `isNodePosition` lookup.

Fixes #143.

Linear: HHVSC-129