### PR TITLE
feat(syntax): allow comments in enums

### DIFF
--- a/syntaxes/solidity.json
+++ b/syntaxes/solidity.json
@@ -707,6 +707,9 @@
             {
               "match": "\\b(\\w+)\\b",
               "name": "entity.name.type.interface.extend"
+            },
+            {
+              "include": "#comment"
             }
           ]
         }
@@ -874,6 +877,9 @@
             },
             {
               "include": "#punctuation"
+            },
+            {
+              "include": "#comment"
             }
           ]
         },

--- a/syntaxes/solidity.json
+++ b/syntaxes/solidity.json
@@ -968,6 +968,9 @@
             },
             {
               "include": "#modifier-call"
+            },
+            {
+              "include": "#comment"
             }
           ]
         },


### PR DESCRIPTION
Include the comment pattern in both enum declaration and function argument lists and modifier lists.

Fixes #165.

## Preview

![image](https://user-images.githubusercontent.com/24030/165271448-6c4edae6-1056-450b-8be0-442c59fc1576.png)

![image](https://user-images.githubusercontent.com/24030/165717806-f7155e4f-286a-465c-a1bc-5ea3a421f0da.png)

Linear: HHVSC-143