### PR TITLE
fix(completion): provide array completions

### DIFF
--- a/server/src/services/completion/arrayCompletions.ts
+++ b/server/src/services/completion/arrayCompletions.ts
@@ -1,0 +1,16 @@
+import { CompletionItemKind } from "@common/types";
+
+export const arrayCompletions = [
+  {
+    label: "length",
+    kind: CompletionItemKind.Property,
+  },
+  {
+    label: "pop",
+    kind: CompletionItemKind.Function,
+  },
+  {
+    label: "push",
+    kind: CompletionItemKind.Function,
+  },
+];

--- a/server/src/services/completion/onCompletion.ts
+++ b/server/src/services/completion/onCompletion.ts
@@ -26,6 +26,7 @@ import { ServerState } from "../../types";
 import { ProjectContext } from "./types";
 import { findProjectFor } from "@utils/findProjectFor";
 import { decodeUriAndRemoveFilePrefix } from "@utils/index";
+import { arrayCompletions } from "./arrayCompletions";
 
 export const onCompletion = (serverState: ServerState) => {
   return (params: CompletionParams): CompletionList | undefined => {
@@ -258,6 +259,10 @@ function getMemberAccessCompletions(
   position: VSCodePosition,
   node: Node
 ): CompletionItem[] {
+  if (isArrayAccess(node)) {
+    return arrayCompletions;
+  }
+
   const definitionNodes: Node[] = [];
   const cursorPosition = getParserPositionFromVSCodePosition(position);
 
@@ -281,6 +286,16 @@ function getMemberAccessCompletions(
   }
 
   return getCompletionsFromNodes(definitionNodes);
+}
+
+function isArrayAccess(node: Node): boolean {
+  const definition = node.getDefinitionNode();
+
+  if (definition?.type !== "VariableDeclaration") {
+    return false;
+  }
+
+  return definition.typeNodes.some((tn) => tn.type === "ArrayTypeName");
 }
 
 function getDefaultCompletions(

--- a/server/test/services/completion/completion.ts
+++ b/server/test/services/completion/completion.ts
@@ -21,24 +21,27 @@ describe("Parser", () => {
     path.join(__dirname, "testData", "MemberAccessNestedStruct.sol")
   );
 
-  let completion: OnCompletion;
+  const memberAccessArraysUri = forceToUnixStyle(
+    path.join(__dirname, "testData", "MemberAccessArrays.sol")
+  );
 
-  before(async () => {
-    ({
-      server: { completion },
-    } = await setupMockLanguageServer({
-      documents: [
-        { uri: globalVariablesUri, analyze: true },
-        { uri: memberAccessStructUri, analyze: false },
-        { uri: memberAccessNestedStructUri, analyze: false },
-      ],
-      errors: [],
-    }));
-  });
+  let completion: OnCompletion;
 
   describe("Completion", () => {
     describe("Member Access", () => {
       describe("structs", () => {
+        before(async () => {
+          ({
+            server: { completion },
+          } = await setupMockLanguageServer({
+            documents: [
+              { uri: memberAccessStructUri, analyze: false },
+              { uri: memberAccessNestedStructUri, analyze: false },
+            ],
+            errors: [],
+          }));
+        });
+
         it("should provide completions", () =>
           assertCompletion(
             completion,
@@ -55,9 +58,69 @@ describe("Parser", () => {
             ["charisma", "intelligence", "strength", "wisdom"]
           ));
       });
+
+      describe("arrays", () => {
+        before(async () => {
+          ({
+            server: { completion },
+          } = await setupMockLanguageServer({
+            documents: [{ uri: memberAccessArraysUri, analyze: false }],
+            errors: [],
+          }));
+        });
+
+        it("should provide completions for local variables", () =>
+          assertCompletion(
+            completion,
+            memberAccessArraysUri,
+            { line: 21, character: 22 },
+            ["length", "pop", "push"]
+          ));
+
+        it("should provide completions for state properties", () =>
+          assertCompletion(
+            completion,
+            memberAccessArraysUri,
+            { line: 22, character: 13 },
+            ["length", "pop", "push"]
+          ));
+
+        it("should provide completions for array properties nested in structs", () =>
+          assertCompletion(
+            completion,
+            memberAccessArraysUri,
+            { line: 23, character: 25 },
+            ["length", "pop", "push"]
+          ));
+
+        it("should provide completions for state properties inherited from a parent contract", () =>
+          assertCompletion(
+            completion,
+            memberAccessArraysUri,
+            { line: 24, character: 12 },
+            ["length", "pop", "push"]
+          ));
+
+        it("should provide completions for array parameters", () =>
+          assertCompletion(
+            completion,
+            memberAccessArraysUri,
+            { line: 25, character: 20 },
+            ["length", "pop", "push"]
+          ));
+      });
     });
 
     describe("Global Variables", () => {
+      before(async () => {
+        ({
+          server: { completion },
+        } = await setupMockLanguageServer({
+          documents: [{ uri: globalVariablesUri, analyze: true }],
+          errors: [],
+        }));
+      });
+
       it("should provide sender completions", () =>
         assertCompletion(
           completion,

--- a/server/test/services/completion/testData/MemberAccessArrays.sol
+++ b/server/test/services/completion/testData/MemberAccessArrays.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract ArrayCompletionBase {
+  int256[] public baseArr;
+}
+
+contract ArrayCompletion is ArrayCompletionBase {
+  struct Example {
+    int256[] nested;
+  }
+
+  int256[] private stateArr;
+  Example private nestedExample;
+
+  function afunction(int256 num, int256[] memory paramArr)
+    public
+    returns (uint256)
+  {
+    uint256[1] memory local = [uint256(1)];
+
+    uint256 l = local.length;
+    stateArr.push(num);
+    nestedExample.nested.pop();
+    baseArr.pop();
+    return paramArr.length + l;
+  }
+}

--- a/server/test/services/navigation/testData/TypeDefinition.sol
+++ b/server/test/services/navigation/testData/TypeDefinition.sol
@@ -7,7 +7,7 @@ contract Test {
     uint120 charisma;
     uint120 intelligence;
     uint120 wisdom;
-	}
+  }
 
   uint120 public balance;
 
@@ -16,17 +16,17 @@ contract Test {
   mapping(address => Hero) public heroes;
   NPC[] public followers;
 
-	constructor() {
-		balance = 10;
+  constructor() {
+    balance = 10;
     hero = Hero({ strength: 1, charisma: 1, intelligence: 1, wisdom: 1 });
-	}
+  }
 
   function resetBalance() public {
     balance = 0;
   }
 
   function resetStrength() public {
-    hero.strength = 0;
+    hero.strength = followers.length;
 
     resetBalance();
   }

--- a/server/test/services/navigation/typeDefinition.ts
+++ b/server/test/services/navigation/typeDefinition.ts
@@ -63,6 +63,19 @@ describe("Parser", () => {
               },
             ]
           ));
+
+        it("should navigate from array attribute usage", () =>
+          assertTypeDefinitionNavigation(
+            typeDefinition,
+            basicUri,
+            { line: 28, character: 21 },
+            [
+              {
+                start: { line: 33, character: 9 },
+                end: { line: 33, character: 12 },
+              },
+            ]
+          ));
       });
     });
   });


### PR DESCRIPTION
If a variable/member access is an array, show the `array` members as completions. Specifically show `length`, `pop` and `push` based on [the solidity docs](https://docs.soliditylang.org/en/latest/types.html?highlight=array#array-members).

Fixes #179

## Preview

![image](https://user-images.githubusercontent.com/24030/166948770-b2d57e73-c4ec-4511-af2d-2dfb3daf9d71.png)

