### PR TITLE
fix: allow hh errors with no source location

### DIFF
--- a/.changeset/heavy-lamps-attack.md
+++ b/.changeset/heavy-lamps-attack.md
@@ -1,0 +1,5 @@
+---
+"hardhat-solidity": patch
+---
+
+Fix - don't throw on hh error objects with no source location

--- a/server/src/parser/index.ts
+++ b/server/src/parser/index.ts
@@ -28,7 +28,8 @@ export class LanguageService {
     this.solidityCompletion = new SolidityCompletion(this.analyzer);
     this.solidityValidation = new SolidityValidation(
       this.analyzer,
-      compProcessFactory
+      compProcessFactory,
+      logger
     );
     this.soliditySignatureHelp = new SoliditySignatureHelp(this.analyzer);
     this.solidityRename = new SolidityRename(this.analyzer);

--- a/server/src/parser/services/validation/SolidityValidation.ts
+++ b/server/src/parser/services/validation/SolidityValidation.ts
@@ -34,11 +34,12 @@ export class SolidityValidation {
       rootPath: string,
       uri: string,
       logger: Logger
-    ) => CompilerProcess
+    ) => CompilerProcess,
+    logger: Logger
   ) {
     this.analyzer = analyzer;
     this.compilerProcessFactory = compilerProcessFactory;
-    this.diagnosticConverter = new DiagnosticConverter(this.analyzer);
+    this.diagnosticConverter = new DiagnosticConverter(logger);
   }
 
   public getValidationJob(telemetry: Telemetry, logger: Logger): ValidationJob {


### PR DESCRIPTION
We group and filter hh errors that are displayed as diagnostics. We were
getting exceptions when a hh error came through with no attached source
location as this was used for the filtering and grouping.

Instead we will let hh errors without source locations pass through, but
send the error message to sentry (so we can dig in with more info).

Fixes #147.

Linear: HHVSC-133
