### PR TITLE
chore(server): suppress val error in none hh files

### DIFF
--- a/server/src/services/validation/SolidityValidation.ts
+++ b/server/src/services/validation/SolidityValidation.ts
@@ -58,9 +58,7 @@ export class SolidityValidation {
         project: ISolProject
       ): Promise<{ [uri: string]: Diagnostic[] }> => {
         if (project.type !== "hardhat") {
-          logger.error(
-            new Error(`Validation failed, not a hardhat project ${uri}`)
-          );
+          logger.trace(`Validation failed, not a hardhat project ${uri}`);
 
           return {};
         }


### PR DESCRIPTION
Change the error log to a trace in validation. We expect non-hh files to not be
validated. It is not an error, though we probably want logging to report
it if we are doing debugging.

Fixes #172

Linear: HHVSC-146
