### PR TITLE
chore(telemetry): turn off client uncaught exceptions

### DIFF
--- a/.changeset/wild-paws-travel.md
+++ b/.changeset/wild-paws-travel.md
@@ -1,0 +1,5 @@
+---
+"hardhat-solidity": patch
+---
+
+Change to stop capturing unhandling exceptions on the client ((#156)[https://github.com/NomicFoundation/hardhat-vscode/issues/156])

--- a/client/src/telemetry/SentryClientTelemetry.ts
+++ b/client/src/telemetry/SentryClientTelemetry.ts
@@ -23,7 +23,14 @@ export class SentryClientTelemetry implements Telemetry {
       environment: this.extensionState.env,
       initialScope: {
         user: { id: this.extensionState.machineId },
+        tags: {
+          component: "ext",
+        },
       },
+      integrations: (defaults) =>
+        defaults.filter((integration) => {
+          return integration.name !== "OnUncaughtException";
+        }),
       beforeSend: (event) =>
         isTelemetryEnabled(this.extensionState) ? event : null,
     });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,7 +4,7 @@ import setupServer from "./server";
 import { compilerProcessFactory } from "@services/validation/compilerProcessFactory";
 import { ConnectionLogger } from "@utils/Logger";
 import { WorkspaceFileRetriever } from "@analyzer/WorkspaceFileRetriever";
-import { SentryTelemetry } from "./telemetry/SentryTelemetry";
+import { SentryServerTelemetry } from "./telemetry/SentryServerTelemetry";
 import { GoogleAnalytics } from "./analytics/GoogleAnalytics";
 
 const GOOGLE_TRACKING_ID = "UA-117668706-4";
@@ -21,7 +21,11 @@ const connection = createConnection(ProposedFeatures.all);
 
 const workspaceFileRetriever = new WorkspaceFileRetriever();
 const analytics = new GoogleAnalytics(GOOGLE_TRACKING_ID);
-const telemetry = new SentryTelemetry(SENTRY_DSN, HEARTBEAT_PERIOD, analytics);
+const telemetry = new SentryServerTelemetry(
+  SENTRY_DSN,
+  HEARTBEAT_PERIOD,
+  analytics
+);
 const logger = new ConnectionLogger(connection, telemetry);
 
 setupServer(

--- a/server/src/telemetry/SentryServerTelemetry.ts
+++ b/server/src/telemetry/SentryServerTelemetry.ts
@@ -9,7 +9,7 @@ import { Analytics } from "analytics/types";
 
 const SENTRY_CLOSE_TIMEOUT = 2000;
 
-export class SentryTelemetry implements Telemetry {
+export class SentryServerTelemetry implements Telemetry {
   dsn: string;
   serverState: ServerState | null;
   analytics: Analytics;
@@ -50,6 +50,9 @@ export class SentryTelemetry implements Telemetry {
       environment: serverState.env,
       initialScope: {
         user: { id: machineId },
+        tags: {
+          component: "lsp",
+        },
       },
       beforeSend: (event) => (isTelemetryEnabled(serverState) ? event : null),
     });


### PR DESCRIPTION
By default Sentry hooks into the uncaught exception handler and reports
all unhandled exceptions. The extension is run within the extension host
and adding the uncaught exception handler give all unhandled exceptions
across all extensions.

To stop that reporting we turn off the global exception handler.

Fixes #156.

Linear: HHVSC-139
