### PR TITLE
fix: rename duplication

### DIFF
--- a/server/src/services/rename/onRename.ts
+++ b/server/src/services/rename/onRename.ts
@@ -73,6 +73,10 @@ function convertRefNodesToUpdates(referenceNodes: Node[], newName: string) {
   const workspaceEdit: WorkspaceEdit = { changes: {} };
 
   referenceNodes.forEach((potentialUpdate) => {
+    if (!potentialUpdate.isAlive) {
+      return;
+    }
+
     if (!potentialUpdate.nameLoc || !workspaceEdit.changes) {
       return;
     }

--- a/server/test/services/rename/rename.ts
+++ b/server/test/services/rename/rename.ts
@@ -44,6 +44,45 @@ describe("Parser", () => {
           },
           newText: "Animal2",
         },
+        {
+          newText: "Animal2",
+          range: {
+            start: {
+              line: 31,
+              character: 17,
+            },
+            end: {
+              line: 31,
+              character: 23,
+            },
+          },
+        },
+        {
+          newText: "Animal2",
+          range: {
+            start: {
+              line: 34,
+              character: 21,
+            },
+            end: {
+              line: 34,
+              character: 27,
+            },
+          },
+        },
+        {
+          newText: "Animal2",
+          range: {
+            end: {
+              line: 36,
+              character: 27,
+            },
+            start: {
+              line: 36,
+              character: 21,
+            },
+          },
+        },
       ];
 
       beforeEach(async () => {

--- a/server/test/services/rename/testData/ContractRename.sol
+++ b/server/test/services/rename/testData/ContractRename.sol
@@ -25,4 +25,16 @@ contract Dog is Animal {
     {
         return "woof";
     }
+
+    function factory()
+        public
+        pure
+        returns (Animal)
+    {
+        if (1 < 2) {
+          return new Animal("woof");
+        } else {
+          return new Animal("woof");
+        }
+    }
 }


### PR DESCRIPTION
When calculating reference nodes for a rename, exclude dead nodes.

Before this fix, it was possible to get duplicates for workspace edits, which would both be applied, leading to a rename of `Auth` to `Auth2` becoming:

```solidity
constructor() {
        _auth = new Auth22(msg.sender);
}
```