### PR TITLE
fix: update extension kind to `workspace`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "Formatters"
   ],
   "extensionKind": [
-    "ui",
     "workspace"
   ],
   "keywords": [


### PR DESCRIPTION
The language server requires access to the file-system so needs to run
in an env that supports those calls.

Fixes #182

Linear: HHVSC-152
