### PR TITLE
chore: apply eslint rules from hardhat

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ server/node_modules/**
 server/out/**
 client/.eslintrc.js
 server/.eslintrc.js
+.eslintrc.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,21 +1,226 @@
 /** @type {import('eslint').Linter.Config} */
 module.exports = {
   root: true,
-  parser: "@typescript-eslint/parser",
-  parserOptions: {
-    ecmaVersion: 12,
-    sourceType: "module",
+  env: {
+    node: true,
   },
-  plugins: ["@typescript-eslint"],
   extends: [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "prettier",
   ],
-  env: {
-    node: true,
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: 12,
+    sourceType: "module",
+    project: `${__dirname}/tsconfig.json`,
   },
+  plugins: ["eslint-plugin-import", "@typescript-eslint"],
+
   rules: {
     "no-console": "warn",
+
+    "@typescript-eslint/adjacent-overload-signatures": "error",
+    "@typescript-eslint/array-type": [
+      "error",
+      {
+        default: "array-simple",
+      },
+    ],
+    "@typescript-eslint/await-thenable": "error",
+    "@typescript-eslint/ban-types": [
+      "error",
+      {
+        types: {
+          Object: {
+            message: "Avoid using the `Object` type. Did you mean `object`?",
+          },
+          Boolean: {
+            message: "Avoid using the `Boolean` type. Did you mean `boolean`?",
+          },
+          Function: {
+            message:
+              "Avoid using the `Function` type. Prefer a specific function type, like `() => void`.",
+          },
+          Number: {
+            message: "Avoid using the `Number` type. Did you mean `number`?",
+          },
+          String: {
+            message: "Avoid using the `String` type. Did you mean `string`?",
+          },
+          Symbol: {
+            message: "Avoid using the `Symbol` type. Did you mean `symbol`?",
+          },
+        },
+        extendDefaults: false,
+      },
+    ],
+    "@typescript-eslint/consistent-type-assertions": "error",
+    "@typescript-eslint/consistent-type-definitions": "error",
+    "@typescript-eslint/dot-notation": "error",
+    "@typescript-eslint/explicit-member-accessibility": [
+      "error",
+      {
+        accessibility: "explicit",
+        overrides: {
+          constructors: "no-public",
+        },
+      },
+    ],
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        selector: "default",
+        format: ["camelCase"],
+        leadingUnderscore: "allow",
+        trailingUnderscore: "allow",
+      },
+      {
+        selector: ["variable", "parameter"],
+        format: ["camelCase", "UPPER_CASE", "PascalCase"],
+        leadingUnderscore: "allow",
+        trailingUnderscore: "allow",
+      },
+      {
+        selector: "classProperty",
+        format: ["camelCase", "UPPER_CASE"],
+        leadingUnderscore: "allow",
+      },
+      {
+        selector: "enumMember",
+        format: ["UPPER_CASE"],
+      },
+      {
+        selector: "memberLike",
+        modifiers: ["private"],
+        format: ["camelCase"],
+        leadingUnderscore: "require",
+      },
+      {
+        selector: ["objectLiteralProperty", "objectLiteralMethod"],
+        format: ["camelCase", "PascalCase", "snake_case", "UPPER_CASE"],
+        leadingUnderscore: "allow",
+      },
+      {
+        selector: "typeProperty",
+        format: ["camelCase", "PascalCase"],
+        leadingUnderscore: "allow",
+      },
+      {
+        selector: "typeLike",
+        format: ["PascalCase"],
+      },
+      {
+        selector: "typeProperty",
+        filter: "__hardhatContext",
+        format: null,
+      },
+    ],
+    "@typescript-eslint/no-empty-interface": "error",
+    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-misused-new": "error",
+    "@typescript-eslint/no-namespace": "error",
+    "@typescript-eslint/no-redeclare": "error",
+    "@typescript-eslint/no-shadow": [
+      "error",
+      {
+        hoist: "all",
+      },
+    ],
+    "@typescript-eslint/no-this-alias": "error",
+    "@typescript-eslint/no-unused-expressions": "error",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        argsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+      },
+    ],
+    "@typescript-eslint/prefer-for-of": "error",
+    "@typescript-eslint/prefer-function-type": "error",
+    "@typescript-eslint/prefer-namespace-keyword": "error",
+    "@typescript-eslint/restrict-plus-operands": "error",
+    "@typescript-eslint/strict-boolean-expressions": [
+      "error",
+      {
+        allowAny: true,
+      },
+    ],
+    "@typescript-eslint/triple-slash-reference": [
+      "error",
+      {
+        path: "always",
+        types: "prefer-import",
+        lib: "always",
+      },
+    ],
+    "@typescript-eslint/unified-signatures": "error",
+    "constructor-super": "error",
+    eqeqeq: ["error", "always"],
+    "guard-for-in": "error",
+    "id-blacklist": "error",
+    "id-match": "error",
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        devDependencies: ["**/test/**/*.ts"],
+      },
+    ],
+    "import/order": [
+      "error",
+      {
+        groups: [
+          "object",
+          ["builtin", "external"],
+          "parent",
+          "sibling",
+          "index",
+        ],
+      },
+    ],
+    "no-bitwise": "error",
+    "no-caller": "error",
+    "no-cond-assign": "error",
+    "no-debugger": "error",
+    "no-duplicate-case": "error",
+    "no-duplicate-imports": "error",
+    "no-eval": "error",
+    "no-extra-bind": "error",
+    "no-new-func": "error",
+    "no-new-wrappers": "error",
+    "no-return-await": "off",
+    "@typescript-eslint/return-await": "error",
+    "no-sequences": "error",
+    "no-sparse-arrays": "error",
+    "no-template-curly-in-string": "error",
+    "no-throw-literal": "error",
+    "no-undef-init": "error",
+    "no-unsafe-finally": "error",
+    "no-unused-labels": "error",
+    "no-unused-vars": "off",
+    "no-var": "error",
+    "object-shorthand": "error",
+    "one-var": ["error", "never"],
+    "prefer-const": "error",
+    "prefer-object-spread": "error",
+    "prefer-template": "error",
+    radix: "error",
+    "spaced-comment": [
+      "error",
+      "always",
+      {
+        markers: ["/"],
+      },
+    ],
+    "use-isnan": "error",
   },
+  overrides: [
+    {
+      files: ["**/test/**/*.ts"],
+      rules: {
+        "@typescript-eslint/await-thenable": "off",
+        "@typescript-eslint/no-floating-promises": "off",
+      },
+    },
+  ],
 };

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -2,4 +2,8 @@
 module.exports = {
   root: true,
   extends: [`../.eslintrc.js`],
+  parserOptions: {
+    project: `${__dirname}/tsconfig.json`,
+    sourceType: "module",
+  },
 };

--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@sentry/types": "6.19.1",
+    "@types/prettier": "2.6.0",
     "@types/vscode": "^1.65.0",
     "eslint": "^7.23.0",
     "rimraf": "3.0.2"

--- a/client/src/deps.d.ts
+++ b/client/src/deps.d.ts
@@ -1,0 +1,1 @@
+declare module "prettier-plugin-solidity";

--- a/client/src/formatter/index.ts
+++ b/client/src/formatter/index.ts
@@ -9,6 +9,10 @@ export function formatDocument(
 ): vscode.TextEdit[] {
   const rootPath = getCurrentWorkspaceRootFsPath();
 
+  if (rootPath === undefined) {
+    return [];
+  }
+
   const ignoreOptions = {
     ignorePath: path.join(rootPath, ".prettierignore"),
   };
@@ -19,7 +23,7 @@ export function formatDocument(
   );
 
   if (fileInfo.ignored) {
-    return null;
+    return [];
   }
 
   const source = document.getText();
@@ -55,12 +59,19 @@ export function formatDocument(
   }
 }
 
-function getCurrentWorkspaceRootFsPath(): string {
-  return getCurrentWorkspaceRootFolder().uri.fsPath;
+function getCurrentWorkspaceRootFsPath(): string | undefined {
+  const rootFolder = getCurrentWorkspaceRootFolder();
+
+  return rootFolder?.uri.fsPath;
 }
 
 function getCurrentWorkspaceRootFolder(): vscode.WorkspaceFolder | undefined {
   const editor = vscode.window.activeTextEditor;
+
+  if (!editor) {
+    return undefined;
+  }
+
   const currentDocument = editor.document.uri;
 
   return vscode.workspace.getWorkspaceFolder(currentDocument);

--- a/client/src/languageitems/hardhatProject.ts
+++ b/client/src/languageitems/hardhatProject.ts
@@ -2,7 +2,10 @@ import { languages, LanguageStatusSeverity } from "vscode";
 import { RequestType } from "vscode-languageclient/node";
 import { ExtensionState } from "../types";
 
-type GetSolFileDetailsParams = { uri: string };
+interface GetSolFileDetailsParams {
+  uri: string;
+}
+
 type GetSolFileDetailsResponse =
   | { found: false }
   | { found: true; hardhat: false }
@@ -23,6 +26,10 @@ export async function updateHardhatProjectLanguageItem(
   extensionState: ExtensionState,
   params: GetSolFileDetailsParams
 ) {
+  if (!extensionState.client) {
+    return;
+  }
+
   const response = await extensionState.client.sendRequest(GetSolFileDetails, {
     uri: ensureFilePrefix(params.uri),
   });
@@ -44,7 +51,7 @@ export async function updateHardhatProjectLanguageItem(
     extensionState.hardhatConfigStatusItem.text =
       "No related Hardhat config file found";
 
-    extensionState.hardhatConfigStatusItem.command = null;
+    extensionState.hardhatConfigStatusItem.command = undefined;
 
     return;
   }

--- a/client/src/popups/setupIndexingHooks.ts
+++ b/client/src/popups/setupIndexingHooks.ts
@@ -10,78 +10,83 @@ import { LanguageClient } from "vscode-languageclient/node";
 import { updateHardhatProjectLanguageItem } from "../languageitems/hardhatProject";
 import { ExtensionState } from "../types";
 
-type IndexFileData = {
+interface IndexFileData {
   jobId: number;
   path: string;
   current: number;
   total: number;
-};
+}
 
 export function setupIndexingHooks(
   extensionState: ExtensionState,
   client: LanguageClient
 ): void {
-  client.onReady().then(() => {
-    const indexingStartDisposable = client.onNotification(
-      "custom/indexing-start",
-      (data: IndexFileData) => {
-        const indexingStatusItem = setupIndexingLanguageStatusItem(data.jobId);
+  client
+    .onReady()
+    .then(() => {
+      const indexingStartDisposable = client.onNotification(
+        "custom/indexing-start",
+        (data: IndexFileData) => {
+          const indexingStatusItem = setupIndexingLanguageStatusItem(
+            data.jobId
+          );
 
-        extensionState.currentIndexingJobs.push(indexingStatusItem);
-      }
-    );
-
-    const indexDisposable = client.onNotification(
-      "custom/indexing-file",
-      (data: IndexFileData) => {
-        const jobId = data.jobId.toString();
-        const indexingStatusItem = extensionState.currentIndexingJobs.find(
-          (si) => si.id === jobId
-        );
-
-        if (!indexingStatusItem) {
-          return;
+          extensionState.currentIndexingJobs.push(indexingStatusItem);
         }
+      );
 
-        if (indexingStatusItem.detail === undefined) {
-          indexingStatusItem.detail = `${data.total} files`;
+      const indexDisposable = client.onNotification(
+        "custom/indexing-file",
+        async (data: IndexFileData) => {
+          const jobId = data.jobId.toString();
+          const indexingStatusItem = extensionState.currentIndexingJobs.find(
+            (si) => si.id === jobId
+          );
+
+          if (!indexingStatusItem) {
+            return;
+          }
+
+          if (indexingStatusItem.detail === undefined) {
+            indexingStatusItem.detail = `${data.total} files`;
+          }
+
+          // Files that were open on vscode load, will
+          // have swallowed the `didChange` event as the
+          // language server wasn't intialized yet. We
+          // revalidate open editor files after indexing
+          // to ensure warning and errors appear on startup.
+          triggerValidationForOpenDoc(client, data.path);
+
+          // check to display language status item
+          if (
+            window.activeTextEditor &&
+            window.activeTextEditor.document.uri.path.endsWith(data.path)
+          ) {
+            await updateHardhatProjectLanguageItem(extensionState, {
+              uri: window.activeTextEditor.document.uri.path,
+            });
+          }
+
+          if (data.total !== data.current) {
+            return;
+          }
+
+          if (window.activeTextEditor && data.total === 0) {
+            await updateHardhatProjectLanguageItem(extensionState, {
+              uri: window.activeTextEditor.document.uri.path,
+            });
+          }
+
+          indexingStatusItem.busy = false;
+          indexingStatusItem.dispose();
         }
+      );
 
-        // Files that were open on vscode load, will
-        // have swallowed the `didChange` event as the
-        // language server wasn't intialized yet. We
-        // revalidate open editor files after indexing
-        // to ensure warning and errors appear on startup.
-        triggerValidationForOpenDoc(client, data.path);
-
-        // check to display language status item
-        if (
-          window.activeTextEditor &&
-          window.activeTextEditor.document.uri.path.endsWith(data.path)
-        ) {
-          updateHardhatProjectLanguageItem(extensionState, {
-            uri: window.activeTextEditor.document.uri.path,
-          });
-        }
-
-        if (data.total !== data.current) {
-          return;
-        }
-
-        if (data.total === 0) {
-          updateHardhatProjectLanguageItem(extensionState, {
-            uri: window.activeTextEditor.document.uri.path,
-          });
-        }
-
-        indexingStatusItem.busy = false;
-        indexingStatusItem.dispose();
-      }
-    );
-
-    extensionState.listenerDisposables.push(indexingStartDisposable);
-    extensionState.listenerDisposables.push(indexDisposable);
-  });
+      extensionState.listenerDisposables.push(indexingStartDisposable);
+      extensionState.listenerDisposables.push(indexDisposable);
+    })
+    .catch((reason) => extensionState.logger.error(reason));
 }
 
 function setupIndexingLanguageStatusItem(jobId: number): LanguageStatusItem {

--- a/client/src/popups/showAnalyticsAllowPopup.ts
+++ b/client/src/popups/showAnalyticsAllowPopup.ts
@@ -14,7 +14,7 @@ export async function showAnalyticsAllowPopup({
     "shownTelemetryMessage"
   );
 
-  if (shownTelemetryMessage) {
+  if (shownTelemetryMessage === true) {
     return;
   }
 
@@ -29,7 +29,7 @@ export async function showAnalyticsAllowPopup({
 
   const config = workspace.getConfiguration("hardhat");
 
-  config.update("telemetry", isAccepted, ConfigurationTarget.Global);
+  await config.update("telemetry", isAccepted, ConfigurationTarget.Global);
 
-  context.globalState.update("shownTelemetryMessage", true);
+  await context.globalState.update("shownTelemetryMessage", true);
 }

--- a/client/src/setup/onDidChangeActiveTextEditor.ts
+++ b/client/src/setup/onDidChangeActiveTextEditor.ts
@@ -6,8 +6,8 @@ import {
 } from "../languageitems/hardhatProject";
 
 export function onDidChangeActiveTextEditor(extensionState: ExtensionState) {
-  return async (e: TextEditor) => {
-    if (!e || !e.document || e.document.languageId !== "solidity") {
+  return async (e: TextEditor | undefined) => {
+    if (!e || e.document?.languageId !== "solidity") {
       return clearHardhatConfigState(extensionState);
     }
 

--- a/client/src/setup/setupExtensionState.ts
+++ b/client/src/setup/setupExtensionState.ts
@@ -24,7 +24,7 @@ export function setupExtensionState(
   const logger = new Logger(outputChannel, telemetry);
 
   const extensionState: ExtensionState = {
-    context: context,
+    context,
     env:
       process.env.NODE_ENV === "development"
         ? process.env.NODE_ENV
@@ -37,9 +37,8 @@ export function setupExtensionState(
     client: null,
     listenerDisposables: [],
     currentIndexingJobs: [],
-    hardhatTelemetryEnabled: workspace
-      .getConfiguration("hardhat")
-      .get<boolean>("telemetry"),
+    hardhatTelemetryEnabled:
+      workspace.getConfiguration("hardhat").get<boolean>("telemetry") ?? false,
     globalTelemetryEnabled: env.isTelemetryEnabled,
     hardhatConfigStatusItem: null,
 

--- a/client/src/setup/setupLanguageServerHooks.ts
+++ b/client/src/setup/setupLanguageServerHooks.ts
@@ -66,25 +66,30 @@ const startLanguageServer = (extensionState: ExtensionState): void => {
     clientOptions
   );
 
-  client.onReady().then(() => {
-    logger.info(`Client ready`);
+  client
+    .onReady()
+    .then(() => {
+      logger.info(`Client ready`);
 
-    client.onNotification("custom/get-unsaved-documents", () => {
-      const unsavedDocuments = getUnsavedDocuments();
+      client.onNotification("custom/get-unsaved-documents", () => {
+        const unsavedDocuments = getUnsavedDocuments();
 
-      client.sendNotification(
-        "custom/get-unsaved-documents",
-        unsavedDocuments.map((unsavedDocument) => {
-          return {
-            uri: unsavedDocument.uri,
-            languageId: unsavedDocument.languageId,
-            version: unsavedDocument.version,
-            content: unsavedDocument.getText(),
-          };
-        })
-      );
+        client.sendNotification(
+          "custom/get-unsaved-documents",
+          unsavedDocuments.map((unsavedDocument) => {
+            return {
+              uri: unsavedDocument.uri,
+              languageId: unsavedDocument.languageId,
+              version: unsavedDocument.version,
+              content: unsavedDocument.getText(),
+            };
+          })
+        );
+      });
+    })
+    .catch((reason) => {
+      logger.error(reason);
     });
-  });
 
   setupIndexingHooks(extensionState, client);
 
@@ -104,9 +109,9 @@ const startLanguageServer = (extensionState: ExtensionState): void => {
         return;
       }
 
-      extensionState.hardhatTelemetryEnabled = workspace
-        .getConfiguration("hardhat")
-        .get<boolean>("telemetry");
+      extensionState.hardhatTelemetryEnabled =
+        workspace.getConfiguration("hardhat").get<boolean>("telemetry") ??
+        false;
 
       client.sendNotification("custom/didChangeHardhatTelemetryEnabled", {
         enabled: extensionState.hardhatTelemetryEnabled,

--- a/client/src/telemetry/SentryClientTelemetry.ts
+++ b/client/src/telemetry/SentryClientTelemetry.ts
@@ -13,7 +13,7 @@ export class SentryClientTelemetry implements Telemetry {
     this.extensionState = null;
   }
 
-  init(extensionState: ExtensionState) {
+  public init(extensionState: ExtensionState) {
     this.extensionState = extensionState;
 
     Sentry.init({
@@ -39,18 +39,18 @@ export class SentryClientTelemetry implements Telemetry {
     });
   }
 
-  captureException(err: unknown): void {
+  public captureException(err: unknown): void {
     Sentry.captureException(err);
   }
 
-  close(): Promise<boolean> {
+  public close(): Promise<boolean> {
     return Sentry.close(SENTRY_CLOSE_TIMEOUT);
   }
 }
 
-function isTelemetryEnabled(extensionState: ExtensionState | undefined | null) {
+function isTelemetryEnabled(extensionState: ExtensionState | null): boolean {
   return (
-    extensionState &&
+    extensionState !== null &&
     extensionState.globalTelemetryEnabled &&
     extensionState.hardhatTelemetryEnabled
   );

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -5,7 +5,7 @@ import { Logger } from "./utils/Logger";
 
 export type Environment = "development" | "production";
 
-export type ExtensionState = {
+export interface ExtensionState {
   context: ExtensionContext;
 
   name: string;
@@ -26,4 +26,4 @@ export type ExtensionState = {
   logger: Logger;
 
   hardhatConfigStatusItem: LanguageStatusItem | null;
-};
+}

--- a/client/src/utils/Logger.ts
+++ b/client/src/utils/Logger.ts
@@ -10,17 +10,17 @@ export class Logger {
     this.telemetry = telemetry;
   }
 
-  log(text: string) {
+  public log(text: string) {
     this.outputChannel.appendLine(text);
   }
 
-  info(text: string) {
+  public info(text: string) {
     this.outputChannel.appendLine(
       `[Info  - ${new Date().toLocaleTimeString()}] ${text}`
     );
   }
 
-  error(err: unknown) {
+  public error(err: unknown) {
     this.telemetry.captureException(err);
 
     const message = err instanceof Error ? err.message : String(err);

--- a/client/src/utils/getOuterMostWorkspaceFolder.ts
+++ b/client/src/utils/getOuterMostWorkspaceFolder.ts
@@ -15,11 +15,15 @@ export function getOuterMostWorkspaceFolder(
     let uri = folder.uri.toString();
 
     if (uri.charAt(uri.length - 1) !== "/") {
-      uri = uri + "/";
+      uri = `${uri}/`;
     }
 
     if (uri.startsWith(element)) {
-      return workspace.getWorkspaceFolder(Uri.parse(element));
+      const foundFolder = workspace.getWorkspaceFolder(Uri.parse(element));
+
+      if (foundFolder) {
+        return foundFolder;
+      }
     }
   }
 
@@ -34,7 +38,7 @@ function sortedWorkspaceFolders(): string[] {
             let result = folder.uri.toString();
 
             if (result.charAt(result.length - 1) !== "/") {
-              result = result + "/";
+              result = `${result}/`;
             }
 
             return result;

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -7,7 +7,8 @@
     "rootDir": "src",
     "sourceMap": true,
     "composite": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "strict": true
   },
   "include": ["src"],
   "exclude": ["node_modules", ".vscode-test"]

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -115,6 +115,11 @@
   dependencies:
     antlr4ts "^0.5.0-alpha.4"
 
+"@types/prettier@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.6.0.tgz#efcbd41937f9ae7434c714ab698604822d890759"
+  integrity sha512-G/AdOadiZhnJp0jXCaBQU449W2h716OW/EoXeYkCytxKL06X1WCXB4DZpp8TpZ8eyIJVS1cw4lrlkkSYU21cDw==
+
 "@types/vscode@^1.65.0":
   version "1.65.0"
   resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.65.0.tgz#042dd8d93c32ac62cb826cd0fa12376069d1f448"

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "workspaceContains:**/hardhat.config.ts"
   ],
   "scripts": {
-    "build": "tsc -b",
-    "watch": "tsc -b -w",
+    "build": "tsc -b ./client/tsconfig.json && tsc -b ./server/tsconfig.build.json && tsc -b",
+    "watch": "concurrently -n client,server \"tsc -b -w ./client/tsconfig.json\" \"tsc -b -w ./server/tsconfig.build.json\"",
     "postinstall": "yarn install --cwd ./client && yarn install --cwd ./server",
     "test:integration": "yarn run build && node ./out/test/runTests.js",
     "test:unit": "yarn --cwd ./server run test",
@@ -70,9 +70,11 @@
     "@typescript-eslint/eslint-plugin": "5.8.0",
     "@typescript-eslint/parser": "5.8.0",
     "@vscode/test-electron": "2.1.3",
+    "concurrently": "7.1.0",
     "esbuild": "0.14.23",
     "eslint": "8.5.0",
     "eslint-config-prettier": "8.3.0",
+    "eslint-plugin-import": "2.26.0",
     "glob": "^7.1.7",
     "mocha": "^9.1.1",
     "prettier": "2.5.1",

--- a/server/.eslintrc.js
+++ b/server/.eslintrc.js
@@ -2,4 +2,8 @@
 module.exports = {
   root: true,
   extends: [`../.eslintrc.js`],
+  parserOptions: {
+    project: `${__dirname}/tsconfig.json`,
+    sourceType: "module",
+  },
 };

--- a/server/package.json
+++ b/server/package.json
@@ -10,14 +10,14 @@
     "node": "*"
   },
   "scripts": {
-    "build": "tsc -b",
+    "build": "tsc -b tsconfig.build.json",
     "test": "cross-env TS_NODE_FILES=true mocha",
     "test:coverage": "cross-env TS_NODE_FILES=true nyc mocha",
     "lint": "yarn prettier --check && yarn eslint",
     "lint:fix": "yarn prettier --write && yarn lint --fix",
     "eslint": "eslint --max-warnings 0 \"./src/**/*.ts\" \"./test/**/*.ts\"",
     "prettier": "prettier \"*.json\" \"src/**/*.{ts,js,md,json,yml}\" \"test/**/*.{ts,js,md,json,yml}\"",
-    "clean": "rimraf out .nyc_output coverage tsconfig.tsbuildinfo"
+    "clean": "rimraf out .nyc_output coverage *.tsbuildinfo"
   },
   "_moduleAliases": {
     "@compilerDiagnostics": "./out/compilerDiagnostics",
@@ -42,7 +42,6 @@
     "eslint": "^7.23.0",
     "mocha": "9.1.3",
     "nyc": "15.1.0",
-    "prettier": "2.5.1",
     "rimraf": "3.0.2",
     "sinon": "12.0.1",
     "ts-node": "10.4.0",
@@ -60,10 +59,12 @@
     "hardhat": "^2.6.0",
     "js-yaml": "^4.1.0",
     "module-alias": "^2.2.2",
+    "prettier": "2.5.1",
     "prettier-plugin-solidity": "1.0.0-beta.19",
     "qs": "^6.10.1",
     "uuid": "^8.3.2",
     "vscode-languageserver": "^7.0.0",
+    "vscode-languageserver-protocol": "3.16.0",
     "vscode-languageserver-textdocument": "^1.0.1",
     "vscode-languageserver-types": "^3.16.0"
   }

--- a/server/src/analytics/types.ts
+++ b/server/src/analytics/types.ts
@@ -1,9 +1,9 @@
 import { ServerState } from "../types";
 
-export type AnalyticsData = {
+export interface AnalyticsData {
   clientId: string;
   isAllowed?: boolean;
-};
+}
 
 // VERY IMPORTANT:
 // The documentation doesn't say so, but the user-agent parameter is required (ua).

--- a/server/src/compilerDiagnostics/conversions/constrainByRegex.ts
+++ b/server/src/compilerDiagnostics/conversions/constrainByRegex.ts
@@ -7,6 +7,10 @@ export function constrainByRegex(
   error: HardhatCompilerError,
   regex: RegExp
 ) {
+  if (error.sourceLocation === undefined) {
+    throw new Error("No source location");
+  }
+
   const diagnostic = passThroughConversion(document, error);
 
   const matchResult = findMatchInRange(document, error.sourceLocation, regex);

--- a/server/src/compilerDiagnostics/conversions/passThroughConversion.ts
+++ b/server/src/compilerDiagnostics/conversions/passThroughConversion.ts
@@ -5,6 +5,10 @@ export function passThroughConversion(
   document: TextDocument,
   error: HardhatCompilerError
 ) {
+  if (!error.sourceLocation) {
+    throw new Error("No source location");
+  }
+
   const range = Range.create(
     document.positionAt(error.sourceLocation.start),
     document.positionAt(error.sourceLocation.end)

--- a/server/src/compilerDiagnostics/diagnostics/AddMultiOverrideSpecifier.ts
+++ b/server/src/compilerDiagnostics/diagnostics/AddMultiOverrideSpecifier.ts
@@ -6,24 +6,24 @@ import {
   ResolveActionsContext,
 } from "../types";
 import { attemptConstrainToFunctionName } from "../conversions/attemptConstrainToFunctionName";
+import { ServerState } from "../../types";
 import {
   Multioverride,
   resolveInsertSpecifierQuickFix,
 } from "./common/resolveInsertSpecifierQuickFix";
-import { ServerState } from "types";
 
 export class AddMultiOverrideSpecifier implements CompilerDiagnostic {
   public code = "4327";
   public blocks: string[] = ["9456"];
 
-  fromHardhatCompilerError(
+  public fromHardhatCompilerError(
     document: TextDocument,
     error: HardhatCompilerError
   ): Diagnostic {
     return attemptConstrainToFunctionName(document, error);
   }
 
-  resolveActions(
+  public resolveActions(
     serverState: ServerState,
     diagnostic: Diagnostic,
     context: ResolveActionsContext

--- a/server/src/compilerDiagnostics/diagnostics/AddOverrideSpecifier.ts
+++ b/server/src/compilerDiagnostics/diagnostics/AddOverrideSpecifier.ts
@@ -6,21 +6,21 @@ import {
   ResolveActionsContext,
 } from "../types";
 import { attemptConstrainToFunctionName } from "../conversions/attemptConstrainToFunctionName";
+import { ServerState } from "../../types";
 import { resolveInsertSpecifierQuickFix } from "./common/resolveInsertSpecifierQuickFix";
-import { ServerState } from "types";
 
 export class AddOverrideSpecifier implements CompilerDiagnostic {
   public code = "9456";
   public blocks: string[] = [];
 
-  fromHardhatCompilerError(
+  public fromHardhatCompilerError(
     document: TextDocument,
     error: HardhatCompilerError
   ): Diagnostic {
     return attemptConstrainToFunctionName(document, error);
   }
 
-  resolveActions(
+  public resolveActions(
     serverState: ServerState,
     diagnostic: Diagnostic,
     context: ResolveActionsContext

--- a/server/src/compilerDiagnostics/diagnostics/AddVirtualSpecifier.ts
+++ b/server/src/compilerDiagnostics/diagnostics/AddVirtualSpecifier.ts
@@ -6,21 +6,21 @@ import {
   ResolveActionsContext,
 } from "../types";
 import { attemptConstrainToFunctionName } from "../conversions/attemptConstrainToFunctionName";
+import { ServerState } from "../../types";
 import { resolveInsertSpecifierQuickFix } from "./common/resolveInsertSpecifierQuickFix";
-import { ServerState } from "types";
 
 export class AddVirtualSpecifier implements CompilerDiagnostic {
   public code = "4334";
   public blocks: string[] = [];
 
-  fromHardhatCompilerError(
+  public fromHardhatCompilerError(
     document: TextDocument,
     error: HardhatCompilerError
   ): Diagnostic {
     return attemptConstrainToFunctionName(document, error);
   }
 
-  resolveActions(
+  public resolveActions(
     serverState: ServerState,
     diagnostic: Diagnostic,
     context: ResolveActionsContext

--- a/server/src/compilerDiagnostics/diagnostics/ConstrainMutability.ts
+++ b/server/src/compilerDiagnostics/diagnostics/ConstrainMutability.ts
@@ -11,25 +11,25 @@ import {
   ResolveActionsContext,
 } from "../types";
 import { attemptConstrainToFunctionName } from "../conversions/attemptConstrainToFunctionName";
+import { ServerState } from "../../types";
 import {
   parseFunctionDefinition,
   ParseFunctionDefinitionResult,
 } from "./parsing/parseFunctionDefinition";
 import { lookupToken } from "./parsing/lookupToken";
-import { ServerState } from "types";
 
 export class ConstrainMutability implements CompilerDiagnostic {
   public code = "2018";
   public blocks: string[] = [];
 
-  fromHardhatCompilerError(
+  public fromHardhatCompilerError(
     document: TextDocument,
     error: HardhatCompilerError
   ): Diagnostic {
     return attemptConstrainToFunctionName(document, error);
   }
 
-  resolveActions(
+  public resolveActions(
     serverState: ServerState,
     diagnostic: Diagnostic,
     { document, uri }: ResolveActionsContext
@@ -49,13 +49,13 @@ export class ConstrainMutability implements CompilerDiagnostic {
     }
 
     if (parseResult.functionDefinition.stateMutability === "view") {
-      return this.modifyViewToPureAction(document, uri, parseResult);
+      return this._modifyViewToPureAction(document, uri, parseResult);
     } else {
-      return this.addMutabilityAction(diagnostic, document, uri, parseResult);
+      return this._addMutabilityAction(diagnostic, document, uri, parseResult);
     }
   }
 
-  private modifyViewToPureAction(
+  private _modifyViewToPureAction(
     document: TextDocument,
     uri: string,
     { functionSourceLocation, tokens }: ParseFunctionDefinitionResult
@@ -94,7 +94,7 @@ export class ConstrainMutability implements CompilerDiagnostic {
     return [action];
   }
 
-  private addMutabilityAction(
+  private _addMutabilityAction(
     diagnostic: Diagnostic,
     document: TextDocument,
     uri: string,

--- a/server/src/compilerDiagnostics/diagnostics/ContractCodeSize.ts
+++ b/server/src/compilerDiagnostics/diagnostics/ContractCodeSize.ts
@@ -1,20 +1,20 @@
 import { CodeAction, Diagnostic } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { CompilerDiagnostic, HardhatCompilerError } from "../types";
 import { attemptConstrainToContractName } from "@compilerDiagnostics/conversions/attemptConstrainToContractName";
+import { CompilerDiagnostic, HardhatCompilerError } from "../types";
 
 export class ContractCodeSize implements CompilerDiagnostic {
   public code = "5574";
   public blocks: string[] = [];
 
-  fromHardhatCompilerError(
+  public fromHardhatCompilerError(
     document: TextDocument,
     error: HardhatCompilerError
   ): Diagnostic {
     return attemptConstrainToContractName(document, error);
   }
 
-  resolveActions(): CodeAction[] {
+  public resolveActions(): CodeAction[] {
     return [];
   }
 }

--- a/server/src/compilerDiagnostics/diagnostics/MarkContractAbstract.ts
+++ b/server/src/compilerDiagnostics/diagnostics/MarkContractAbstract.ts
@@ -5,27 +5,27 @@ import {
   Range,
 } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { HardhatCompilerError, ResolveActionsContext } from "../types";
 import { attemptConstrainToContractName } from "@compilerDiagnostics/conversions/attemptConstrainToContractName";
+import { HardhatCompilerError, ResolveActionsContext } from "../types";
+import { ServerState } from "../../types";
 import {
   parseContractDefinition,
   ParseContractDefinitionResult,
 } from "./parsing/parseContractDefinition";
 import { buildImplementInterfaceQuickFix } from "./common/ImplementInterface/buildImplementInterfaceQuickFix";
-import { ServerState } from "types";
 
 export class MarkContractAbstract {
   public code = "3656";
   public blocks = [];
 
-  fromHardhatCompilerError(
+  public fromHardhatCompilerError(
     document: TextDocument,
     error: HardhatCompilerError
   ): Diagnostic {
     return attemptConstrainToContractName(document, error);
   }
 
-  resolveActions(
+  public resolveActions(
     serverState: ServerState,
     diagnostic: Diagnostic,
     context: ResolveActionsContext
@@ -46,7 +46,7 @@ export class MarkContractAbstract {
       context
     );
 
-    const addAbstrackQuickFix = this.buildAddAbstractQuickFix(
+    const addAbstrackQuickFix = this._buildAddAbstractQuickFix(
       parseResult,
       context
     );
@@ -56,7 +56,7 @@ export class MarkContractAbstract {
     );
   }
 
-  private buildAddAbstractQuickFix(
+  private _buildAddAbstractQuickFix(
     { tokens, functionSourceLocation }: ParseContractDefinitionResult,
     { document, uri }: ResolveActionsContext
   ): CodeAction | null {

--- a/server/src/compilerDiagnostics/diagnostics/SpecifyVisibility.ts
+++ b/server/src/compilerDiagnostics/diagnostics/SpecifyVisibility.ts
@@ -7,9 +7,9 @@ import {
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { HardhatCompilerError, ResolveActionsContext } from "../types";
 import { attemptConstrainToFunctionName } from "../conversions/attemptConstrainToFunctionName";
+import { ServerState } from "../../types";
 import { parseFunctionDefinition } from "./parsing/parseFunctionDefinition";
 import { lookupToken } from "./parsing/lookupToken";
-import { ServerState } from "types";
 
 type Visibility = "public" | "private" | "external" | "internal";
 
@@ -19,14 +19,14 @@ export class SpecifyVisibility {
   public code = "4937";
   public blocks: string[] = [];
 
-  fromHardhatCompilerError(
+  public fromHardhatCompilerError(
     document: TextDocument,
     error: HardhatCompilerError
   ): Diagnostic {
     return attemptConstrainToFunctionName(document, error);
   }
 
-  resolveActions(
+  public resolveActions(
     serverState: ServerState,
     diagnostic: Diagnostic,
     context: ResolveActionsContext
@@ -66,7 +66,7 @@ export class SpecifyVisibility {
       functionSourceLocation.start + closingParamListToken.range[0] + 1;
 
     return QUICK_FIX_VISIBILITIES.map((visibility) =>
-      this.constructVisibilityCodeActionFor(
+      this._constructVisibilityCodeActionFor(
         visibility,
         document,
         uri,
@@ -75,7 +75,7 @@ export class SpecifyVisibility {
     );
   }
 
-  private constructVisibilityCodeActionFor(
+  private _constructVisibilityCodeActionFor(
     visibility: Visibility,
     document: TextDocument,
     uri: string,

--- a/server/src/compilerDiagnostics/diagnostics/common/ImplementInterface/buildImplementInterfaceQuickFix.ts
+++ b/server/src/compilerDiagnostics/diagnostics/common/ImplementInterface/buildImplementInterfaceQuickFix.ts
@@ -1,10 +1,10 @@
 import { CodeAction, CodeActionKind } from "vscode-languageserver/node";
 import { ResolveActionsContext } from "../../../types";
 import { ParseContractDefinitionResult } from "../../parsing/parseContractDefinition";
+import { ServerState } from "../../../../types";
 import { createAppendFunctionsToContractChange } from "./createAppendFunctionsToContractChange";
 import { resolveFunctionsToImplement } from "./resolveFunctionsToImplement";
 import { findAnalyzedContract } from "./findAnalyzedContract";
-import { ServerState } from "types";
 
 export function buildImplementInterfaceQuickFix(
   serverState: ServerState,

--- a/server/src/compilerDiagnostics/diagnostics/common/ImplementInterface/createAppendFunctionsToContractChange.ts
+++ b/server/src/compilerDiagnostics/diagnostics/common/ImplementInterface/createAppendFunctionsToContractChange.ts
@@ -22,7 +22,7 @@ export function createAppendFunctionsToContractChange(
     .join("\n\n");
 
   const newText = prettyPrinter
-    .format(originalText.slice(0, -1) + functionsAppendText + "}", { document })
+    .format(`${originalText.slice(0, -1) + functionsAppendText}}`, { document })
     .slice(0, -1);
 
   return {

--- a/server/src/compilerDiagnostics/diagnostics/common/ImplementInterface/findAnalyzedContract.ts
+++ b/server/src/compilerDiagnostics/diagnostics/common/ImplementInterface/findAnalyzedContract.ts
@@ -1,5 +1,3 @@
-import { ResolveActionsContext } from "../../../types";
-import { ParseContractDefinitionResult } from "../../parsing/parseContractDefinition";
 import {
   ContractDefinitionNode,
   ISolFileEntry,
@@ -7,7 +5,9 @@ import {
 } from "@common/types";
 import { isContractDefinitionNode } from "@analyzer/utils/typeGuards";
 import { lookupEntryForDocument } from "@utils/lookupEntryForDocument";
-import { ServerState } from "types";
+import { ParseContractDefinitionResult } from "../../parsing/parseContractDefinition";
+import { ResolveActionsContext } from "../../../types";
+import { ServerState } from "../../../../types";
 
 export function findAnalyzedContract(
   serverState: ServerState,
@@ -20,7 +20,7 @@ export function findAnalyzedContract(
 
   const currentAnalyzer = lookupEntryForDocument(serverState, document);
 
-  if (currentAnalyzer.status !== SolFileState.Analyzed) {
+  if (currentAnalyzer.status !== SolFileState.ANALYZED) {
     return null;
   }
 

--- a/server/src/compilerDiagnostics/diagnostics/common/ImplementInterface/types.ts
+++ b/server/src/compilerDiagnostics/diagnostics/common/ImplementInterface/types.ts
@@ -1,14 +1,18 @@
 import { ContractDefinitionNode, FunctionDefinition } from "@common/types";
 
-export type InheritanceLookupTable = { [key: string]: string[] };
-export type ContractIdToNodeMapping = { [key: string]: ContractDefinitionNode };
+export interface InheritanceLookupTable {
+  [key: string]: string[];
+}
+export interface ContractIdToNodeMapping {
+  [key: string]: ContractDefinitionNode;
+}
 
-export type LinearizationContext = {
+export interface LinearizationContext {
   linearizations: { [key: string]: string[] };
   contracts: ContractIdToNodeMapping;
-};
+}
 
-export type FunctionRecord = {
+export interface FunctionRecord {
   definition: FunctionDefinition;
   implementedIn: string[];
-};
+}

--- a/server/src/compilerDiagnostics/diagnostics/common/ImplementInterface/utils/methodResolutionOrdersFor.ts
+++ b/server/src/compilerDiagnostics/diagnostics/common/ImplementInterface/utils/methodResolutionOrdersFor.ts
@@ -1,11 +1,11 @@
 import { linearize } from "c3-linearization";
 import { ContractDefinitionNode } from "@common/types";
-import { toContractId } from "./toContractId";
 import {
   ContractIdToNodeMapping,
   InheritanceLookupTable,
   LinearizationContext,
 } from "../types";
+import { toContractId } from "./toContractId";
 
 export function methodResoltionOrdersFor(
   contractNode: ContractDefinitionNode

--- a/server/src/compilerDiagnostics/diagnostics/common/ImplementInterface/utils/resolveAllContractFunctions.ts
+++ b/server/src/compilerDiagnostics/diagnostics/common/ImplementInterface/utils/resolveAllContractFunctions.ts
@@ -7,9 +7,9 @@ import {
   mutabliltyPrecedence,
   visibilityPrecedence,
 } from "@common/types";
+import { FunctionRecord, LinearizationContext } from "../types";
 import { isMatchingTypeName } from "./isMatchingTypeName";
 import { toContractId } from "./toContractId";
-import { FunctionRecord, LinearizationContext } from "../types";
 
 /**
  * Build a combined view of all of a contracts functions, both those

--- a/server/src/compilerDiagnostics/diagnostics/common/ImplementInterface/utils/resolveImplementationOverrides.ts
+++ b/server/src/compilerDiagnostics/diagnostics/common/ImplementInterface/utils/resolveImplementationOverrides.ts
@@ -55,9 +55,7 @@ function findMostDerivedContractImplementedIn(
 ): string | undefined {
   const contractId = toContractId(contractNode);
 
-  return linearizations[contractId].find((contractId) =>
-    implementedIn.includes(contractId)
-  );
+  return linearizations[contractId].find((cid) => implementedIn.includes(cid));
 }
 
 /**

--- a/server/src/compilerDiagnostics/diagnostics/common/resolveInsertSpecifierQuickFix.ts
+++ b/server/src/compilerDiagnostics/diagnostics/common/resolveInsertSpecifierQuickFix.ts
@@ -5,27 +5,27 @@ import {
   Range,
 } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
+import { Token } from "@solidity-parser/parser/dist/src/types";
+import { ResolveActionsContext } from "@compilerDiagnostics/types";
+import { Logger } from "@utils/Logger";
+import { LookupResult, lookupToken } from "../parsing/lookupToken";
 import {
   parseFunctionDefinition,
   ParseFunctionDefinitionResult,
 } from "../parsing/parseFunctionDefinition";
-import { LookupResult, lookupToken } from "../parsing/lookupToken";
-import { Token } from "@solidity-parser/parser/dist/src/types";
-import { ResolveActionsContext } from "@compilerDiagnostics/types";
-import { Logger } from "@utils/Logger";
 
 export class Multioverride {
-  contractIdentifiers: string[];
+  public contractIdentifiers: string[];
 
   constructor(contractIdentifiers: string[]) {
     this.contractIdentifiers = contractIdentifiers;
   }
 
-  toDisplayName(): string {
+  public toDisplayName(): string {
     return "override(...)";
   }
 
-  toString(): string {
+  public toString(): string {
     return `override(${this.contractIdentifiers.join(", ")})`;
   }
 }
@@ -107,10 +107,10 @@ function buildActionFrom(
   specifier: Specifier,
   document: TextDocument,
   uri: string,
-  parseFunctionDefinition: ParseFunctionDefinitionResult,
+  parseFnDef: ParseFunctionDefinitionResult,
   tokenSelector: (token: Token) => boolean
 ) {
-  const { tokens, functionSourceLocation } = parseFunctionDefinition;
+  const { tokens, functionSourceLocation } = parseFnDef;
 
   const lookupResult = lookupToken(
     tokens,
@@ -133,7 +133,7 @@ function buildActionFrom(
     specifier,
     document,
     token,
-    parseFunctionDefinition,
+    parseFnDef,
     lookupResult
   );
 

--- a/server/src/compilerDiagnostics/diagnostics/parsing/lookupToken.ts
+++ b/server/src/compilerDiagnostics/diagnostics/parsing/lookupToken.ts
@@ -1,11 +1,11 @@
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { Token } from "@solidity-parser/parser/dist/src/types";
 
-export type LookupResult = {
+export interface LookupResult {
   token: Token;
   isSameLine: boolean;
   offset: number;
-};
+}
 
 const HEADER_KEYWORDS = [
   "public",

--- a/server/src/compilerDiagnostics/diagnostics/parsing/parseContractDefinition.ts
+++ b/server/src/compilerDiagnostics/diagnostics/parsing/parseContractDefinition.ts
@@ -6,12 +6,12 @@ import { isContractDefinition } from "@analyzer/utils/typeGuards";
 import { ResolveActionsContext } from "@compilerDiagnostics/types";
 import { Logger } from "@utils/Logger";
 
-export type ParseContractDefinitionResult = {
+export interface ParseContractDefinitionResult {
   contractDefinition: ContractDefinition;
   tokens: Token[];
   functionSourceLocation: { start: number; end: number };
   contractText: string;
-};
+}
 
 export function parseContractDefinition(
   diagnostic: Diagnostic,

--- a/server/src/compilerDiagnostics/diagnostics/parsing/parseFunctionDefinition.ts
+++ b/server/src/compilerDiagnostics/diagnostics/parsing/parseFunctionDefinition.ts
@@ -4,11 +4,11 @@ import { FunctionDefinition, TextDocument } from "@common/types";
 import { Token } from "@solidity-parser/parser/dist/src/types";
 import { Logger } from "@utils/Logger";
 
-export type ParseFunctionDefinitionResult = {
+export interface ParseFunctionDefinitionResult {
   functionDefinition: FunctionDefinition;
   tokens: Token[];
   functionSourceLocation: { start: number; end: number };
-};
+}
 
 export function parseFunctionDefinition(
   diagnostic: Diagnostic,

--- a/server/src/compilerDiagnostics/types.ts
+++ b/server/src/compilerDiagnostics/types.ts
@@ -1,21 +1,21 @@
 import { CodeAction, Diagnostic } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { ServerState } from "types";
+import { ServerState } from "../types";
 
-export type HardhatCompilerError = {
+export interface HardhatCompilerError {
   errorCode: string;
   severity: "error" | "warning";
   message: string;
-  sourceLocation: {
+  sourceLocation?: {
     start: number;
     end: number;
   };
-};
+}
 
-export type ResolveActionsContext = {
+export interface ResolveActionsContext {
   document: TextDocument;
   uri: string;
-};
+}
 
 export interface CompilerDiagnostic {
   code: string;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,9 +1,9 @@
 import "module-alias/register";
 import { createConnection, ProposedFeatures } from "vscode-languageserver/node";
-import setupServer from "./server";
-import { compilerProcessFactory } from "./services/validation/compilerProcessFactory";
 import { ConnectionLogger } from "@utils/Logger";
 import { WorkspaceFileRetriever } from "@analyzer/WorkspaceFileRetriever";
+import setupServer from "./server";
+import { compilerProcessFactory } from "./services/validation/compilerProcessFactory";
 import { SentryServerTelemetry } from "./telemetry/SentryServerTelemetry";
 import { GoogleAnalytics } from "./analytics/GoogleAnalytics";
 

--- a/server/src/parser/analyzer/HardhatProject.ts
+++ b/server/src/parser/analyzer/HardhatProject.ts
@@ -2,10 +2,10 @@ import { ISolProject } from "@common/types";
 import { WorkspaceFolder } from "vscode-languageserver-protocol";
 
 export class HardhatProject implements ISolProject {
-  type: "hardhat" = "hardhat";
-  basePath: string;
-  configPath: string;
-  workspaceFolder: WorkspaceFolder;
+  public type: "hardhat" = "hardhat";
+  public basePath: string;
+  public configPath: string;
+  public workspaceFolder: WorkspaceFolder;
 
   constructor(
     basePath: string,

--- a/server/src/parser/analyzer/NoProject.ts
+++ b/server/src/parser/analyzer/NoProject.ts
@@ -2,10 +2,10 @@ import { ISolProject, SolProjectType } from "@common/types";
 import { WorkspaceFolder } from "vscode-languageserver-protocol";
 
 export class NoProject implements ISolProject {
-  type: SolProjectType = "none";
-  basePath: string;
-  configPath: string;
-  workspaceFolder: WorkspaceFolder;
+  public type: SolProjectType = "none";
+  public basePath: string;
+  public configPath: string;
+  public workspaceFolder: WorkspaceFolder;
 
   constructor() {
     this.basePath = "";

--- a/server/src/parser/analyzer/SolFileEntry.ts
+++ b/server/src/parser/analyzer/SolFileEntry.ts
@@ -10,21 +10,21 @@ import {
 } from "@common/types";
 
 export class SolFileEntry implements ISolFileEntry {
-  uri: string;
-  project: ISolProject;
-  document: string | undefined;
-  status: SolFileState;
+  public uri: string;
+  public project: ISolProject;
+  public document: string | undefined;
+  public status: SolFileState;
 
-  ast: ASTNode | undefined;
-  analyzerTree: { tree: Node };
-  searcher: ISearcher;
-  orphanNodes: Node[] = [];
+  public ast: ASTNode | undefined;
+  public analyzerTree: { tree: Node };
+  public searcher: ISearcher;
+  public orphanNodes: Node[] = [];
 
   private constructor(uri: string, project: ISolProject) {
     this.uri = uri;
     this.project = project;
     this.document = "";
-    this.status = SolFileState.Unloaded;
+    this.status = SolFileState.UNLOADED;
 
     this.analyzerTree = {
       tree: new EmptyNode(
@@ -38,24 +38,28 @@ export class SolFileEntry implements ISolFileEntry {
     this.searcher = new Searcher(this.analyzerTree);
   }
 
-  static createUnloadedEntry(uri: string, project: ISolProject) {
+  public static createUnloadedEntry(uri: string, project: ISolProject) {
     return new SolFileEntry(uri, project);
   }
 
-  static createLoadedEntry(uri: string, project: ISolProject, text: string) {
+  public static createLoadedEntry(
+    uri: string,
+    project: ISolProject,
+    text: string
+  ) {
     const unloaded = new SolFileEntry(uri, project);
 
     return unloaded.loadText(text);
   }
 
   public loadText(text: string): ISolFileEntry {
-    this.status = SolFileState.Dirty;
+    this.status = SolFileState.DIRTY;
     this.document = text;
 
     return this;
   }
 
   public isAnalyzed(): boolean {
-    return this.status === SolFileState.Analyzed;
+    return this.status === SolFileState.ANALYZED;
   }
 }

--- a/server/src/parser/analyzer/analyzeSolFile.ts
+++ b/server/src/parser/analyzer/analyzeSolFile.ts
@@ -16,18 +16,18 @@ export function analyzeSolFile(
   try {
     solFileEntry.orphanNodes = [];
 
-    if (text) {
+    if (text !== undefined) {
       solFileEntry.document = text;
     }
 
     try {
-      solFileEntry.ast = parser.parse(solFileEntry.document || "", {
+      solFileEntry.ast = parser.parse(solFileEntry.document ?? "", {
         loc: true,
         range: true,
         tolerant: true,
       });
     } catch {
-      solFileEntry.status = SolFileState.Errored;
+      solFileEntry.status = SolFileState.ERRORED;
       return solFileEntry.analyzerTree.tree;
     }
 
@@ -41,7 +41,7 @@ export function analyzeSolFile(
       }
     }
 
-    solFileEntry.status = SolFileState.Analyzed;
+    solFileEntry.status = SolFileState.ANALYZED;
     solFileEntry.analyzerTree.tree = matcher
       .find(
         solFileEntry.ast,

--- a/server/src/parser/analyzer/nodes/ArrayTypeNameNode.ts
+++ b/server/src/parser/analyzer/nodes/ArrayTypeNameNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class ArrayTypeNameNode extends Node {
-  astNode: ArrayTypeName;
+  public astNode: ArrayTypeName;
 
   constructor(
     arrayTypeName: ArrayTypeName,
@@ -18,7 +18,7 @@ export class ArrayTypeNameNode extends Node {
     this.astNode = arrayTypeName;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
@@ -33,6 +33,7 @@ export class ArrayTypeNameNode extends Node {
       this.documentsAnalyzer
     ).accept(find, orphanNodes, parent, this);
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (typeNode) {
       this.addTypeNode(typeNode);
     }

--- a/server/src/parser/analyzer/nodes/AssemblyAssignmentNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyAssignmentNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class AssemblyAssignmentNode extends Node {
-  astNode: AssemblyAssignment;
+  public astNode: AssemblyAssignment;
 
   constructor(
     assemblyAssignment: AssemblyAssignment,
@@ -18,7 +18,7 @@ export class AssemblyAssignmentNode extends Node {
     this.astNode = assemblyAssignment;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
@@ -26,7 +26,7 @@ export class AssemblyAssignmentNode extends Node {
   ): Node {
     this.setExpressionNode(expression);
 
-    for (const name of this.astNode.names || []) {
+    for (const name of this.astNode.names ?? []) {
       find(name, this.uri, this.rootPath, this.documentsAnalyzer).accept(
         find,
         orphanNodes,
@@ -34,6 +34,7 @@ export class AssemblyAssignmentNode extends Node {
       );
     }
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this.astNode.expression) {
       find(
         this.astNode.expression,

--- a/server/src/parser/analyzer/nodes/AssemblyBlockNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyBlockNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class AssemblyBlockNode extends Node {
-  astNode: AssemblyBlock;
+  public astNode: AssemblyBlock;
 
   constructor(
     assemblyBlock: AssemblyBlock,
@@ -18,7 +18,7 @@ export class AssemblyBlockNode extends Node {
     this.astNode = assemblyBlock;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
@@ -30,7 +30,7 @@ export class AssemblyBlockNode extends Node {
       this.setParent(parent);
     }
 
-    for (const operation of this.astNode.operations || []) {
+    for (const operation of this.astNode.operations ?? []) {
       find(operation, this.uri, this.rootPath, this.documentsAnalyzer).accept(
         find,
         orphanNodes,

--- a/server/src/parser/analyzer/nodes/AssemblyCallNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyCallNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class AssemblyCallNode extends Node {
-  astNode: AssemblyCall;
+  public astNode: AssemblyCall;
 
   constructor(
     assemblyCall: AssemblyCall,
@@ -33,7 +33,7 @@ export class AssemblyCallNode extends Node {
     this.astNode = assemblyCall;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
@@ -41,7 +41,7 @@ export class AssemblyCallNode extends Node {
   ): Node {
     this.setExpressionNode(expression);
 
-    for (const argument of this.astNode.arguments || []) {
+    for (const argument of this.astNode.arguments ?? []) {
       find(argument, this.uri, this.rootPath, this.documentsAnalyzer).accept(
         find,
         orphanNodes,

--- a/server/src/parser/analyzer/nodes/AssemblyCaseNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyCaseNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class AssemblyCaseNode extends Node {
-  astNode: AssemblyCase;
+  public astNode: AssemblyCase;
 
   constructor(
     assemblyCase: AssemblyCase,
@@ -18,7 +18,7 @@ export class AssemblyCaseNode extends Node {
     this.astNode = assemblyCase;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/AssemblyForNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyForNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class AssemblyForNode extends Node {
-  astNode: AssemblyFor;
+  public astNode: AssemblyFor;
 
   constructor(
     assemblyFor: AssemblyFor,
@@ -18,7 +18,7 @@ export class AssemblyForNode extends Node {
     this.astNode = assemblyFor;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/AssemblyFunctionDefinitionNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyFunctionDefinitionNode.ts
@@ -7,9 +7,9 @@ import {
 } from "@common/types";
 
 export class AssemblyFunctionDefinitionNode extends Node {
-  astNode: AssemblyFunctionDefinition;
+  public astNode: AssemblyFunctionDefinition;
 
-  connectionTypeRules: string[] = ["AssemblyCall"];
+  public connectionTypeRules: string[] = ["AssemblyCall"];
 
   constructor(
     assemblyFunctionDefinition: AssemblyFunctionDefinition,
@@ -45,11 +45,11 @@ export class AssemblyFunctionDefinitionNode extends Node {
     }
   }
 
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return this;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
@@ -61,7 +61,7 @@ export class AssemblyFunctionDefinitionNode extends Node {
       this.setParent(parent);
     }
 
-    this.findChildren(orphanNodes);
+    this._findChildren(orphanNodes);
 
     for (const argument of this.astNode.arguments) {
       find(argument, this.uri, this.rootPath, this.documentsAnalyzer).accept(
@@ -94,7 +94,7 @@ export class AssemblyFunctionDefinitionNode extends Node {
     return this;
   }
 
-  private findChildren(orphanNodes: Node[]): void {
+  private _findChildren(orphanNodes: Node[]): void {
     const newOrphanNodes: Node[] = [];
     const parent = this.getParent();
 
@@ -105,7 +105,7 @@ export class AssemblyFunctionDefinitionNode extends Node {
         parent &&
         isNodeShadowedByNode(orphanNode, parent) &&
         this.connectionTypeRules.includes(
-          orphanNode.getExpressionNode()?.type || ""
+          orphanNode.getExpressionNode()?.type ?? ""
         ) &&
         orphanNode.type !== "MemberAccess"
       ) {

--- a/server/src/parser/analyzer/nodes/AssemblyFunctionReturnsNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyFunctionReturnsNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class AssemblyFunctionReturnsNode extends Node {
-  astNode: AssemblyFunctionReturns;
+  public astNode: AssemblyFunctionReturns;
 
   constructor(
     assemblyFunctionReturns: AssemblyFunctionReturns,
@@ -19,7 +19,7 @@ export class AssemblyFunctionReturnsNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/AssemblyIfNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyIfNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class AssemblyIfNode extends Node {
-  astNode: AssemblyIf;
+  public astNode: AssemblyIf;
 
   constructor(
     assemblyIf: AssemblyIf,
@@ -18,7 +18,7 @@ export class AssemblyIfNode extends Node {
     this.astNode = assemblyIf;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/AssemblyLiteralNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyLiteralNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class AssemblyLiteralNode extends Node {
-  astNode: AssemblyLiteral;
+  public astNode: AssemblyLiteral;
 
   constructor(
     assemblyLiteral: AssemblyLiteral,
@@ -19,7 +19,7 @@ export class AssemblyLiteralNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/AssemblyLocalDefinitionNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyLocalDefinitionNode.ts
@@ -6,9 +6,9 @@ import {
 } from "@common/types";
 
 export class AssemblyLocalDefinitionNode extends Node {
-  astNode: AssemblyLocalDefinition;
+  public astNode: AssemblyLocalDefinition;
 
-  connectionTypeRules: string[] = ["AssemblyCall", "Identifier"];
+  public connectionTypeRules: string[] = ["AssemblyCall", "Identifier"];
 
   constructor(
     assemblyLocalDefinition: AssemblyLocalDefinition,
@@ -31,15 +31,15 @@ export class AssemblyLocalDefinitionNode extends Node {
     }
   }
 
-  getTypeNodes(): Node[] {
+  public getTypeNodes(): Node[] {
     return this.typeNodes;
   }
 
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return this;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
@@ -47,7 +47,7 @@ export class AssemblyLocalDefinitionNode extends Node {
   ): Node {
     this.setExpressionNode(expression);
 
-    for (const name of this.astNode.names || []) {
+    for (const name of this.astNode.names ?? []) {
       const identifierNode = find(
         name,
         this.uri,

--- a/server/src/parser/analyzer/nodes/AssemblyMemberAccessNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyMemberAccessNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class AssemblyMemberAccessNode extends Node {
-  astNode: AssemblyMemberAccess;
+  public astNode: AssemblyMemberAccess;
 
   constructor(
     assemblyMemberAccess: AssemblyMemberAccess,
@@ -19,7 +19,7 @@ export class AssemblyMemberAccessNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/AssemblyStackAssignmentNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyStackAssignmentNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class AssemblyStackAssignmentNode extends Node {
-  astNode: AssemblyStackAssignment;
+  public astNode: AssemblyStackAssignment;
 
   constructor(
     assemblyStackAssignment: AssemblyStackAssignment,
@@ -19,7 +19,7 @@ export class AssemblyStackAssignmentNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/AssemblySwitchNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblySwitchNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class AssemblySwitchNode extends Node {
-  astNode: AssemblySwitch;
+  public astNode: AssemblySwitch;
 
   constructor(
     assemblySwitch: AssemblySwitch,
@@ -18,7 +18,7 @@ export class AssemblySwitchNode extends Node {
     this.astNode = assemblySwitch;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/BinaryOperationNode.ts
+++ b/server/src/parser/analyzer/nodes/BinaryOperationNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class BinaryOperationNode extends Node {
-  astNode: BinaryOperation;
+  public astNode: BinaryOperation;
 
   constructor(
     binaryOperation: BinaryOperation,
@@ -18,7 +18,7 @@ export class BinaryOperationNode extends Node {
     this.astNode = binaryOperation;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/BlockNode.ts
+++ b/server/src/parser/analyzer/nodes/BlockNode.ts
@@ -1,7 +1,7 @@
 import { Block, FinderType, DocumentsAnalyzerMap, Node } from "@common/types";
 
 export class BlockNode extends Node {
-  astNode: Block;
+  public astNode: Block;
 
   constructor(
     block: Block,
@@ -13,11 +13,11 @@ export class BlockNode extends Node {
     this.astNode = block;
   }
 
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return undefined;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/BooleanLiteralNode.ts
+++ b/server/src/parser/analyzer/nodes/BooleanLiteralNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class BooleanLiteralNode extends Node {
-  astNode: BooleanLiteral;
+  public astNode: BooleanLiteral;
 
   constructor(
     booleanLiteral: BooleanLiteral,
@@ -19,7 +19,7 @@ export class BooleanLiteralNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/BreakNode.ts
+++ b/server/src/parser/analyzer/nodes/BreakNode.ts
@@ -1,7 +1,7 @@
 import { Break, FinderType, DocumentsAnalyzerMap, Node } from "@common/types";
 
 export class BreakNode extends Node {
-  astNode: Break;
+  public astNode: Break;
 
   constructor(
     astBreak: Break,
@@ -14,7 +14,7 @@ export class BreakNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/BreakStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/BreakStatementNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class BreakStatementNode extends Node {
-  astNode: BreakStatement;
+  public astNode: BreakStatement;
 
   constructor(
     breakStatement: BreakStatement,
@@ -19,7 +19,7 @@ export class BreakStatementNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/CatchClauseNode.ts
+++ b/server/src/parser/analyzer/nodes/CatchClauseNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class CatchClauseNode extends Node {
-  astNode: CatchClause;
+  public astNode: CatchClause;
 
   constructor(
     catchClause: CatchClause,
@@ -18,7 +18,7 @@ export class CatchClauseNode extends Node {
     this.astNode = catchClause;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/ConditionalNode.ts
+++ b/server/src/parser/analyzer/nodes/ConditionalNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class ConditionalNode extends Node {
-  astNode: Conditional;
+  public astNode: Conditional;
 
   constructor(
     conditional: Conditional,
@@ -18,7 +18,7 @@ export class ConditionalNode extends Node {
     this.astNode = conditional;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
@@ -26,6 +26,7 @@ export class ConditionalNode extends Node {
   ): Node {
     this.setExpressionNode(expression);
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this.astNode.condition) {
       find(
         this.astNode.condition,
@@ -35,6 +36,7 @@ export class ConditionalNode extends Node {
       ).accept(find, orphanNodes, parent);
     }
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this.astNode.trueExpression) {
       find(
         this.astNode.trueExpression,
@@ -44,6 +46,7 @@ export class ConditionalNode extends Node {
       ).accept(find, orphanNodes, parent);
     }
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this.astNode.falseExpression) {
       find(
         this.astNode.falseExpression,

--- a/server/src/parser/analyzer/nodes/ContinueNode.ts
+++ b/server/src/parser/analyzer/nodes/ContinueNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class ContinueNode extends Node {
-  astNode: Continue;
+  public astNode: Continue;
 
   constructor(
     astContinue: Continue,
@@ -19,7 +19,7 @@ export class ContinueNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/ContinueStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/ContinueStatementNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class ContinueStatementNode extends Node {
-  astNode: ContinueStatement;
+  public astNode: ContinueStatement;
 
   constructor(
     continueStatement: ContinueStatement,
@@ -19,7 +19,7 @@ export class ContinueStatementNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/ContractDefinitionNode.ts
+++ b/server/src/parser/analyzer/nodes/ContractDefinitionNode.ts
@@ -8,9 +8,9 @@ import {
 } from "@common/types";
 
 export class ContractDefinitionNode extends AbstractContractDefinitionNode {
-  astNode: ContractDefinition;
+  public astNode: ContractDefinition;
 
-  connectionTypeRules: string[] = [
+  public connectionTypeRules: string[] = [
     "Identifier",
     "UserDefinedTypeName",
     "FunctionCall",
@@ -56,19 +56,19 @@ export class ContractDefinitionNode extends AbstractContractDefinitionNode {
     this.addTypeNode(this);
   }
 
-  getKind(): string {
+  public getKind(): string {
     return this.astNode.kind;
   }
 
-  getTypeNodes(): Node[] {
+  public getTypeNodes(): Node[] {
     return this.typeNodes;
   }
 
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return this;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
@@ -124,7 +124,7 @@ export class ContractDefinitionNode extends AbstractContractDefinitionNode {
     return this;
   }
 
-  findParentForOrphanNodesInInheritanceNodes(orphanNodes: Node[]): void {
+  public findParentForOrphanNodesInInheritanceNodes(orphanNodes: Node[]): void {
     const searcher = this.documentsAnalyzer[this.uri]?.searcher;
     const newOrphanNodes: Node[] = [];
 

--- a/server/src/parser/analyzer/nodes/CustomErrorDefinitionNode.ts
+++ b/server/src/parser/analyzer/nodes/CustomErrorDefinitionNode.ts
@@ -7,9 +7,9 @@ import {
 } from "@common/types";
 
 export class CustomErrorDefinitionNode extends Node {
-  astNode: CustomErrorDefinition;
+  public astNode: CustomErrorDefinition;
 
-  connectionTypeRules: string[] = ["Identifier", "UserDefinedTypeName"];
+  public connectionTypeRules: string[] = ["Identifier", "UserDefinedTypeName"];
 
   constructor(
     customErrorDefinition: CustomErrorDefinition,
@@ -45,15 +45,15 @@ export class CustomErrorDefinitionNode extends Node {
     this.addTypeNode(this);
   }
 
-  getTypeNodes(): Node[] {
+  public getTypeNodes(): Node[] {
     return this.typeNodes;
   }
 
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return this;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/DecimalNumberNode.ts
+++ b/server/src/parser/analyzer/nodes/DecimalNumberNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class DecimalNumberNode extends Node {
-  astNode: DecimalNumber;
+  public astNode: DecimalNumber;
 
   constructor(
     decimalNumber: DecimalNumber,
@@ -19,7 +19,7 @@ export class DecimalNumberNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/DoWhileStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/DoWhileStatementNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class DoWhileStatementNode extends Node {
-  astNode: DoWhileStatement;
+  public astNode: DoWhileStatement;
 
   constructor(
     doWhileStatement: DoWhileStatement,
@@ -18,11 +18,11 @@ export class DoWhileStatementNode extends Node {
     this.astNode = doWhileStatement;
   }
 
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return undefined;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
@@ -40,6 +40,7 @@ export class DoWhileStatementNode extends Node {
       this.rootPath,
       this.documentsAnalyzer
     ).accept(find, orphanNodes, this);
+
     find(
       this.astNode.body,
       this.uri,

--- a/server/src/parser/analyzer/nodes/ElementaryTypeNameNode.ts
+++ b/server/src/parser/analyzer/nodes/ElementaryTypeNameNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class ElementaryTypeNameNode extends Node {
-  astNode: ElementaryTypeName;
+  public astNode: ElementaryTypeName;
 
   constructor(
     elementaryTypeName: ElementaryTypeName,
@@ -25,7 +25,7 @@ export class ElementaryTypeNameNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/EmitStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/EmitStatementNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class EmitStatementNode extends Node {
-  astNode: EmitStatement;
+  public astNode: EmitStatement;
 
   constructor(
     emitStatement: EmitStatement,
@@ -18,7 +18,7 @@ export class EmitStatementNode extends Node {
     this.astNode = emitStatement;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/EnumDefinitionNode.ts
+++ b/server/src/parser/analyzer/nodes/EnumDefinitionNode.ts
@@ -7,9 +7,9 @@ import {
 } from "@common/types";
 
 export class EnumDefinitionNode extends Node {
-  astNode: EnumDefinition;
+  public astNode: EnumDefinition;
 
-  connectionTypeRules: string[] = ["Identifier", "UserDefinedTypeName"];
+  public connectionTypeRules: string[] = ["Identifier", "UserDefinedTypeName"];
 
   constructor(
     enumDefinition: EnumDefinition,
@@ -45,15 +45,15 @@ export class EnumDefinitionNode extends Node {
     this.addTypeNode(this);
   }
 
-  getTypeNodes(): Node[] {
+  public getTypeNodes(): Node[] {
     return this.typeNodes;
   }
 
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return this;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/EnumValueNode.ts
+++ b/server/src/parser/analyzer/nodes/EnumValueNode.ts
@@ -6,9 +6,9 @@ import {
 } from "@common/types";
 
 export class EnumValueNode extends Node {
-  astNode: EnumValue;
+  public astNode: EnumValue;
 
-  connectionTypeRules: string[] = ["MemberAccess"];
+  public connectionTypeRules: string[] = ["MemberAccess"];
 
   constructor(
     enumValue: EnumValue,
@@ -29,11 +29,11 @@ export class EnumValueNode extends Node {
     this.astNode = enumValue;
   }
 
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return this;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/EventDefinitionNode.ts
+++ b/server/src/parser/analyzer/nodes/EventDefinitionNode.ts
@@ -7,9 +7,9 @@ import {
 } from "@common/types";
 
 export class EventDefinitionNode extends Node {
-  astNode: EventDefinition;
+  public astNode: EventDefinition;
 
-  connectionTypeRules: string[] = ["EmitStatement"];
+  public connectionTypeRules: string[] = ["EmitStatement"];
 
   constructor(
     eventDefinition: EventDefinition,
@@ -37,7 +37,7 @@ export class EventDefinitionNode extends Node {
           column:
             eventDefinition.loc.start.column +
             "event ".length +
-            (this.getName()?.length || 0),
+            (this.getName()?.length ?? 0),
         },
       };
     }
@@ -45,15 +45,15 @@ export class EventDefinitionNode extends Node {
     this.addTypeNode(this);
   }
 
-  getTypeNodes(): Node[] {
+  public getTypeNodes(): Node[] {
     return this.typeNodes;
   }
 
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return this;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/ExpressionStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/ExpressionStatementNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class ExpressionStatementNode extends Node {
-  astNode: ExpressionStatement;
+  public astNode: ExpressionStatement;
 
   constructor(
     expressionStatement: ExpressionStatement,
@@ -18,7 +18,7 @@ export class ExpressionStatementNode extends Node {
     this.astNode = expressionStatement;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/FileLevelConstantNode.ts
+++ b/server/src/parser/analyzer/nodes/FileLevelConstantNode.ts
@@ -6,9 +6,9 @@ import {
 } from "@common/types";
 
 export class FileLevelConstantNode extends Node {
-  astNode: FileLevelConstant;
+  public astNode: FileLevelConstant;
 
-  connectionTypeRules: string[] = ["Identifier"];
+  public connectionTypeRules: string[] = ["Identifier"];
 
   constructor(
     fileLevelConstant: FileLevelConstant,
@@ -40,11 +40,11 @@ export class FileLevelConstantNode extends Node {
     }
   }
 
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return this;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
@@ -56,6 +56,7 @@ export class FileLevelConstantNode extends Node {
       this.setParent(parent);
     }
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this.astNode.typeName) {
       let typeNode = find(
         this.astNode.typeName,
@@ -76,6 +77,7 @@ export class FileLevelConstantNode extends Node {
       typeNode.setDeclarationNode(this);
     }
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this.astNode.initialValue) {
       find(
         this.astNode.initialValue,
@@ -90,14 +92,14 @@ export class FileLevelConstantNode extends Node {
     return this;
   }
 
-  updateLocationName(typeNode: Node): void {
+  public updateLocationName(typeNode: Node): void {
     if (this.astNode.loc && this.nameLoc && typeNode.astNode.range) {
       const diff =
         1 + (+typeNode.astNode.range[1] - +typeNode.astNode.range[0]);
 
       this.nameLoc.start.column = this.astNode.loc.start.column + diff + 1;
       this.nameLoc.end.column =
-        this.nameLoc.start.column + (this.getName()?.length || 0);
+        this.nameLoc.start.column + (this.getName()?.length ?? 0);
 
       if (this.astNode.isDeclaredConst) {
         this.nameLoc.start.column += "constant ".length;

--- a/server/src/parser/analyzer/nodes/ForStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/ForStatementNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class ForStatementNode extends Node {
-  astNode: ForStatement;
+  public astNode: ForStatement;
 
   constructor(
     forStatement: ForStatement,
@@ -18,11 +18,11 @@ export class ForStatementNode extends Node {
     this.astNode = forStatement;
   }
 
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return undefined;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
@@ -42,6 +42,7 @@ export class ForStatementNode extends Node {
         this.documentsAnalyzer
       ).accept(find, orphanNodes, this);
     }
+
     if (this.astNode.conditionExpression) {
       find(
         this.astNode.conditionExpression,
@@ -50,6 +51,8 @@ export class ForStatementNode extends Node {
         this.documentsAnalyzer
       ).accept(find, orphanNodes, this);
     }
+
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this.astNode.loopExpression) {
       find(
         this.astNode.loopExpression,

--- a/server/src/parser/analyzer/nodes/FunctionCallNode.ts
+++ b/server/src/parser/analyzer/nodes/FunctionCallNode.ts
@@ -7,7 +7,7 @@ import {
 } from "@common/types";
 
 export class FunctionCallNode extends Node {
-  astNode: FunctionCall;
+  public astNode: FunctionCall;
 
   constructor(
     functionCall: FunctionCall,
@@ -19,7 +19,7 @@ export class FunctionCallNode extends Node {
     this.astNode = functionCall;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/FunctionDefinitionNode.ts
+++ b/server/src/parser/analyzer/nodes/FunctionDefinitionNode.ts
@@ -9,9 +9,9 @@ import {
 } from "@common/types";
 
 export class FunctionDefinitionNode extends AbstractFunctionDefinitionNode {
-  astNode: FunctionDefinition;
+  public astNode: FunctionDefinition;
 
-  connectionTypeRules: string[] = [
+  public connectionTypeRules: string[] = [
     "FunctionCall",
     "MemberAccess",
     "ModifierInvocation",
@@ -29,7 +29,7 @@ export class FunctionDefinitionNode extends AbstractFunctionDefinitionNode {
       uri,
       rootPath,
       documentsAnalyzer,
-      functionDefinition.name || undefined
+      functionDefinition.name ?? undefined
     );
     this.astNode = functionDefinition;
     this.isConstructor = functionDefinition.isConstructor;
@@ -53,7 +53,7 @@ export class FunctionDefinitionNode extends AbstractFunctionDefinitionNode {
       return;
     }
 
-    if (!functionDefinition.name) {
+    if (functionDefinition.name === null) {
       return;
     }
 
@@ -72,15 +72,15 @@ export class FunctionDefinitionNode extends AbstractFunctionDefinitionNode {
     };
   }
 
-  getName(): string | undefined {
+  public getName(): string | undefined {
     return this.isConstructor ? this.parent?.name : this.name;
   }
 
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return this;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
@@ -99,7 +99,7 @@ export class FunctionDefinitionNode extends AbstractFunctionDefinitionNode {
       }
     }
 
-    this.findChildren(orphanNodes);
+    this._findChildren(orphanNodes);
 
     for (const override of this.astNode.override || []) {
       find(override, this.uri, this.rootPath, this.documentsAnalyzer).accept(
@@ -117,7 +117,7 @@ export class FunctionDefinitionNode extends AbstractFunctionDefinitionNode {
       );
     }
 
-    for (const returnParam of this.astNode.returnParameters || []) {
+    for (const returnParam of this.astNode.returnParameters ?? []) {
       const typeNode = find(
         returnParam,
         this.uri,
@@ -128,7 +128,7 @@ export class FunctionDefinitionNode extends AbstractFunctionDefinitionNode {
       this.addTypeNode(typeNode);
     }
 
-    for (const modifier of this.astNode.modifiers || []) {
+    for (const modifier of this.astNode.modifiers ?? []) {
       const typeNode = find(
         modifier,
         this.uri,
@@ -168,7 +168,7 @@ export class FunctionDefinitionNode extends AbstractFunctionDefinitionNode {
     return this;
   }
 
-  private findChildren(orphanNodes: Node[]): void {
+  private _findChildren(orphanNodes: Node[]): void {
     const newOrphanNodes: Node[] = [];
     const parent = this.getParent();
 
@@ -179,7 +179,7 @@ export class FunctionDefinitionNode extends AbstractFunctionDefinitionNode {
         parent &&
         isNodeShadowedByNode(orphanNode, parent) &&
         this.connectionTypeRules.includes(
-          orphanNode.getExpressionNode()?.type || ""
+          orphanNode.getExpressionNode()?.type ?? ""
         ) &&
         orphanNode.type !== "MemberAccess"
       ) {

--- a/server/src/parser/analyzer/nodes/FunctionTypeNameNode.ts
+++ b/server/src/parser/analyzer/nodes/FunctionTypeNameNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class FunctionTypeNameNode extends Node {
-  astNode: FunctionTypeName;
+  public astNode: FunctionTypeName;
 
   constructor(
     functionTypeName: FunctionTypeName,
@@ -19,7 +19,7 @@ export class FunctionTypeNameNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/HexLiteralNode.ts
+++ b/server/src/parser/analyzer/nodes/HexLiteralNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class HexLiteralNode extends Node {
-  astNode: HexLiteral;
+  public astNode: HexLiteral;
 
   constructor(
     hexLiteral: HexLiteral,
@@ -19,7 +19,7 @@ export class HexLiteralNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/HexNumberNode.ts
+++ b/server/src/parser/analyzer/nodes/HexNumberNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class HexNumberNode extends Node {
-  astNode: HexNumber;
+  public astNode: HexNumber;
 
   constructor(
     hexNumber: HexNumber,
@@ -19,7 +19,7 @@ export class HexNumberNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/IdentifierNode.ts
+++ b/server/src/parser/analyzer/nodes/IdentifierNode.ts
@@ -9,7 +9,7 @@ import {
 } from "@common/types";
 
 export class IdentifierNode extends AbstractIdentifierNode {
-  astNode: Identifier;
+  public astNode: Identifier;
 
   constructor(
     identifier: Identifier,
@@ -32,7 +32,7 @@ export class IdentifierNode extends AbstractIdentifierNode {
     this.astNode = identifier;
   }
 
-  setParent(parent: Node | undefined): void {
+  public setParent(parent: Node | undefined): void {
     this.parent = parent;
 
     let expressionNode = this.getExpressionNode();
@@ -46,9 +46,9 @@ export class IdentifierNode extends AbstractIdentifierNode {
       }
 
       if (expressionNode && expressionNode.type === "MemberAccess") {
-        const definitionTypes = parent.getTypeNodes();
+        const parentDefinitionTypes = parent.getTypeNodes();
 
-        this.findMemberAccessParent(expressionNode, definitionTypes);
+        this.findMemberAccessParent(expressionNode, parentDefinitionTypes);
       }
     }
 
@@ -68,7 +68,7 @@ export class IdentifierNode extends AbstractIdentifierNode {
     }
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
@@ -108,7 +108,10 @@ export class IdentifierNode extends AbstractIdentifierNode {
     return this;
   }
 
-  findMemberAccessParent(expressionNode: Node, definitionTypes: Node[]): void {
+  public findMemberAccessParent(
+    expressionNode: Node,
+    definitionTypes: Node[]
+  ): void {
     for (const definitionType of definitionTypes) {
       for (const definitionChild of definitionType.children) {
         if (utils.isNodeConnectable(definitionChild, expressionNode)) {
@@ -118,6 +121,7 @@ export class IdentifierNode extends AbstractIdentifierNode {
           definitionChild?.addChild(expressionNode);
 
           // If the parent uri and node uri are not the same, add the node to the exportNode field
+          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
           if (definitionChild && definitionChild.uri !== expressionNode.uri) {
             const exportRootNode = utils.findSourceUnitNode(definitionChild);
             const importRootNode = utils.findSourceUnitNode(

--- a/server/src/parser/analyzer/nodes/IfStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/IfStatementNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class IfStatementNode extends Node {
-  astNode: IfStatement;
+  public astNode: IfStatement;
 
   constructor(
     ifStatement: IfStatement,
@@ -18,11 +18,11 @@ export class IfStatementNode extends Node {
     this.astNode = ifStatement;
   }
 
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return undefined;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/ImportDirectiveNode.ts
+++ b/server/src/parser/analyzer/nodes/ImportDirectiveNode.ts
@@ -11,14 +11,14 @@ import {
   ImportDirectiveNode as AbstractImportDirectiveNode,
   SolFileState,
 } from "@common/types";
-import { toUnixStyle } from "../../../utils/index";
 import { analyzeSolFile } from "@analyzer/analyzeSolFile";
+import { toUnixStyle } from "../../../utils/index";
 
 export class ImportDirectiveNode extends AbstractImportDirectiveNode {
-  realUri: string;
+  public realUri: string;
 
-  uri: string;
-  astNode: ImportDirective;
+  public uri: string;
+  public astNode: ImportDirective;
 
   constructor(
     importDirective: ImportDirective,
@@ -44,6 +44,7 @@ export class ImportDirectiveNode extends AbstractImportDirectiveNode {
       this.uri = "";
     }
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (importDirective.pathLiteral && importDirective.pathLiteral.loc) {
       this.nameLoc = importDirective.pathLiteral.loc;
       this.nameLoc.end.column =
@@ -55,11 +56,11 @@ export class ImportDirectiveNode extends AbstractImportDirectiveNode {
     this.astNode = importDirective;
   }
 
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return this;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
@@ -72,7 +73,7 @@ export class ImportDirectiveNode extends AbstractImportDirectiveNode {
     }
 
     const documentAnalyzer = this.documentsAnalyzer[toUnixStyle(this.uri)];
-    if (documentAnalyzer && documentAnalyzer.status !== SolFileState.Analyzed) {
+    if (documentAnalyzer && documentAnalyzer.status !== SolFileState.ANALYZED) {
       analyzeSolFile(documentAnalyzer, this.documentsAnalyzer);
 
       // Analyze will change root node so we need to return root node after analyze

--- a/server/src/parser/analyzer/nodes/IndexAccessNode.ts
+++ b/server/src/parser/analyzer/nodes/IndexAccessNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class IndexAccessNode extends Node {
-  astNode: IndexAccess;
+  public astNode: IndexAccess;
 
   constructor(
     indexAccess: IndexAccess,
@@ -18,7 +18,7 @@ export class IndexAccessNode extends Node {
     this.astNode = indexAccess;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/IndexRangeAccessNode.ts
+++ b/server/src/parser/analyzer/nodes/IndexRangeAccessNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class IndexRangeAccessNode extends Node {
-  astNode: IndexRangeAccess;
+  public astNode: IndexRangeAccess;
 
   constructor(
     indexRangeAccess: IndexRangeAccess,
@@ -18,7 +18,7 @@ export class IndexRangeAccessNode extends Node {
     this.astNode = indexRangeAccess;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/InheritanceSpecifierNode.ts
+++ b/server/src/parser/analyzer/nodes/InheritanceSpecifierNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class InheritanceSpecifierNode extends Node {
-  astNode: InheritanceSpecifier;
+  public astNode: InheritanceSpecifier;
 
   constructor(
     inheritanceSpecifier: InheritanceSpecifier,
@@ -18,7 +18,7 @@ export class InheritanceSpecifierNode extends Node {
     this.astNode = inheritanceSpecifier;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/InlineAssemblyStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/InlineAssemblyStatementNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class InlineAssemblyStatementNode extends Node {
-  astNode: InlineAssemblyStatement;
+  public astNode: InlineAssemblyStatement;
 
   constructor(
     inlineAssemblyStatement: InlineAssemblyStatement,
@@ -18,7 +18,7 @@ export class InlineAssemblyStatementNode extends Node {
     this.astNode = inlineAssemblyStatement;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
@@ -26,6 +26,7 @@ export class InlineAssemblyStatementNode extends Node {
   ): Node {
     this.setExpressionNode(expression);
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this.astNode.body) {
       find(
         this.astNode.body,

--- a/server/src/parser/analyzer/nodes/LabelDefinitionNode.ts
+++ b/server/src/parser/analyzer/nodes/LabelDefinitionNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class LabelDefinitionNode extends Node {
-  astNode: LabelDefinition;
+  public astNode: LabelDefinition;
 
   constructor(
     labelDefinition: LabelDefinition,
@@ -19,15 +19,15 @@ export class LabelDefinitionNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  getTypeNodes(): Node[] {
+  public getTypeNodes(): Node[] {
     return this.typeNodes;
   }
 
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return this;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/MappingNode.ts
+++ b/server/src/parser/analyzer/nodes/MappingNode.ts
@@ -1,7 +1,7 @@
 import { Mapping, FinderType, DocumentsAnalyzerMap, Node } from "@common/types";
 
 export class MappingNode extends Node {
-  astNode: Mapping;
+  public astNode: Mapping;
 
   constructor(
     mapping: Mapping,
@@ -13,7 +13,7 @@ export class MappingNode extends Node {
     this.astNode = mapping;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/MemberAccessNode.ts
+++ b/server/src/parser/analyzer/nodes/MemberAccessNode.ts
@@ -10,7 +10,7 @@ import {
 } from "@common/types";
 
 export class MemberAccessNode extends IMemberAccessNode {
-  astNode: MemberAccess;
+  public astNode: MemberAccess;
 
   constructor(
     memberAccess: MemberAccess,
@@ -39,7 +39,7 @@ export class MemberAccessNode extends IMemberAccessNode {
     this.astNode = memberAccess;
   }
 
-  setParent(parent: Node | undefined): void {
+  public setParent(parent: Node | undefined): void {
     this.parent = parent;
 
     let expressionNode = this.getExpressionNode();
@@ -60,7 +60,7 @@ export class MemberAccessNode extends IMemberAccessNode {
     }
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
@@ -162,7 +162,7 @@ export class MemberAccessNode extends IMemberAccessNode {
     return this;
   }
 
-  findMemberAccessParent(
+  public findMemberAccessParent(
     expressionNode: Node,
     definitionTypes: Node[]
   ): Node | undefined {
@@ -175,6 +175,7 @@ export class MemberAccessNode extends IMemberAccessNode {
           definitionChild?.addChild(expressionNode);
 
           // If the parent uri and node uri are not the same, add the node to the exportNode field
+          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
           if (definitionChild && definitionChild.uri !== expressionNode.uri) {
             const exportRootNode = findSourceUnitNode(definitionChild);
             const importRootNode = findSourceUnitNode(

--- a/server/src/parser/analyzer/nodes/ModifierDefinitionNode.ts
+++ b/server/src/parser/analyzer/nodes/ModifierDefinitionNode.ts
@@ -7,9 +7,9 @@ import {
 } from "@common/types";
 
 export class ModifierDefinitionNode extends Node {
-  astNode: ModifierDefinition;
+  public astNode: ModifierDefinition;
 
-  connectionTypeRules: string[] = ["ModifierInvocation"];
+  public connectionTypeRules: string[] = ["ModifierInvocation"];
 
   constructor(
     modifierDefinition: ModifierDefinition,
@@ -45,15 +45,15 @@ export class ModifierDefinitionNode extends Node {
     this.addTypeNode(this);
   }
 
-  getTypeNodes(): Node[] {
+  public getTypeNodes(): Node[] {
     return this.typeNodes;
   }
 
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return this;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/ModifierInvocationNode.ts
+++ b/server/src/parser/analyzer/nodes/ModifierInvocationNode.ts
@@ -8,7 +8,7 @@ import { isContractDefinitionNode } from "@analyzer/utils/typeGuards";
 import { lookupConstructorFor } from "@analyzer/utils/lookups";
 
 export class ModifierInvocationNode extends Node {
-  astNode: ModifierInvocation;
+  public astNode: ModifierInvocation;
 
   constructor(
     modifierInvocation: ModifierInvocation,
@@ -41,7 +41,7 @@ export class ModifierInvocationNode extends Node {
     }
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/NameValueExpressionNode.ts
+++ b/server/src/parser/analyzer/nodes/NameValueExpressionNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class NameValueExpressionNode extends Node {
-  astNode: NameValueExpression;
+  public astNode: NameValueExpression;
 
   constructor(
     nameValueExpression: NameValueExpression,
@@ -18,7 +18,7 @@ export class NameValueExpressionNode extends Node {
     this.astNode = nameValueExpression;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/NameValueListNode.ts
+++ b/server/src/parser/analyzer/nodes/NameValueListNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class NameValueListNode extends Node {
-  astNode: NameValueList;
+  public astNode: NameValueList;
 
   constructor(
     nameValueList: NameValueList,
@@ -18,7 +18,7 @@ export class NameValueListNode extends Node {
     this.astNode = nameValueList;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/NewExpressionNode.ts
+++ b/server/src/parser/analyzer/nodes/NewExpressionNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class NewExpressionNode extends Node {
-  astNode: NewExpression;
+  public astNode: NewExpression;
 
   constructor(
     newExpression: NewExpression,
@@ -18,7 +18,7 @@ export class NewExpressionNode extends Node {
     this.astNode = newExpression;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
@@ -26,6 +26,7 @@ export class NewExpressionNode extends Node {
   ): Node {
     this.setExpressionNode(expression);
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this.astNode.typeName) {
       find(
         this.astNode.typeName,

--- a/server/src/parser/analyzer/nodes/NumberLiteralNode.ts
+++ b/server/src/parser/analyzer/nodes/NumberLiteralNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class NumberLiteralNode extends Node {
-  astNode: NumberLiteral;
+  public astNode: NumberLiteral;
 
   constructor(
     numberLiteral: NumberLiteral,
@@ -19,7 +19,7 @@ export class NumberLiteralNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/PragmaDirectiveNode.ts
+++ b/server/src/parser/analyzer/nodes/PragmaDirectiveNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class PragmaDirectiveNode extends Node {
-  astNode: PragmaDirective;
+  public astNode: PragmaDirective;
 
   constructor(
     pragmaDirective: PragmaDirective,
@@ -19,7 +19,7 @@ export class PragmaDirectiveNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/ReturnStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/ReturnStatementNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class ReturnStatementNode extends Node {
-  astNode: ReturnStatement;
+  public astNode: ReturnStatement;
 
   constructor(
     returnStatement: ReturnStatement,
@@ -18,7 +18,7 @@ export class ReturnStatementNode extends Node {
     this.astNode = returnStatement;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/RevertStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/RevertStatementNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class RevertStatementNode extends Node {
-  astNode: RevertStatement;
+  public astNode: RevertStatement;
 
   constructor(
     revertStatement: RevertStatement,
@@ -18,7 +18,7 @@ export class RevertStatementNode extends Node {
     this.astNode = revertStatement;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/SourceUnitNode.ts
+++ b/server/src/parser/analyzer/nodes/SourceUnitNode.ts
@@ -7,7 +7,7 @@ import {
 } from "@common/types";
 
 export class SourceUnitNode extends AbstractSourceUnitNode {
-  astNode: SourceUnit;
+  public astNode: SourceUnit;
 
   constructor(
     sourceUnit: SourceUnit,
@@ -19,11 +19,11 @@ export class SourceUnitNode extends AbstractSourceUnitNode {
     this.astNode = sourceUnit;
   }
 
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return undefined;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
@@ -33,7 +33,7 @@ export class SourceUnitNode extends AbstractSourceUnitNode {
 
     const documentAnalyzer = this.documentsAnalyzer[this.uri];
     if (
-      documentAnalyzer?.isAnalyzed() &&
+      documentAnalyzer?.isAnalyzed() === true &&
       documentAnalyzer.analyzerTree.tree instanceof SourceUnitNode
     ) {
       this.exportNodes = documentAnalyzer.analyzerTree.tree

--- a/server/src/parser/analyzer/nodes/StateVariableDeclarationNode.ts
+++ b/server/src/parser/analyzer/nodes/StateVariableDeclarationNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class StateVariableDeclarationNode extends Node {
-  astNode: StateVariableDeclaration;
+  public astNode: StateVariableDeclaration;
 
   constructor(
     stateVariableDeclaration: StateVariableDeclaration,
@@ -24,11 +24,11 @@ export class StateVariableDeclarationNode extends Node {
     this.astNode = stateVariableDeclaration;
   }
 
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return this;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/StringLiteralNode.ts
+++ b/server/src/parser/analyzer/nodes/StringLiteralNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class StringLiteralNode extends Node {
-  astNode: StringLiteral;
+  public astNode: StringLiteral;
 
   constructor(
     stringLiteral: StringLiteral,
@@ -19,7 +19,7 @@ export class StringLiteralNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/StructDefinitionNode.ts
+++ b/server/src/parser/analyzer/nodes/StructDefinitionNode.ts
@@ -7,9 +7,9 @@ import {
 } from "@common/types";
 
 export class StructDefinitionNode extends Node {
-  astNode: StructDefinition;
+  public astNode: StructDefinition;
 
-  connectionTypeRules: string[] = [
+  public connectionTypeRules: string[] = [
     "UserDefinedTypeName",
     "MemberAccess",
     "FunctionCall",
@@ -49,15 +49,15 @@ export class StructDefinitionNode extends Node {
     this.addTypeNode(this);
   }
 
-  getTypeNodes(): Node[] {
+  public getTypeNodes(): Node[] {
     return this.typeNodes;
   }
 
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return this;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/SubAssemblyNode.ts
+++ b/server/src/parser/analyzer/nodes/SubAssemblyNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class SubAssemblyNode extends Node {
-  astNode: SubAssembly;
+  public astNode: SubAssembly;
 
   constructor(
     subAssembly: SubAssembly,
@@ -19,7 +19,7 @@ export class SubAssemblyNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/ThrowStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/ThrowStatementNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class ThrowStatementNode extends Node {
-  astNode: ThrowStatement;
+  public astNode: ThrowStatement;
 
   constructor(
     throwStatement: ThrowStatement,
@@ -19,7 +19,7 @@ export class ThrowStatementNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/TryStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/TryStatementNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class TryStatementNode extends Node {
-  astNode: TryStatement;
+  public astNode: TryStatement;
 
   constructor(
     tryStatement: TryStatement,
@@ -18,7 +18,7 @@ export class TryStatementNode extends Node {
     this.astNode = tryStatement;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
@@ -53,7 +53,7 @@ export class TryStatementNode extends Node {
       this.documentsAnalyzer
     ).accept(find, orphanNodes, this);
 
-    for (const catchClause of this.astNode.catchClauses || []) {
+    for (const catchClause of this.astNode.catchClauses ?? []) {
       find(catchClause, this.uri, this.rootPath, this.documentsAnalyzer).accept(
         find,
         orphanNodes,

--- a/server/src/parser/analyzer/nodes/TupleExpressionNode.ts
+++ b/server/src/parser/analyzer/nodes/TupleExpressionNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class TupleExpressionNode extends Node {
-  astNode: TupleExpression;
+  public astNode: TupleExpression;
 
   constructor(
     tupleExpression: TupleExpression,
@@ -18,7 +18,7 @@ export class TupleExpressionNode extends Node {
     this.astNode = tupleExpression;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/TypeDefinitionNode.ts
+++ b/server/src/parser/analyzer/nodes/TypeDefinitionNode.ts
@@ -7,9 +7,9 @@ import {
 } from "@common/types";
 
 export class TypeDefinitionNode extends Node {
-  astNode: TypeDefinition;
+  public astNode: TypeDefinition;
 
-  connectionTypeRules: string[] = ["Identifier", "UserDefinedTypeName"];
+  public connectionTypeRules: string[] = ["Identifier", "UserDefinedTypeName"];
 
   constructor(
     typeDefinition: TypeDefinition,
@@ -45,15 +45,15 @@ export class TypeDefinitionNode extends Node {
     this.addTypeNode(this);
   }
 
-  getTypeNodes(): Node[] {
+  public getTypeNodes(): Node[] {
     return this.typeNodes;
   }
 
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return this;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/TypeNameExpressionNode.ts
+++ b/server/src/parser/analyzer/nodes/TypeNameExpressionNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class TypeNameExpressionNode extends Node {
-  astNode: TypeNameExpression;
+  public astNode: TypeNameExpression;
 
   constructor(
     typeNameExpression: TypeNameExpression,
@@ -19,7 +19,7 @@ export class TypeNameExpressionNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/UnaryOperationNode.ts
+++ b/server/src/parser/analyzer/nodes/UnaryOperationNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class UnaryOperationNode extends Node {
-  astNode: UnaryOperation;
+  public astNode: UnaryOperation;
 
   constructor(
     unaryOperation: UnaryOperation,
@@ -18,7 +18,7 @@ export class UnaryOperationNode extends Node {
     this.astNode = unaryOperation;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/UncheckedStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/UncheckedStatementNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class UncheckedStatementNode extends Node {
-  astNode: UncheckedStatement;
+  public astNode: UncheckedStatement;
 
   constructor(
     uncheckedStatement: UncheckedStatement,
@@ -18,7 +18,7 @@ export class UncheckedStatementNode extends Node {
     this.astNode = uncheckedStatement;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
@@ -26,6 +26,7 @@ export class UncheckedStatementNode extends Node {
   ): Node {
     this.setExpressionNode(expression);
 
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this.astNode.block) {
       find(
         this.astNode.block,

--- a/server/src/parser/analyzer/nodes/UserDefinedTypeNameNode.ts
+++ b/server/src/parser/analyzer/nodes/UserDefinedTypeNameNode.ts
@@ -13,7 +13,7 @@ import {
 import { lookupConstructorFor } from "@analyzer/utils/lookups";
 
 export class UserDefinedTypeNameNode extends Node {
-  astNode: UserDefinedTypeName;
+  public astNode: UserDefinedTypeName;
 
   constructor(
     userDefinedTypeName: UserDefinedTypeName,
@@ -41,7 +41,7 @@ export class UserDefinedTypeNameNode extends Node {
     this.astNode = userDefinedTypeName;
   }
 
-  setParent(parent: Node | undefined): void {
+  public setParent(parent: Node | undefined): void {
     this.parent = parent;
 
     const declarationNode = this.getDeclarationNode();
@@ -66,7 +66,7 @@ export class UserDefinedTypeNameNode extends Node {
     }
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
@@ -112,7 +112,10 @@ export class UserDefinedTypeNameNode extends Node {
     return this;
   }
 
-  findMemberAccessParent(expressionNode: Node, definitionTypes: Node[]): void {
+  public findMemberAccessParent(
+    expressionNode: Node,
+    definitionTypes: Node[]
+  ): void {
     for (const definitionType of definitionTypes) {
       for (const definitionChild of definitionType.children) {
         if (isNodeConnectable(definitionChild, expressionNode)) {
@@ -122,6 +125,7 @@ export class UserDefinedTypeNameNode extends Node {
           definitionChild?.addChild(expressionNode);
 
           // If the parent uri and node uri are not the same, add the node to the exportNode field
+          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
           if (definitionChild && definitionChild.uri !== expressionNode.uri) {
             const exportRootNode = findSourceUnitNode(definitionChild);
             const importRootNode = findSourceUnitNode(

--- a/server/src/parser/analyzer/nodes/UsingForDeclarationNode.ts
+++ b/server/src/parser/analyzer/nodes/UsingForDeclarationNode.ts
@@ -6,9 +6,9 @@ import {
 } from "@common/types";
 
 export class UsingForDeclarationNode extends Node {
-  astNode: UsingForDeclaration;
+  public astNode: UsingForDeclaration;
 
-  connectionTypeRules: string[] = ["ContractDefinition"];
+  public connectionTypeRules: string[] = ["ContractDefinition"];
 
   constructor(
     usingForDeclaration: UsingForDeclaration,
@@ -36,13 +36,13 @@ export class UsingForDeclarationNode extends Node {
           column:
             usingForDeclaration.loc.start.column +
             "using ".length +
-            (this.getName()?.length || 0),
+            (this.getName()?.length ?? 0),
         },
       };
     }
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/VariableDeclarationNode.ts
+++ b/server/src/parser/analyzer/nodes/VariableDeclarationNode.ts
@@ -8,9 +8,9 @@ import {
 } from "@common/types";
 
 export class VariableDeclarationNode extends AbstractVariableDeclarationNode {
-  astNode: VariableDeclaration;
+  public astNode: VariableDeclaration;
 
-  connectionTypeRules: string[] = [
+  public connectionTypeRules: string[] = [
     "Identifier",
     "MemberAccess",
     "AssemblyCall",
@@ -27,11 +27,14 @@ export class VariableDeclarationNode extends AbstractVariableDeclarationNode {
       uri,
       rootPath,
       documentsAnalyzer,
-      variableDeclaration.name || undefined
+      variableDeclaration.name ?? undefined
     );
     this.astNode = variableDeclaration;
 
-    if (variableDeclaration.identifier?.loc && variableDeclaration.name) {
+    if (
+      variableDeclaration.identifier?.loc &&
+      variableDeclaration.name !== null
+    ) {
       this.nameLoc = {
         start: {
           line: variableDeclaration.identifier.loc.start.line,
@@ -49,11 +52,11 @@ export class VariableDeclarationNode extends AbstractVariableDeclarationNode {
     this.astNode.loc = this.nameLoc;
   }
 
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return this;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
@@ -77,12 +80,14 @@ export class VariableDeclarationNode extends AbstractVariableDeclarationNode {
 
       // Find Type of declaration skip MappingNode, ArrayTypeNameNode, FunctionTypeNameNode
       while (
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         typeNode &&
         !["UserDefinedTypeName", "ElementaryTypeName"].includes(typeNode.type)
       ) {
         typeNode = typeNode.typeNodes[0];
       }
 
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       if (typeNode) {
         typeNode.setDeclarationNode(this);
       }

--- a/server/src/parser/analyzer/nodes/VariableDeclarationStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/VariableDeclarationStatementNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class VariableDeclarationStatementNode extends Node {
-  astNode: VariableDeclarationStatement;
+  public astNode: VariableDeclarationStatement;
 
   constructor(
     variableDeclarationStatement: VariableDeclarationStatement,
@@ -24,11 +24,11 @@ export class VariableDeclarationStatementNode extends Node {
     this.astNode = variableDeclarationStatement;
   }
 
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return this;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/nodes/WhileStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/WhileStatementNode.ts
@@ -6,7 +6,7 @@ import {
 } from "@common/types";
 
 export class WhileStatementNode extends Node {
-  astNode: WhileStatement;
+  public astNode: WhileStatement;
 
   constructor(
     whileStatement: WhileStatement,
@@ -18,11 +18,11 @@ export class WhileStatementNode extends Node {
     this.astNode = whileStatement;
   }
 
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return undefined;
   }
 
-  accept(
+  public accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,

--- a/server/src/parser/analyzer/utils/lookups.ts
+++ b/server/src/parser/analyzer/utils/lookups.ts
@@ -1,6 +1,6 @@
-import { isFunctionDefinitionNode } from "./typeGuards";
 import { ContractDefinitionNode } from "../nodes/ContractDefinitionNode";
 import { FunctionDefinitionNode } from "../nodes/FunctionDefinitionNode";
+import { isFunctionDefinitionNode } from "./typeGuards";
 
 export function lookupConstructorFor(
   contractDefinition: ContractDefinitionNode

--- a/server/src/parser/analyzer/utils/typeGuards.ts
+++ b/server/src/parser/analyzer/utils/typeGuards.ts
@@ -10,10 +10,6 @@ import {
   Mapping,
   EmptyNodeType,
 } from "@common/types";
-import { ContractDefinitionNode } from "../nodes/ContractDefinitionNode";
-import { FunctionDefinitionNode } from "../nodes/FunctionDefinitionNode";
-import { MemberAccessNode } from "../nodes/MemberAccessNode";
-import { FunctionCallNode } from "../nodes/FunctionCallNode";
 import {
   ArrayTypeName,
   BaseASTNode,
@@ -24,6 +20,10 @@ import {
   VariableDeclaration,
 } from "@solidity-parser/parser/dist/src/ast-types";
 import { ElementaryTypeNameNode } from "@analyzer/nodes/ElementaryTypeNameNode";
+import { ContractDefinitionNode } from "../nodes/ContractDefinitionNode";
+import { FunctionDefinitionNode } from "../nodes/FunctionDefinitionNode";
+import { MemberAccessNode } from "../nodes/MemberAccessNode";
+import { FunctionCallNode } from "../nodes/FunctionCallNode";
 
 export function isContractDefinition(
   node: ASTNode

--- a/server/src/parser/common/event/index.ts
+++ b/server/src/parser/common/event/index.ts
@@ -1,6 +1,6 @@
-export type IndexFileData = {
+export interface IndexFileData {
   jobId: number;
   path: string;
   current: number;
   total: number;
-};
+}

--- a/server/src/parser/common/types/index.ts
+++ b/server/src/parser/common/types/index.ts
@@ -352,10 +352,10 @@ export interface Searcher {
 }
 
 export enum SolFileState {
-  Unloaded = "Unloaded",
-  Dirty = "Dirty",
-  Analyzed = "Analyzed",
-  Errored = "Errored",
+  UNLOADED = "UNLOADED",
+  DIRTY = "DIRTY",
+  ANALYZED = "ANALYZED",
+  ERRORED = "ERRORED",
 }
 
 export type SolProjectType = "hardhat" | "none";
@@ -370,9 +370,9 @@ export interface ISolProject {
   workspaceFolder: WorkspaceFolder;
 }
 
-export type SolProjectMap = {
+export interface SolProjectMap {
   [key: string]: ISolProject;
-};
+}
 
 export interface ISolFileEntry {
   /**
@@ -445,62 +445,62 @@ export type FinderType = (
 /**
  * documentsAnalyzer Map { [uri: string]: DocumentAnalyzer } have all documentsAnalyzer class instances used for handle imports on first project start.
  */
-export type DocumentsAnalyzerMap = {
+export interface DocumentsAnalyzerMap {
   [uri: string]: ISolFileEntry | undefined;
-};
+}
 
-export type EmptyNodeType = {
+export interface EmptyNodeType {
   type: "Empty";
   range?: [number, number];
   loc?: Location;
-};
+}
 
 export abstract class Node {
   /**
    * AST node type.
    */
-  type: string;
+  public type: string;
 
   /**
    * The path to the {@link Node} file.
    * URI need to be decoded and without "file://" prefix.
    * To get that format of uri you can use decodeUriAndRemoveFilePrefix in @common/util
    */
-  uri: string;
+  public uri: string;
 
   /**
    * The rootPath of the workspace where this Node belongs.
    */
-  rootPath: string;
+  public rootPath: string;
 
-  readonly documentsAnalyzer: DocumentsAnalyzerMap;
+  public readonly documentsAnalyzer: DocumentsAnalyzerMap;
 
   /**
    * AST node interface.
    */
-  abstract astNode: BaseASTNode | EmptyNodeType;
+  public abstract astNode: BaseASTNode | EmptyNodeType;
 
   /**
    * Represents is node alive or not. If it isn't alive we need to remove it, because if we don't
    * remove the dead nodes, we can have references to code that doesn't exist. Default is true and
    * default implementations of the removeChildren will set isAlive to false.
    */
-  isAlive = true;
+  public isAlive = true;
 
   /**
    * Exact name Location of Node used for rename and search node by name.
    */
-  nameLoc?: Location | undefined;
+  public nameLoc?: Location | undefined;
 
   /**
    * Node name. Name can be undefined for Nodes that don't have a name.
    */
-  name: string | undefined;
+  public name: string | undefined;
 
   /**
    * Import alias name. If the aliasName exists he is the real name and {@link Node.getName getName} will return the alias.
    */
-  aliasName?: string | undefined;
+  public aliasName?: string | undefined;
 
   /**
    * Serves to let us know if there is a Node expression like FunctionCallNode, ArrayTypeNameNode...
@@ -512,32 +512,32 @@ export abstract class Node {
    * This will be needed for autocomplete because we need to know if some Node expression
    * might be a FunctionCallNode and then we know that Node needs brackets.
    */
-  expressionNode?: Node | undefined;
+  public expressionNode?: Node | undefined;
   /**
    * Serves to let us know who is declaration of some type Node this is the reverse of getTypeNodes.
    */
-  declarationNode?: Node | undefined;
+  public declarationNode?: Node | undefined;
 
   /**
    * Rules for declaration nodes that must be met in order for nodes to be connected.
    */
-  connectionTypeRules: string[] = [];
+  public connectionTypeRules: string[] = [];
 
   /**
    * Node parent. Can be undefined for root or orphan Node.
    */
-  parent?: Node | undefined;
+  public parent?: Node | undefined;
   /**
    * Node children.
    */
-  children: Node[] = [];
+  public children: Node[] = [];
 
   /**
    * Node types.
    * Example: uint256 num; uint256 will be typeNode for VariableDeclarationNode num
    * TypeNodes is an array because some declaration can have more than one types like function.
    */
-  typeNodes: Node[] = [];
+  public typeNodes: Node[] = [];
 
   /**
    * Base Node constructor
@@ -561,7 +561,7 @@ export abstract class Node {
   /**
    * Return Nodes that are the type definition of the Node
    */
-  getTypeNodes(): Node[] {
+  public getTypeNodes(): Node[] {
     let nodes: Node[] = [];
 
     this.typeNodes.forEach((typeNode) => {
@@ -575,12 +575,12 @@ export abstract class Node {
    * If node alerdy exists in the {@link Node.typeNodes typeNodes}, the old node will be removed, and new node will be added.
    * In that way we secure that we alwes have the latast node references in our {@link Node.typeNodes typeNodes}.
    */
-  addTypeNode(node: Node): void {
-    const typeNodeExist = this.typeNodes.filter((typeNode) =>
+  public addTypeNode(node: Node): void {
+    const typeNodeExist: Node | undefined = this.typeNodes.filter((typeNode) =>
       isNodeEqual(typeNode, node)
     )[0];
 
-    if (typeNodeExist) {
+    if (typeNodeExist !== undefined) {
       const index = this.typeNodes.indexOf(typeNodeExist);
       this.typeNodes.splice(index, 1);
     }
@@ -592,37 +592,37 @@ export abstract class Node {
    * An {@link Node.expressionNode expressionNode} is a Node above the current Node by AST.
    * @returns ExpressionNode if exist otherwise undefined
    */
-  getExpressionNode(): Node | undefined {
+  public getExpressionNode(): Node | undefined {
     return this.expressionNode;
   }
 
-  setExpressionNode(node: Node | undefined): void {
+  public setExpressionNode(node: Node | undefined): void {
     this.expressionNode = node;
   }
 
   /**
    * Return Node that are the definition of the Node if definition exists.
    */
-  getDefinitionNode(): Node | undefined {
+  public getDefinitionNode(): Node | undefined {
     return this.parent?.getDefinitionNode();
   }
 
-  getDeclarationNode(): Node | undefined {
+  public getDeclarationNode(): Node | undefined {
     return this.declarationNode;
   }
 
-  setDeclarationNode(node: Node | undefined): void {
+  public setDeclarationNode(node: Node | undefined): void {
     this.declarationNode = node;
   }
 
   /**
    * A Node name can be undefined for Nodes that don't have a name.
    */
-  getName(): string | undefined {
+  public getName(): string | undefined {
     return this.name;
   }
 
-  setName(name: string): void {
+  public setName(name: string): void {
     this.name = name;
   }
 
@@ -630,23 +630,23 @@ export abstract class Node {
    * A Node alias name can be undefined for Nodes that don't declared with alias name.
    * If the aliasName exists he is the real name and {@link Node.getName getName} will return the alias.
    */
-  getAliasName(): string | undefined {
+  public getAliasName(): string | undefined {
     return this.aliasName;
   }
 
-  setAliasName(aliasName: string | undefined): void {
+  public setAliasName(aliasName: string | undefined): void {
     this.aliasName = aliasName;
   }
 
   /**
    * If a child already exists in the {@link Node.children children}, it will not be added.
    */
-  addChild(child: Node): void {
-    const childExist = this.children.filter((tmpChild) =>
+  public addChild(child: Node): void {
+    const childExist: Node | undefined = this.children.filter((tmpChild) =>
       isNodeEqual(tmpChild, child)
     )[0];
 
-    if (!childExist) {
+    if (childExist === undefined) {
       this.children.push(child);
     }
   }
@@ -655,7 +655,7 @@ export abstract class Node {
    * Note that removeChild will set {@link Node.isAlive isAlive} to false for the removed child
    * @param child Child who you want to remove
    */
-  removeChild(child: Node): void {
+  public removeChild(child: Node): void {
     const index = this.children.indexOf(child, 0);
 
     if (index > -1) {
@@ -665,11 +665,11 @@ export abstract class Node {
     child.isAlive = false;
   }
 
-  setParent(parent: Node | undefined): void {
+  public setParent(parent: Node | undefined): void {
     this.parent = parent;
   }
 
-  getParent(): Node | undefined {
+  public getParent(): Node | undefined {
     return this.parent;
   }
 
@@ -682,7 +682,7 @@ export abstract class Node {
    *
    * @returns Child node in AST.
    */
-  abstract accept(
+  public abstract accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
@@ -691,7 +691,7 @@ export abstract class Node {
 }
 
 export class EmptyNode extends Node {
-  astNode: EmptyNodeType;
+  public astNode: EmptyNodeType;
 
   constructor(
     emptyNode: EmptyNodeType,
@@ -703,7 +703,7 @@ export class EmptyNode extends Node {
     this.astNode = emptyNode;
   }
 
-  accept(
+  public accept(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     find: FinderType,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -721,20 +721,20 @@ export abstract class ContractDefinitionNode extends Node {
   /**
    * AST ContractDefinition interface.
    */
-  abstract astNode: ContractDefinition;
+  public abstract astNode: ContractDefinition;
 
-  inheritanceNodes: ContractDefinitionNode[] = [];
+  public inheritanceNodes: ContractDefinitionNode[] = [];
 
   /**
    * Kind can be "abstract" | "contract" | "library" | "interface".
    * @returns Contract kind.
    */
-  abstract getKind(): string;
+  public abstract getKind(): string;
 
   /**
    * @returns inherited Nodes
    */
-  getInheritanceNodes(): ContractDefinitionNode[] {
+  public getInheritanceNodes(): ContractDefinitionNode[] {
     return this.inheritanceNodes;
   }
 }
@@ -743,18 +743,18 @@ export abstract class MemberAccessNode extends Node {
   /**
    * AST MemberAccess interface.
    */
-  abstract astNode: MemberAccess;
+  public abstract astNode: MemberAccess;
 
-  previousMemberAccessNode: Node | undefined;
+  public previousMemberAccessNode: Node | undefined;
 
-  setPreviousMemberAccessNode(node: Node): void {
+  public setPreviousMemberAccessNode(node: Node): void {
     this.previousMemberAccessNode = node;
   }
 
   /**
    * @returns get previous MemberAccessNode
    */
-  getPreviousMemberAccessNode(): Node | undefined {
+  public getPreviousMemberAccessNode(): Node | undefined {
     return this.previousMemberAccessNode;
   }
 }
@@ -763,26 +763,26 @@ export abstract class ImportDirectiveNode extends Node {
   /**
    * AST ImportDirective interface.
    */
-  abstract astNode: ImportDirective;
+  public abstract astNode: ImportDirective;
 
   /**
    * The path to the file.
    * But in this case, realUri will be the URI of the file in which the import is declared.
    * And {@link Node.uri uri} will be a path to imported Node.
    */
-  abstract realUri: string;
+  public abstract realUri: string;
 
-  aliasNodes: Node[] = [];
+  public aliasNodes: Node[] = [];
 
-  getImportPath(): string | undefined {
+  public getImportPath(): string | undefined {
     return this.uri;
   }
 
-  addAliasNode(aliasNode: Node): void {
+  public addAliasNode(aliasNode: Node): void {
     this.aliasNodes.push(aliasNode);
   }
 
-  getAliasNodes(): Node[] {
+  public getAliasNodes(): Node[] {
     return this.aliasNodes;
   }
 }
@@ -791,30 +791,30 @@ export abstract class SourceUnitNode extends Node {
   /**
    * AST SourceUnit interface.
    */
-  abstract astNode: SourceUnit;
+  public abstract astNode: SourceUnit;
 
-  importNodes: Node[] = [];
-  exportNodes: Node[] = [];
+  public importNodes: Node[] = [];
+  public exportNodes: Node[] = [];
 
-  addImportNode(importNode: Node): void {
+  public addImportNode(importNode: Node): void {
     this.importNodes.push(importNode);
   }
 
   /**
    * @returns all imported Nodes in this SourceUint.
    */
-  getImportNodes(): Node[] {
+  public getImportNodes(): Node[] {
     return this.importNodes;
   }
 
-  addExportNode(exportNode: Node): void {
+  public addExportNode(exportNode: Node): void {
     this.exportNodes.push(exportNode);
   }
 
   /**
    * @returns all exported Nodes from this SourceUint.
    */
-  getExportNodes(): Node[] {
+  public getExportNodes(): Node[] {
     return this.exportNodes;
   }
 }
@@ -823,16 +823,16 @@ export abstract class FunctionDefinitionNode extends Node {
   /**
    * AST FunctionDefinition interface.
    */
-  abstract astNode: FunctionDefinition;
+  public abstract astNode: FunctionDefinition;
 
-  isConstructor = false;
+  public isConstructor = false;
 
   /**
    * Visibility can be 'default' | 'external' | 'internal' | 'public' | 'private'
    *
    * @returns function visibility.
    */
-  getVisibility(): string {
+  public getVisibility(): string {
     return this.astNode.visibility;
   }
 }
@@ -841,14 +841,14 @@ export abstract class VariableDeclarationNode extends Node {
   /**
    * AST VariableDeclaration interface.
    */
-  abstract astNode: VariableDeclaration;
+  public abstract astNode: VariableDeclaration;
 
   /**
    * Visibility can be 'public' | 'private' | 'internal' | 'default'
    *
    * @returns function visibility.
    */
-  getVisibility(): string | undefined {
+  public getVisibility(): string | undefined {
     return this.astNode.visibility;
   }
 }
@@ -857,11 +857,11 @@ export abstract class IdentifierNode extends Node {
   /**
    * AST Identifier interface.
    */
-  abstract astNode: Identifier;
+  public abstract astNode: Identifier;
 
-  identifierFields: Node[] = [];
+  public identifierFields: Node[] = [];
 
-  getIdentifierFields(): Node[] {
+  public getIdentifierFields(): Node[] {
     return this.identifierFields;
   }
 
@@ -869,7 +869,7 @@ export abstract class IdentifierNode extends Node {
    * This is the place for all nonhandled identifier fileds like FunctionCallNode identifiers,
    * that we want to handle after when this node gets a parent.
    */
-  addIdentifierField(identifierField: Node): void {
+  public addIdentifierField(identifierField: Node): void {
     this.identifierFields.push(identifierField);
   }
 }

--- a/server/src/parser/common/utils/index.ts
+++ b/server/src/parser/common/utils/index.ts
@@ -15,11 +15,11 @@ import {
   isMemberAccessNode,
 } from "@analyzer/utils/typeGuards";
 
-type FindUpOptions = {
+interface FindUpOptions {
   cwd?: string;
   stopAt?: string;
   fullPath?: boolean;
-};
+}
 
 export function findUpSync(
   fileName: string,
@@ -28,10 +28,12 @@ export function findUpSync(
   if (!options) {
     options = {};
   }
-  options.cwd = options.cwd ? path.resolve(options.cwd) : process.cwd();
-  options.stopAt = options.stopAt
-    ? path.resolve(options.stopAt)
-    : path.parse(process.cwd()).root;
+  options.cwd =
+    options.cwd !== undefined ? path.resolve(options.cwd) : process.cwd();
+  options.stopAt =
+    options.stopAt !== undefined
+      ? path.resolve(options.stopAt)
+      : path.parse(process.cwd()).root;
 
   if (!options.cwd.includes(options.stopAt)) {
     return undefined;
@@ -46,7 +48,7 @@ export function findUpSync(
     directory = path.resolve(directory, "..");
   }
 
-  if (options.fullPath) {
+  if (options.fullPath !== undefined) {
     return path.join(directory, fileName);
   }
 
@@ -80,10 +82,7 @@ export function getRange(loc: Location): Range {
  */
 export function isNodePosition(node: Node, position: Position): boolean {
   if (
-    position &&
     node.nameLoc &&
-    node.nameLoc.start &&
-    node.nameLoc.end &&
     node.nameLoc.start.line === position.line &&
     node.nameLoc.end.line === position.line &&
     node.nameLoc.start.column <= position.column &&
@@ -128,7 +127,6 @@ export function isPositionShadowedByNode(
   node: Node | undefined
 ): boolean {
   if (
-    position &&
     node?.astNode.loc &&
     ((node.astNode.loc.start.line < position.line &&
       node.astNode.loc.end.line > position.line) ||
@@ -160,7 +158,7 @@ export function isNodeConnectable(
   const childName = child.getName();
   const childAlias = child.getAliasName();
 
-  if (!parentName || !childName) {
+  if (parentName === undefined || childName === undefined) {
     return false;
   }
 
@@ -170,7 +168,7 @@ export function isNodeConnectable(
 
   if (
     !parent.connectionTypeRules.includes(child.type) &&
-    !parent.connectionTypeRules.includes(child.getExpressionNode()?.type || "")
+    !parent.connectionTypeRules.includes(child.getExpressionNode()?.type ?? "")
   ) {
     return false;
   }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -2,8 +2,6 @@ import { Connection } from "vscode-languageserver";
 import { TextDocuments } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { Logger } from "@utils/Logger";
-import { Telemetry } from "./telemetry/types";
-import { ServerState } from "./types";
 import { WorkspaceFileRetriever } from "@analyzer/WorkspaceFileRetriever";
 import { onHover } from "@services/hover/onHover";
 import { onInitialize } from "@services/initialization/onInitialize";
@@ -19,10 +17,14 @@ import { onImplementation } from "@services/implementation/onImplementation";
 import { onRename } from "@services/rename/onRename";
 import { onDidChangeContent } from "@services/validation/onDidChangeContent";
 import { RequestType } from "vscode-languageserver-protocol";
-import { decodeUriAndRemoveFilePrefix, toUnixStyle } from "./utils";
 import path = require("path");
+import { decodeUriAndRemoveFilePrefix, toUnixStyle } from "./utils";
+import { ServerState } from "./types";
+import { Telemetry } from "./telemetry/types";
 
-export type GetSolFileDetailsParams = { uri: string };
+export interface GetSolFileDetailsParams {
+  uri: string;
+}
 export type GetSolFileDetailsResponse =
   | { found: false }
   | { found: true; hardhat: false }

--- a/server/src/services/codeactions/QuickFixResolver.ts
+++ b/server/src/services/codeactions/QuickFixResolver.ts
@@ -1,7 +1,7 @@
 import { CodeAction, Diagnostic } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { compilerDiagnostics } from "@compilerDiagnostics/compilerDiagnostics";
-import { ServerState } from "types";
+import { ServerState } from "../../types";
 
 export function resolveQuickFixes(
   serverState: ServerState,
@@ -32,7 +32,7 @@ function resolveActionsFor(
   diagnostic: Diagnostic,
   { document, uri }: { document: TextDocument; uri: string }
 ): CodeAction[] {
-  if (diagnostic && diagnostic.code && diagnostic.code in compilerDiagnostics) {
+  if (diagnostic.code !== undefined && diagnostic.code in compilerDiagnostics) {
     return compilerDiagnostics[diagnostic.code].resolveActions(
       serverState,
       diagnostic,

--- a/server/src/services/codeactions/onCodeAction.ts
+++ b/server/src/services/codeactions/onCodeAction.ts
@@ -1,6 +1,6 @@
 import { CodeActionParams, CodeAction } from "vscode-languageserver/node";
-import { resolveQuickFixes } from "./QuickFixResolver";
 import { ServerState } from "../../types";
+import { resolveQuickFixes } from "./QuickFixResolver";
 
 export function onCodeAction(serverState: ServerState) {
   return (params: CodeActionParams): CodeAction[] => {

--- a/server/src/services/completion/defaultCompletion.ts
+++ b/server/src/services/completion/defaultCompletion.ts
@@ -175,7 +175,9 @@ const globalFunctions = [
   "selfdestruct",
 ];
 
-type GlobalVariablesType = { [globalVariable: string]: string[] };
+interface GlobalVariablesType {
+  [globalVariable: string]: string[];
+}
 export const globalVariables: GlobalVariablesType = {
   abi: [
     "decode",

--- a/server/src/services/completion/getImportPathCompletion.ts
+++ b/server/src/services/completion/getImportPathCompletion.ts
@@ -1,7 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as lsp from "vscode-languageserver/node";
-import { toUnixStyle } from "../../utils/index";
 import {
   CompletionItem,
   CompletionItemKind,
@@ -10,6 +9,7 @@ import {
   VSCodePosition,
 } from "@common/types";
 import { Logger } from "@utils/Logger";
+import { toUnixStyle } from "../../utils/index";
 import { ProjectContext } from "./types";
 
 export function getImportPathCompletion(
@@ -73,7 +73,7 @@ function getRelativeImportPathCompletions(
     partial = "";
   } else {
     importDir = path.dirname(importPath);
-    partial = importPath.replace(importDir + "/", "");
+    partial = importPath.replace(`${importDir}/`, "");
 
     if (!fs.existsSync(importDir)) {
       return [];
@@ -114,7 +114,7 @@ function getIndexedNodeModuleFolderCompletions(
 }
 
 function replaceFor(
-  path: string,
+  filePath: string,
   position: VSCodePosition,
   currentImport: string
 ) {
@@ -125,7 +125,7 @@ function replaceFor(
 
   return lsp.TextEdit.replace(
     lsp.Range.create(startingPosition, position),
-    path
+    filePath
   );
 }
 

--- a/server/src/services/completion/types.ts
+++ b/server/src/services/completion/types.ts
@@ -1,6 +1,6 @@
 import { DocumentsAnalyzerMap, ISolProject } from "@common/types";
 
-export type ProjectContext = {
+export interface ProjectContext {
   project: ISolProject;
   solFileIndex: DocumentsAnalyzerMap;
-};
+}

--- a/server/src/services/hover/onHover.ts
+++ b/server/src/services/hover/onHover.ts
@@ -4,11 +4,11 @@ import {
 } from "@analyzer/utils/typeGuards";
 import { getParserPositionFromVSCodePosition } from "@common/utils";
 import { HoverParams, Hover } from "vscode-languageserver/node";
-import { ServerState } from "../../types";
 import { ISolFileEntry, IdentifierNode, MemberAccessNode } from "@common/types";
+import { onCommand } from "@utils/onCommand";
+import { ServerState } from "../../types";
 import { astToText } from "./utils/astToText";
 import { textToHover } from "./utils/textTohover";
-import { onCommand } from "@utils/onCommand";
 
 export function onHover(serverState: ServerState) {
   return (params: HoverParams): Hover | null => {

--- a/server/src/services/hover/utils/astToText.ts
+++ b/server/src/services/hover/utils/astToText.ts
@@ -53,7 +53,7 @@ export function variableDeclarationToText(variable: VariableDeclaration) {
   const visibility =
     variable.visibility === "default" ? null : variable.visibility;
 
-  const constant = variable.isDeclaredConst ? "constant" : null;
+  const constant = variable.isDeclaredConst === true ? "constant" : null;
 
   const storageLocation = variable.storageLocation;
 

--- a/server/src/services/initialization/indexWorkspaceFolders.ts
+++ b/server/src/services/initialization/indexWorkspaceFolders.ts
@@ -2,7 +2,6 @@ import * as path from "path";
 import { IndexFileData } from "@common/event";
 import { Logger } from "@utils/Logger";
 import { WorkspaceFolder } from "vscode-languageserver-protocol";
-import { decodeUriAndRemoveFilePrefix, toUnixStyle } from "../../utils/index";
 import { Connection } from "vscode-languageserver";
 import { WorkspaceFileRetriever } from "@analyzer/WorkspaceFileRetriever";
 import { SolFileEntry } from "@analyzer/SolFileEntry";
@@ -11,16 +10,17 @@ import { getDocumentAnalyzer } from "@utils/getDocumentAnalyzer";
 import { analyzeSolFile } from "@analyzer/analyzeSolFile";
 import { HardhatProject } from "@analyzer/HardhatProject";
 import { findProjectFor } from "@utils/findProjectFor";
+import { decodeUriAndRemoveFilePrefix, toUnixStyle } from "../../utils/index";
 import { resolveTopLevelWorkspaceFolders } from "./resolveTopLevelWorkspaceFolders";
 
-export type IndexWorkspaceFoldersContext = {
+export interface IndexWorkspaceFoldersContext {
   indexJobCount: number;
   connection: Connection;
   solFileIndex: DocumentsAnalyzerMap;
   workspaceFolders: WorkspaceFolder[];
   projects: SolProjectMap;
   logger: Logger;
-};
+}
 
 export async function indexWorkspaceFolders(
   indexWorkspaceFoldersContext: IndexWorkspaceFoldersContext,

--- a/server/src/services/initialization/onInitialize.ts
+++ b/server/src/services/initialization/onInitialize.ts
@@ -50,8 +50,8 @@ export const onInitialize = (serverState: ServerState) => {
 
         workspace: {
           workspaceFolders: {
-            supported: true,
-            changeNotifications: true,
+            supported: false,
+            changeNotifications: false,
           },
         },
       },
@@ -61,6 +61,7 @@ export const onInitialize = (serverState: ServerState) => {
       result.capabilities.workspace = {
         workspaceFolders: {
           supported: true,
+          changeNotifications: true,
         },
       };
     }
@@ -92,10 +93,9 @@ function updateServerStateFromParams(
 
   serverState.workspaceFolders = params.workspaceFolders ?? [];
 
-  serverState.hasWorkspaceFolderCapability = !!(
-    params.capabilities.workspace &&
-    !!params.capabilities.workspace.workspaceFolders
-  );
+  serverState.hasWorkspaceFolderCapability =
+    params.capabilities.workspace !== undefined &&
+    params.capabilities.workspace.workspaceFolders !== undefined;
 }
 
 function logInitializationInfo(
@@ -115,10 +115,11 @@ function logInitializationInfo(
   logger.info(`  Release: ${extensionName}@${extensionVersion}`);
   logger.info(`  Environment: ${serverState.env}`);
   logger.info(`  Telemetry Enabled: ${serverState.globalTelemetryEnabled}`);
-  if (machineId) {
+
+  if (machineId !== undefined) {
     logger.info(
       `  Telemetry Tracking Id: ${
-        machineId.length > 10 ? machineId.substring(0, 10) + "..." : machineId
+        machineId.length > 10 ? `${machineId.substring(0, 10)}...` : machineId
       }`
     );
   }

--- a/server/src/services/rename/onRename.ts
+++ b/server/src/services/rename/onRename.ts
@@ -1,6 +1,5 @@
 import { onCommand } from "@utils/onCommand";
 import { RenameParams } from "vscode-languageserver/node";
-import { ServerState } from "../../types";
 import { isFunctionDefinitionNode } from "@analyzer/utils/typeGuards";
 import {
   VSCodePosition,
@@ -12,6 +11,7 @@ import {
 
 import { getParserPositionFromVSCodePosition, getRange } from "@common/utils";
 import { findReferencesFor } from "@utils/findReferencesFor";
+import { ServerState } from "../../types";
 import { convertHardhatUriToVscodeUri } from "../../utils/index";
 
 export const onRename = (serverState: ServerState) => {
@@ -90,7 +90,10 @@ function convertRefNodesToUpdates(referenceNodes: Node[], newName: string) {
 
     const uri = convertHardhatUriToVscodeUri(potentialUpdate.uri);
 
-    if (workspaceEdit.changes && !workspaceEdit.changes[uri]) {
+    if (
+      workspaceEdit.changes !== undefined &&
+      !(uri in workspaceEdit.changes)
+    ) {
       workspaceEdit.changes[uri] = [];
     }
 
@@ -103,19 +106,19 @@ function convertRefNodesToUpdates(referenceNodes: Node[], newName: string) {
   return workspaceEdit;
 }
 
-function isConstructorContractModifier(initialRenameNode: Node) {
+function isConstructorContractModifier(initialRenameNode: Node): boolean {
   return (
     initialRenameNode.type === "ModifierInvocation" &&
-    initialRenameNode.parent &&
+    initialRenameNode.parent !== undefined &&
     isFunctionDefinitionNode(initialRenameNode.parent) &&
     initialRenameNode.parent.isConstructor
   );
 }
 
-function isFunctionOverrideContractSymbol(initialRenameNode: Node) {
+function isFunctionOverrideContractSymbol(initialRenameNode: Node): boolean {
   return (
     initialRenameNode.type === "UserDefinedTypeName" &&
-    initialRenameNode.parent &&
+    initialRenameNode.parent !== undefined &&
     isFunctionDefinitionNode(initialRenameNode.parent) &&
     initialRenameNode.parent.isConstructor
   );

--- a/server/src/services/validation/convertHardhatErrorToDiagnostic.ts
+++ b/server/src/services/validation/convertHardhatErrorToDiagnostic.ts
@@ -4,7 +4,7 @@ import { TextDocument } from "vscode-languageserver-textdocument";
 type ImportLineErrorCode = 404 | 405 | 406 | 407 | 408 | 409;
 const IMPORT_LINE_ERROR_CODES = [404, 405, 406, 407, 408, 409];
 
-type HardhatImportLineError = {
+interface HardhatImportLineError {
   errorDescriptor: {
     number: ImportLineErrorCode;
     title: string;
@@ -13,15 +13,15 @@ type HardhatImportLineError = {
   messageArguments: {
     imported: string;
   };
-};
+}
 
-type UnknownHardhatError = {
+interface UnknownHardhatError {
   errorDescriptor: {
     number: number;
     title: string;
     description: string;
   };
-};
+}
 
 type HardhatError = UnknownHardhatError | HardhatImportLineError;
 

--- a/server/src/services/validation/helper.ts
+++ b/server/src/services/validation/helper.ts
@@ -11,6 +11,7 @@ export const SOLIDITY_COMPILE_EVENT = "solidity_compile";
 export const HARDHAT_CONFIG_FILE_EXIST_EVENT = "hardhat_config_file_exist";
 export const HARDHAT_PROCESS_ERROR = "error";
 
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
 (async () => {
   // TypeScript forces to check send method on existence
   if (!process.send) {
@@ -31,14 +32,14 @@ export const HARDHAT_PROCESS_ERROR = "error";
     });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    process.on("message", (data: any) => {
-      switch (data.type) {
+    process.on("message", (message: any) => {
+      switch (message.type) {
         case GET_DOCUMENT_EVENT:
-          getDocumentPromisePromiseResolver(data.data);
+          getDocumentPromisePromiseResolver(message.data);
           break;
 
         case SOLIDITY_COMPILE_CONFIRMATION_EVENT:
-          solidityCompileConfirmationPromiseResolver(data);
+          solidityCompileConfirmationPromiseResolver(message);
           break;
 
         default:
@@ -52,7 +53,7 @@ export const HARDHAT_PROCESS_ERROR = "error";
     let hre;
     const uri: string = data.uri;
     const documentText: string = data.documentText;
-    const unsavedDocuments: { uri: string; documentText: string }[] =
+    const unsavedDocuments: Array<{ uri: string; documentText: string }> =
       data.unsavedDocuments;
 
     let hardhatBase = "";
@@ -169,7 +170,7 @@ export const HARDHAT_PROCESS_ERROR = "error";
 
     // download solc version and compile files
     const { output } = await hre.run(TASK_COMPILE_SOLIDITY_COMPILE, {
-      solcVersion: solcVersion,
+      solcVersion,
       input,
       quiet: true,
       compilationJob,

--- a/server/src/telemetry/types.ts
+++ b/server/src/telemetry/types.ts
@@ -1,4 +1,4 @@
-import { Transaction } from "@sentry/types";
+import type { Transaction } from "@sentry/types";
 import { ServerState } from "../types";
 
 export interface Telemetry {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -2,11 +2,11 @@ import { Connection } from "vscode-languageserver";
 import * as childProcess from "child_process";
 import { TextDocuments } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { Telemetry } from "telemetry/types";
 import { Logger } from "@utils/Logger";
 import { WorkspaceFolder } from "vscode-languageserver-protocol";
 import { DocumentsAnalyzerMap, SolProjectMap, Diagnostic } from "@common/types";
 import { HardhatProject } from "@analyzer/HardhatProject";
+import { Telemetry } from "./telemetry/types";
 
 export type CancelResolver = (diagnostics: {
   [key: string]: Diagnostic[];
@@ -30,7 +30,7 @@ export type CompilerProcessFactory = (
   logger: Logger
 ) => CompilerProcess;
 
-export type ServerState = {
+export interface ServerState {
   env: "production" | "development";
   hasWorkspaceFolderCapability: boolean;
 
@@ -48,4 +48,4 @@ export type ServerState = {
 
   telemetry: Telemetry;
   logger: Logger;
-};
+}

--- a/server/src/utils/PrettyPrinter.ts
+++ b/server/src/utils/PrettyPrinter.ts
@@ -3,7 +3,7 @@ import * as prettierPluginSolidity from "prettier-plugin-solidity";
 import { ASTNode, TextDocument } from "@common/types";
 
 export class PrettyPrinter {
-  options: prettier.Options;
+  private options: prettier.Options;
 
   constructor() {
     this.options = {
@@ -12,18 +12,18 @@ export class PrettyPrinter {
     };
   }
 
-  format(text: string, { document }: { document: TextDocument }) {
-    const options = this.mergeOptions(document);
+  public format(text: string, { document }: { document: TextDocument }) {
+    const options = this._mergeOptions(document);
 
     return prettier.format(text, options);
   }
 
-  formatAst(
+  public formatAst(
     ast: ASTNode,
     originalText: string,
     { document }: { document: TextDocument }
   ): string {
-    const options = this.mergeOptions(document);
+    const options = this._mergeOptions(document);
 
     // @ts-expect-error you bet __debug isn't on the type
     const { formatted } = prettier.__debug.formatAST(
@@ -38,7 +38,7 @@ export class PrettyPrinter {
     return formatted;
   }
 
-  private mergeOptions(document: TextDocument) {
+  private _mergeOptions(document: TextDocument) {
     const options = {
       parser: "solidity-parse",
       plugins: [prettierPluginSolidity],
@@ -49,7 +49,7 @@ export class PrettyPrinter {
         prettier.resolveConfig.sync(document.uri, {
           useCache: false,
           editorconfig: true,
-        }) ?? this.defaultConfig();
+        }) ?? this._defaultConfig();
 
       return {
         ...config,
@@ -57,13 +57,13 @@ export class PrettyPrinter {
       };
     } catch (err) {
       return {
-        ...this.defaultConfig(),
+        ...this._defaultConfig(),
         ...options,
       };
     }
   }
 
-  private defaultConfig() {
+  private _defaultConfig() {
     return {
       printWidth: 80,
       tabWidth: 4,

--- a/server/src/utils/applyEditToDocumentAnalyzer.ts
+++ b/server/src/utils/applyEditToDocumentAnalyzer.ts
@@ -1,9 +1,9 @@
-import { getUriFromDocument } from "./index";
-import { ServerState } from "../types";
-import { LookupResult } from "./lookupEntryForUri";
 import { TextDocument } from "@common/types";
 import { analyzeDocument } from "@utils/analyzeDocument";
 import { getDocumentAnalyzer } from "@utils/getDocumentAnalyzer";
+import { ServerState } from "../types";
+import { LookupResult } from "./lookupEntryForUri";
+import { getUriFromDocument } from "./index";
 
 export function applyEditToDocumentAnalyzer(
   serverState: ServerState,

--- a/server/src/utils/debounce.ts
+++ b/server/src/utils/debounce.ts
@@ -15,26 +15,26 @@ export const debounce = <F extends (...args: any[]) => ReturnType<F>>(
   wait: number,
   immediate?: boolean
 ) => {
-  let timeout: NodeJS.Timeout;
-  let previousArgs: IArguments;
+  let timeout: NodeJS.Timeout | null = null;
+  let previousArgs: IArguments | null = null;
 
   const debounced: DebouncedFunction = function (this: void) {
     const context = this;
     const args = arguments;
 
     const later = function () {
-      if (!immediate) {
+      if (immediate === undefined) {
         func.call(context, ...args);
       }
     };
 
-    const callNow = immediate && !timeout;
+    const callNow = immediate !== undefined && !timeout;
 
     if (timeout) {
       if (
         previousArgs &&
         previousArgs[0] &&
-        typeof previousArgs[0].close == "function"
+        typeof previousArgs[0].close === "function"
       ) {
         previousArgs[0].close();
       }
@@ -53,11 +53,13 @@ export const debounce = <F extends (...args: any[]) => ReturnType<F>>(
   debounced.cancel = function () {
     const args = arguments;
 
-    if (args[0] && typeof args[0].close == "function") {
+    if (args[0] && typeof args[0].close === "function") {
       args[0].close();
     }
 
-    clearTimeout(timeout);
+    if (timeout) {
+      clearTimeout(timeout);
+    }
   };
 
   return debounced as (...args: Parameters<F>) => ReturnType<F>;

--- a/server/src/utils/findReferencesFor.ts
+++ b/server/src/utils/findReferencesFor.ts
@@ -3,7 +3,7 @@ import { Node } from "@common/types";
 export function findReferencesFor(definitionNode: Node | undefined): Node[] {
   const nodeName = definitionNode?.getName();
 
-  if (!definitionNode || !nodeName) {
+  if (!definitionNode || nodeName === undefined) {
     return [];
   }
 

--- a/server/src/utils/getDocumentAnalyzer.ts
+++ b/server/src/utils/getDocumentAnalyzer.ts
@@ -29,12 +29,6 @@ export function getDocumentAnalyzer(
   if (!documentAnalyzer) {
     const project = findProjectFor({ projects }, uri);
 
-    if (!project) {
-      throw new Error(
-        "Document analyzer can't be retrieved as project base path not set."
-      );
-    }
-
     if (fs.existsSync(uri)) {
       const docText = fs.readFileSync(uri).toString();
       documentAnalyzer = SolFileEntry.createLoadedEntry(uri, project, docText);

--- a/server/src/utils/lookupEntryForUri.ts
+++ b/server/src/utils/lookupEntryForUri.ts
@@ -1,15 +1,15 @@
-import { getUriFromDocument } from "./index";
-import { ServerState } from "../types";
 import { ISolFileEntry } from "@common/types";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { getDocumentAnalyzer } from "@utils/getDocumentAnalyzer";
+import { ServerState } from "../types";
+import { getUriFromDocument } from "./index";
 
-export type LookupResult = {
+export interface LookupResult {
   found: boolean;
   errorMessage?: string;
   documentAnalyzer?: ISolFileEntry;
   document?: TextDocument;
-};
+}
 
 export function lookupEntryForUri(
   serverState: ServerState,

--- a/server/src/utils/serverStateUtils.ts
+++ b/server/src/utils/serverStateUtils.ts
@@ -2,9 +2,10 @@ import { ServerState } from "../types";
 
 export function isTelemetryEnabled(
   serverState: ServerState | undefined | null
-) {
+): boolean {
   return (
-    serverState &&
+    serverState !== undefined &&
+    serverState !== null &&
     serverState.globalTelemetryEnabled &&
     serverState.hardhatTelemetryEnabled
   );

--- a/server/test/helpers/setupMockCompilerProcessFactory.ts
+++ b/server/test/helpers/setupMockCompilerProcessFactory.ts
@@ -3,7 +3,7 @@ import * as sinon from "sinon";
 import { CompilerProcess } from "../../src/types";
 
 export function setupMockCompilerProcessFactory(
-  errors: {
+  errors: Array<{
     errorCode: string;
     severity: string;
     message: string;
@@ -12,7 +12,7 @@ export function setupMockCompilerProcessFactory(
       start: number;
       end: number;
     };
-  }[] = []
+  }> = []
 ) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   return (project: HardhatProject, uri: string): CompilerProcess => {

--- a/server/test/helpers/setupMockConnection.ts
+++ b/server/test/helpers/setupMockConnection.ts
@@ -28,12 +28,12 @@ export function setupMockConnection() {
       (
         _method: string,
         handler: (
-          unsavedDocuments: {
+          unsavedDocuments: Array<{
             uri: string;
             languageId: string;
             version: number;
             content: string;
-          }[]
+          }>
         ) => void
       ) => {
         handler([]);

--- a/server/test/helpers/setupMockLanguageServer.ts
+++ b/server/test/helpers/setupMockLanguageServer.ts
@@ -1,7 +1,6 @@
 import { assert } from "chai";
 import * as fs from "fs";
 import * as path from "path";
-import { getUriFromDocument } from "../../src/utils/index";
 import {
   CompletionItem,
   CompletionList,
@@ -21,6 +20,8 @@ import {
   HoverParams,
   Hover,
 } from "vscode-languageserver/node";
+import { getDocumentAnalyzer } from "@utils/getDocumentAnalyzer";
+import { getUriFromDocument } from "../../src/utils/index";
 import setupServer, {
   GetSolFileDetailsParams,
   GetSolFileDetailsResponse,
@@ -32,7 +33,6 @@ import { setupMockLogger } from "./setupMockLogger";
 import { setupMockWorkspaceFileRetriever } from "./setupMockWorkspaceFileRetriever";
 import { setupMockTelemetry } from "./setupMockTelemetry";
 import { forceToUnixStyle } from "./forceToUnixStyle";
-import { getDocumentAnalyzer } from "@utils/getDocumentAnalyzer";
 
 export type OnSignatureHelp = (
   params: SignatureHelpParams
@@ -66,7 +66,7 @@ export async function setupMockLanguageServer({
   errors,
 }: {
   projects?: { [key: string]: string[] };
-  documents: { uri: string; content?: string; analyze: boolean }[];
+  documents: Array<{ uri: string; content?: string; analyze: boolean }>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   errors: any[];
 }) {
@@ -138,7 +138,7 @@ export async function setupMockLanguageServer({
       text: fileContent.toString(),
     };
 
-    await didOpenTextDocument({ textDocument: textDocument });
+    await didOpenTextDocument({ textDocument });
 
     if (!analyze) {
       continue;
@@ -157,7 +157,7 @@ export async function setupMockLanguageServer({
 
           const documentAnalyzer = getDocumentAnalyzer(serverState, localUri);
 
-          return documentAnalyzer && documentAnalyzer.isAnalyzed();
+          return documentAnalyzer.isAnalyzed();
         },
         100,
         1600

--- a/server/test/parser/analyzer.ts
+++ b/server/test/parser/analyzer.ts
@@ -1,16 +1,16 @@
 import * as path from "path";
 import { assert } from "chai";
-import { setupMockLogger } from "../helpers/setupMockLogger";
 import { IndexFileData } from "@common/event";
-import { forceToUnixStyle } from "../helpers/forceToUnixStyle";
 import { indexWorkspaceFolders } from "@services/initialization/indexWorkspaceFolders";
 import { Connection } from "vscode-languageserver";
 import { HardhatProject } from "@analyzer/HardhatProject";
+import { forceToUnixStyle } from "../helpers/forceToUnixStyle";
+import { setupMockLogger } from "../helpers/setupMockLogger";
 
 describe("Analyzer", () => {
   describe("indexing", () => {
     const exampleRootPath = forceToUnixStyle(__dirname);
-    let collectedData: [string, IndexFileData][];
+    let collectedData: Array<[string, IndexFileData]>;
     let foundSolFiles: string[];
 
     describe("with multiple files", () => {
@@ -102,7 +102,7 @@ describe("Analyzer", () => {
 async function runIndexing(
   rootPath: string,
   foundSolFiles: string[],
-  collectedData: [string, IndexFileData][]
+  collectedData: Array<[string, IndexFileData]>
 ) {
   const exampleWorkspaceFolder = { name: "example", uri: rootPath };
 

--- a/server/test/services/codeactions/addMultioverrideSpecifier.ts
+++ b/server/test/services/codeactions/addMultioverrideSpecifier.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
-import { assertCodeAction } from "./asserts/assertCodeAction";
 import { AddMultiOverrideSpecifier } from "@compilerDiagnostics/diagnostics/AddMultiOverrideSpecifier";
+import { assertCodeAction } from "./asserts/assertCodeAction";
 
 describe("Code Actions", () => {
   describe("Add Multi-override Specifier", () => {

--- a/server/test/services/codeactions/addOverrideSpecifier.ts
+++ b/server/test/services/codeactions/addOverrideSpecifier.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
-import { assertCodeAction } from "./asserts/assertCodeAction";
 import { AddOverrideSpecifier } from "@compilerDiagnostics/diagnostics/AddOverrideSpecifier";
+import { assertCodeAction } from "./asserts/assertCodeAction";
 
 describe("Code Actions", () => {
   describe("Add Override Specifier", () => {

--- a/server/test/services/codeactions/addVirtualSpecifier.ts
+++ b/server/test/services/codeactions/addVirtualSpecifier.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
-import { assertCodeAction } from "./asserts/assertCodeAction";
 import { AddVirtualSpecifier } from "@compilerDiagnostics/diagnostics/AddVirtualSpecifier";
+import { assertCodeAction } from "./asserts/assertCodeAction";
 
 describe("Code Actions", () => {
   describe("Add Virtual Specifier", () => {

--- a/server/test/services/codeactions/asserts/assertCodeAction.ts
+++ b/server/test/services/codeactions/asserts/assertCodeAction.ts
@@ -2,22 +2,22 @@ import { assert } from "chai";
 import { Diagnostic, TextEdit } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { CompilerDiagnostic } from "@compilerDiagnostics/types";
+import { indexWorkspaceFolders } from "@services/initialization/indexWorkspaceFolders";
 import { setupMockWorkspaceFileRetriever } from "../../../helpers/setupMockWorkspaceFileRetriever";
 import { setupMockLogger } from "../../../helpers/setupMockLogger";
 import { setupMockConnection } from "../../../helpers/setupMockConnection";
-import { indexWorkspaceFolders } from "@services/initialization/indexWorkspaceFolders";
-import { ServerState } from "types";
+import { ServerState } from "../../../../src/types";
 
 export async function assertCodeAction(
   compilerDiagnostic: CompilerDiagnostic,
   docText: string,
   diagnostic: Diagnostic,
-  expectedActions: (null | {
+  expectedActions: Array<null | {
     title: string;
     kind: string;
     isPreferred: boolean;
     edits: TextEdit[];
-  })[]
+  }>
 ) {
   const exampleUri = "/example";
 
@@ -57,6 +57,7 @@ export async function assertCodeAction(
   assert(actions);
   assert.equal(actions.length, expectedActions.length);
 
+  // eslint-disable-next-line guard-for-in
   for (const index in expectedActions) {
     const expectedAction = expectedActions[index];
 

--- a/server/test/services/codeactions/constrainMutability.ts
+++ b/server/test/services/codeactions/constrainMutability.ts
@@ -3,9 +3,9 @@ import * as fs from "fs";
 import * as path from "path";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { ConstrainMutability } from "@compilerDiagnostics/diagnostics/ConstrainMutability";
-import { assertCodeAction } from "./asserts/assertCodeAction";
 import { setupMockLogger } from "../../helpers/setupMockLogger";
-import { ServerState } from "types";
+import { ServerState } from "../../../src/types";
+import { assertCodeAction } from "./asserts/assertCodeAction";
 
 describe("Code Actions", () => {
   const constrainMutability = new ConstrainMutability();

--- a/server/test/services/codeactions/markContractAbstract.ts
+++ b/server/test/services/codeactions/markContractAbstract.ts
@@ -2,13 +2,13 @@ import { assert } from "chai";
 import * as fs from "fs";
 import * as path from "path";
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { assertCodeAction } from "./asserts/assertCodeAction";
 import { MarkContractAbstract } from "@compilerDiagnostics/diagnostics/MarkContractAbstract";
+import { indexWorkspaceFolders } from "@services/initialization/indexWorkspaceFolders";
 import { setupMockWorkspaceFileRetriever } from "../../helpers/setupMockWorkspaceFileRetriever";
 import { setupMockLogger } from "../../helpers/setupMockLogger";
 import { setupMockConnection } from "../../helpers/setupMockConnection";
-import { indexWorkspaceFolders } from "@services/initialization/indexWorkspaceFolders";
-import { ServerState } from "types";
+import { ServerState } from "../../../src/types";
+import { assertCodeAction } from "./asserts/assertCodeAction";
 
 describe("Code Actions", () => {
   describe("Mark Contract Abstract", () => {

--- a/server/test/services/codeactions/specifyVisibility.ts
+++ b/server/test/services/codeactions/specifyVisibility.ts
@@ -1,9 +1,9 @@
 import { assert } from "chai";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { SpecifyVisibility } from "@compilerDiagnostics/diagnostics/SpecifyVisibility";
-import { assertCodeAction } from "./asserts/assertCodeAction";
 import { setupMockLogger } from "../../helpers/setupMockLogger";
-import { ServerState } from "types";
+import { ServerState } from "../../../src/types";
+import { assertCodeAction } from "./asserts/assertCodeAction";
 
 describe("Code Actions", () => {
   describe("Specify Visibility", () => {

--- a/server/test/services/completion/completion.ts
+++ b/server/test/services/completion/completion.ts
@@ -1,11 +1,11 @@
 import { assert } from "chai";
 import * as path from "path";
 import { VSCodePosition } from "@common/types";
+import { CompletionContext } from "vscode-languageserver/node";
 import {
   OnCompletion,
   setupMockLanguageServer,
 } from "../../helpers/setupMockLanguageServer";
-import { CompletionContext } from "vscode-languageserver/node";
 import { forceToUnixStyle } from "../../helpers/forceToUnixStyle";
 
 describe("Parser", () => {

--- a/server/test/services/completion/imports.ts
+++ b/server/test/services/completion/imports.ts
@@ -2,14 +2,14 @@ import { assert } from "chai";
 import * as path from "path";
 import { VSCodePosition } from "@common/types";
 import {
-  OnCompletion,
-  setupMockLanguageServer,
-} from "../../helpers/setupMockLanguageServer";
-import {
   CompletionContext,
   CompletionItem,
   CompletionItemKind,
 } from "vscode-languageserver/node";
+import {
+  OnCompletion,
+  setupMockLanguageServer,
+} from "../../helpers/setupMockLanguageServer";
 import { forceToUnixStyle } from "../../helpers/forceToUnixStyle";
 import { prependWithSlash } from "../../helpers/prependWithSlash";
 

--- a/server/test/services/hover/assertOnServerHover.ts
+++ b/server/test/services/hover/assertOnServerHover.ts
@@ -1,7 +1,7 @@
 import { assert } from "chai";
 import { VSCodePosition } from "@common/types";
-import { OnHover } from "../../helpers/setupMockLanguageServer";
 import { MarkupContent } from "vscode-languageserver/node";
+import { OnHover } from "../../helpers/setupMockLanguageServer";
 
 export async function assertOnServerHover(
   hover: OnHover,

--- a/server/test/services/hover/error.ts
+++ b/server/test/services/hover/error.ts
@@ -1,8 +1,8 @@
 import * as path from "path";
 import { VSCodePosition } from "@common/types";
+import { MarkupKind } from "vscode-languageserver/node";
 import { setupMockLanguageServer } from "../../helpers/setupMockLanguageServer";
 import { forceToUnixStyle } from "../../helpers/forceToUnixStyle";
-import { MarkupKind } from "vscode-languageserver/node";
 import { assertOnServerHover } from "./assertOnServerHover";
 
 describe("Parser", () => {

--- a/server/test/services/hover/event.ts
+++ b/server/test/services/hover/event.ts
@@ -1,8 +1,8 @@
 import * as path from "path";
 import { VSCodePosition } from "@common/types";
+import { MarkupKind } from "vscode-languageserver/node";
 import { setupMockLanguageServer } from "../../helpers/setupMockLanguageServer";
 import { forceToUnixStyle } from "../../helpers/forceToUnixStyle";
-import { MarkupKind } from "vscode-languageserver/node";
 import { assertOnServerHover } from "./assertOnServerHover";
 
 describe("Parser", () => {

--- a/server/test/services/hover/function.ts
+++ b/server/test/services/hover/function.ts
@@ -1,8 +1,8 @@
 import * as path from "path";
 import { VSCodePosition } from "@common/types";
+import { MarkupKind } from "vscode-languageserver/node";
 import { setupMockLanguageServer } from "../../helpers/setupMockLanguageServer";
 import { forceToUnixStyle } from "../../helpers/forceToUnixStyle";
-import { MarkupKind } from "vscode-languageserver/node";
 import { assertOnServerHover } from "./assertOnServerHover";
 
 describe("Parser", () => {

--- a/server/test/services/hover/identifier.ts
+++ b/server/test/services/hover/identifier.ts
@@ -1,8 +1,8 @@
 import * as path from "path";
 import { VSCodePosition } from "@common/types";
+import { MarkupKind } from "vscode-languageserver/node";
 import { setupMockLanguageServer } from "../../helpers/setupMockLanguageServer";
 import { forceToUnixStyle } from "../../helpers/forceToUnixStyle";
-import { MarkupKind } from "vscode-languageserver/node";
 import { assertOnServerHover } from "./assertOnServerHover";
 
 describe("Parser", () => {

--- a/server/test/services/navigation/implementation.ts
+++ b/server/test/services/navigation/implementation.ts
@@ -71,7 +71,7 @@ const assertImplementationNavigation = async (
   implementation: OnImplementation,
   uri: string,
   position: VSCodePosition,
-  expectedRanges: { start: VSCodePosition; end: VSCodePosition }[]
+  expectedRanges: Array<{ start: VSCodePosition; end: VSCodePosition }>
 ) => {
   const response = await implementation({ textDocument: { uri }, position });
 

--- a/server/test/services/navigation/typeDefinition.ts
+++ b/server/test/services/navigation/typeDefinition.ts
@@ -85,7 +85,7 @@ const assertTypeDefinitionNavigation = async (
   typeDefinition: OnTypeDefinition,
   uri: string,
   position: VSCodePosition,
-  expectedRanges: { start: VSCodePosition; end: VSCodePosition }[]
+  expectedRanges: Array<{ start: VSCodePosition; end: VSCodePosition }>
 ) => {
   const response = await typeDefinition({ textDocument: { uri }, position });
 

--- a/server/test/services/validation/convertHardhatErrorToDiagnostic.ts
+++ b/server/test/services/validation/convertHardhatErrorToDiagnostic.ts
@@ -7,13 +7,13 @@ import {
 import { convertHardhatErrorToDiagnostic } from "@services/validation/convertHardhatErrorToDiagnostic";
 import { assert } from "chai";
 
-type ErrorDescription = {
+interface ErrorDescription {
   number: number;
   message: string;
   title: string;
   description: string;
   shouldBeReported: false;
-};
+}
 
 describe("validation", () => {
   describe("convertHardhatErrorToDiagnostic", () => {

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -1,11 +1,11 @@
 import * as moduleAlias from "module-alias";
 
 const aliases = {
-  "@compilerDiagnostics": __dirname + "/../src/compilerDiagnostics",
-  "@analyzer": __dirname + "/../src/parser/analyzer",
-  "@common": __dirname + "/../src/parser/common",
-  "@services": __dirname + "/../src/services",
-  "@utils": __dirname + "/../src/utils",
+  "@compilerDiagnostics": `${__dirname}/../src/compilerDiagnostics`,
+  "@analyzer": `${__dirname}/../src/parser/analyzer`,
+  "@common": `${__dirname}/../src/parser/common`,
+  "@services": `${__dirname}/../src/services`,
+  "@utils": `${__dirname}/../src/utils`,
 };
 
 moduleAlias.addAliases(aliases);

--- a/server/test/solFileDetails/getSolFileDetails.ts
+++ b/server/test/solFileDetails/getSolFileDetails.ts
@@ -81,6 +81,8 @@ describe("Solidity Language Server", () => {
   });
 });
 
-function prependWithFilePrefix(path: string) {
-  return os.platform() === "win32" ? `file:///${path}` : `file://${path}`;
+function prependWithFilePrefix(filePath: string) {
+  return os.platform() === "win32"
+    ? `file:///${filePath}`
+    : `file://${filePath}`;
 }

--- a/server/test/tsconfig.json
+++ b/server/test/tsconfig.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": ".."
-  },
-  "include": ["../src", "../test"]
-}

--- a/server/tsconfig.build.json
+++ b/server/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "baseUrl": "./src",
+    "esModuleInterop": true,
+    "paths": {
+      "@compilerDiagnostics/*": ["./compilerDiagnostics/*"],
+      "@analyzer/*": ["./parser/analyzer/*"],
+      "@common/*": ["./parser/common/*"],
+      "@services/*": ["./services/*"],
+      "@utils/*": ["./utils/*"]
+    }
+  },
+  "exclude": ["test", "out", "coverage"]
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -5,22 +5,20 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "outDir": "out",
-    "rootDir": "src",
     "allowJs": true,
     "sourceMap": true,
     "strict": true,
     "composite": true,
     "declaration": true,
-    "baseUrl": "./src",
     "esModuleInterop": true,
     "paths": {
-      "@compilerDiagnostics/*": ["./compilerDiagnostics/*"],
-      "@analyzer/*": ["./parser/analyzer/*"],
-      "@common/*": ["./parser/common/*"],
-      "@services/*": ["./services/*"],
-      "@utils/*": ["./utils/*"]
+      "@compilerDiagnostics/*": ["./src/compilerDiagnostics/*"],
+      "@analyzer/*": ["./src/parser/analyzer/*"],
+      "@common/*": ["./src/parser/common/*"],
+      "@services/*": ["./src/services/*"],
+      "@utils/*": ["./src/utils/*"]
     }
-  },
-  "include": ["src"],
-  "exclude": ["node_modules", ".vscode-test"]
+  }
+  // "include": ["src", "test"],
+  // "exclude": ["node_modules", ".vscode-test", ".eslintrc.js"]
 }

--- a/test/integration/common/helper.ts
+++ b/test/integration/common/helper.ts
@@ -72,9 +72,9 @@ export function isInstanceOf<T>(
 }
 
 export function isArray<T>(
-  value: Array<T> | undefined | null,
+  value: T[] | undefined | null,
   length = 1
-): asserts value is Array<T> {
+): asserts value is T[] {
   assert.ok(
     Array.isArray(value),
     `value must be array ${JSON.stringify(value, null, 2)}`

--- a/test/integration/common/types.ts
+++ b/test/integration/common/types.ts
@@ -3,7 +3,7 @@
 import * as vscode from "vscode";
 import * as lsclient from "vscode-languageclient/node";
 
-export type Position = {
+export interface Position {
   /**
    * The zero-based line value.
    */
@@ -12,9 +12,9 @@ export type Position = {
    * The zero-based character value.
    */
   character: number;
-};
+}
 
-export type ActionParams = {
+export interface ActionParams {
   /**
    * Represents a line and character position, such as the position of the cursor.
    */
@@ -23,10 +23,11 @@ export type ActionParams = {
   /**
    * Optional param. Currently used only in RenameRequest.
    */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   new_name?: string | undefined;
-};
+}
 
-export type Action = {
+export interface Action {
   /**
    * The name of the action to be executed.
    */
@@ -47,9 +48,9 @@ export type Action = {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   expected: any[];
-};
+}
 
-export type IntegrationSamples = {
+export interface IntegrationSamples {
   /**
    * Test title.
    */
@@ -59,13 +60,13 @@ export type IntegrationSamples = {
    * List of related actions
    */
   actions: Action[];
-};
+}
 
-export type IndexFileData = {
+export interface IndexFileData {
   path: string;
   current: number;
   total: number;
-};
+}
 
 export interface NavigationProvider {
   client: lsclient.LanguageClient;
@@ -91,11 +92,11 @@ export interface NavigationProvider {
 }
 
 export interface Client {
-  client: lsclient.LanguageClient;
+  client: lsclient.LanguageClient | null;
   tokenSource: vscode.CancellationTokenSource;
 
-  document: vscode.TextDocument;
-  docUri: vscode.Uri;
+  document: vscode.TextDocument | null;
+  docUri: vscode.Uri | null;
 
   /**
    * Activates the extension

--- a/test/integration/index.ts
+++ b/test/integration/index.ts
@@ -1,5 +1,7 @@
 import path from "path";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import Mocha from "mocha";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import glob from "glob";
 
 export function run(): Promise<void> {
@@ -29,10 +31,10 @@ export function run(): Promise<void> {
             resolve();
           }
         });
-      } catch (err) {
+      } catch (innerErr) {
         // eslint-disable-next-line no-console
-        console.error(err);
-        reject(err);
+        console.error(innerErr);
+        reject(innerErr);
       }
     });
   });

--- a/test/integration/tests/configuration/configuration.test.ts
+++ b/test/integration/tests/configuration/configuration.test.ts
@@ -35,6 +35,7 @@ suite("Configuration", function () {
         workspace: {
           workspaceFolders: {
             supported: true,
+            changeNotifications: true,
           },
         },
       },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "out",
     "sourceMap": true,
     "resolveJsonModule": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "strict": true
   },
   "include": ["./client", "./server", "./test", "./test/**/*.json"],
   "exclude": [
@@ -15,7 +16,8 @@
     "./server/test",
     "./client/out",
     "./server/out",
-    "./out"
+    "./out",
+    ".eslintrc.js"
   ],
   "references": [{ "path": "./client" }, { "path": "./server" }]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -348,6 +348,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
 "@types/minimatch@*":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
@@ -589,10 +594,31 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+array-includes@^3.1.4:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.5.tgz#2c320010db8d31031fd2a5f6b3bbd4b1aad31bdb"
+  integrity sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.19.5"
+    get-intrinsic "^1.1.1"
+    is-string "^1.0.7"
+
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
+array.prototype.flat@^1.2.5:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz#0b0c1567bf57b38b56b4c97b8aa72ab45e4adc7b"
+  integrity sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.2"
+    es-shim-unscopables "^1.0.0"
 
 arrify@^1.0.1:
   version "1.0.1"
@@ -716,7 +742,7 @@ buffers@~0.1.1:
   resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
   integrity sha1-skV5w77U1tOWru5tmorn9Ugqt7s=
 
-call-bind@^1.0.0:
+call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
   integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
@@ -905,6 +931,20 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
+concurrently@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-7.1.0.tgz#477b49b8cfc630bb491f9b02e9ed7fb7bff02942"
+  integrity sha512-Bz0tMlYKZRUDqJlNiF/OImojMB9ruKUz6GCfmhFnSapXgPe+3xzY4byqoKG9tUZ7L2PGEUjfLPOLfIX3labnmw==
+  dependencies:
+    chalk "^4.1.0"
+    date-fns "^2.16.1"
+    lodash "^4.17.21"
+    rxjs "^6.6.3"
+    spawn-command "^0.0.2-1"
+    supports-color "^8.1.0"
+    tree-kill "^1.2.2"
+    yargs "^16.2.0"
+
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
@@ -985,12 +1025,31 @@ csv@^5.3.1:
     csv-stringify "^5.6.5"
     stream-transform "^2.1.3"
 
+date-fns@^2.16.1:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
+  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
+
 debug@4, debug@4.3.3, debug@^4.1.1, debug@^4.3.2:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
   dependencies:
     ms "2.1.2"
+
+debug@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
+debug@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
 
 decamelize-keys@^1.1.0:
   version "1.1.0"
@@ -1034,6 +1093,14 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
+define-properties@^1.1.3, define-properties@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.4.tgz#0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1"
+  integrity sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==
+  dependencies:
+    has-property-descriptors "^1.0.0"
+    object-keys "^1.1.1"
+
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
@@ -1060,6 +1127,13 @@ dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
+
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
+  dependencies:
+    esutils "^2.0.2"
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -1145,6 +1219,51 @@ error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
+
+es-abstract@^1.19.0, es-abstract@^1.19.1, es-abstract@^1.19.2, es-abstract@^1.19.5:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.20.0.tgz#b2d526489cceca004588296334726329e0a6bfb6"
+  integrity sha512-URbD8tgRthKD3YcC39vbvSDrX23upXnPcnGAjQfgxXF5ID75YcENawc9ZX/9iTP9ptUyfCLIxTTuMYoRfiOVKA==
+  dependencies:
+    call-bind "^1.0.2"
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    function.prototype.name "^1.1.5"
+    get-intrinsic "^1.1.1"
+    get-symbol-description "^1.0.0"
+    has "^1.0.3"
+    has-property-descriptors "^1.0.0"
+    has-symbols "^1.0.3"
+    internal-slot "^1.0.3"
+    is-callable "^1.2.4"
+    is-negative-zero "^2.0.2"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.2"
+    is-string "^1.0.7"
+    is-weakref "^1.0.2"
+    object-inspect "^1.12.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.2"
+    regexp.prototype.flags "^1.4.1"
+    string.prototype.trimend "^1.0.5"
+    string.prototype.trimstart "^1.0.5"
+    unbox-primitive "^1.0.2"
+
+es-shim-unscopables@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz#702e632193201e3edf8713635d083d378e510241"
+  integrity sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==
+  dependencies:
+    has "^1.0.3"
+
+es-to-primitive@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
+  integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
 
 esbuild-android-arm64@0.14.23:
   version "0.14.23"
@@ -1285,6 +1404,41 @@ eslint-config-prettier@8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
   integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
+
+eslint-import-resolver-node@^0.3.6:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz#4048b958395da89668252001dbd9eca6b83bacbd"
+  integrity sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==
+  dependencies:
+    debug "^3.2.7"
+    resolve "^1.20.0"
+
+eslint-module-utils@^2.7.3:
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz#ad7e3a10552fdd0642e1e55292781bd6e34876ee"
+  integrity sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==
+  dependencies:
+    debug "^3.2.7"
+    find-up "^2.1.0"
+
+eslint-plugin-import@2.26.0:
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz#f812dc47be4f2b72b478a021605a59fc6fe8b88b"
+  integrity sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==
+  dependencies:
+    array-includes "^3.1.4"
+    array.prototype.flat "^1.2.5"
+    debug "^2.6.9"
+    doctrine "^2.1.0"
+    eslint-import-resolver-node "^0.3.6"
+    eslint-module-utils "^2.7.3"
+    has "^1.0.3"
+    is-core-module "^2.8.1"
+    is-glob "^4.0.3"
+    minimatch "^3.1.2"
+    object.values "^1.1.5"
+    resolve "^1.22.0"
+    tsconfig-paths "^3.14.1"
 
 eslint-scope@^5.1.1:
   version "5.1.1"
@@ -1500,6 +1654,13 @@ find-up@5.0.0, find-up@^5.0.0:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
 
+find-up@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
+  dependencies:
+    locate-path "^2.0.0"
+
 find-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
@@ -1589,10 +1750,25 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+function.prototype.name@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.5.tgz#cce0505fe1ffb80503e6f9e46cc64e46a12a9621"
+  integrity sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.0"
+    functions-have-names "^1.2.2"
+
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
+functions-have-names@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
+  integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -1613,7 +1789,7 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.2:
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
   integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
@@ -1628,6 +1804,14 @@ get-stream@^4.0.0:
   integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
   dependencies:
     pump "^3.0.0"
+
+get-symbol-description@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/get-symbol-description/-/get-symbol-description-1.0.0.tgz#7fdb81c900101fbd564dd5f1a30af5aadc1e58d6"
+  integrity sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.1"
 
 github-from-package@0.0.0:
   version "0.0.0"
@@ -1699,6 +1883,11 @@ hard-rejection@^2.1.0:
   resolved "https://registry.yarnpkg.com/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883"
   integrity sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==
 
+has-bigints@^1.0.1, has-bigints@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
+  integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -1709,10 +1898,29 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
+has-property-descriptors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz#610708600606d36961ed04c196193b6a607fa861"
+  integrity sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==
+  dependencies:
+    get-intrinsic "^1.1.1"
+
 has-symbols@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
   integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
+has-symbols@^1.0.2, has-symbols@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
+  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
+
+has-tostringtag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
+  integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
+  dependencies:
+    has-symbols "^1.0.2"
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -1833,10 +2041,26 @@ ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
+internal-slot@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.3.tgz#7347e307deeea2faac2ac6205d4bc7d34967f59c"
+  integrity sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==
+  dependencies:
+    get-intrinsic "^1.1.0"
+    has "^1.0.3"
+    side-channel "^1.0.4"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+
+is-bigint@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.4.tgz#08147a1875bc2b32005d41ccd8291dffc6691df3"
+  integrity sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==
+  dependencies:
+    has-bigints "^1.0.1"
 
 is-binary-path@~2.1.0:
   version "2.1.0"
@@ -1844,6 +2068,19 @@ is-binary-path@~2.1.0:
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
+
+is-boolean-object@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.2.tgz#5c6dc200246dd9321ae4b885a114bb1f75f63719"
+  integrity sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
+is-callable@^1.1.4, is-callable@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
+  integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
 
 is-ci@^3.0.1:
   version "3.0.1"
@@ -1858,6 +2095,13 @@ is-core-module@^2.8.1:
   integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
   dependencies:
     has "^1.0.3"
+
+is-date-object@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.5.tgz#0841d5536e724c25597bf6ea62e1bd38298df31f"
+  integrity sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==
+  dependencies:
+    has-tostringtag "^1.0.0"
 
 is-extglob@^2.1.1:
   version "2.1.1"
@@ -1888,6 +2132,18 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-negative-zero@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
+  integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
+
+is-number-object@^1.0.4:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.7.tgz#59d50ada4c45251784e9904f5246c742f07a42fc"
+  integrity sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==
+  dependencies:
+    has-tostringtag "^1.0.0"
+
 is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
@@ -1903,10 +2159,32 @@ is-plain-obj@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
+is-regex@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
+  integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
+is-shared-array-buffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz#8f259c573b60b6a32d4058a1a07430c0a7344c79"
+  integrity sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==
+  dependencies:
+    call-bind "^1.0.2"
+
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
+
+is-string@^1.0.5, is-string@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd"
+  integrity sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==
+  dependencies:
+    has-tostringtag "^1.0.0"
 
 is-subdir@^1.1.1:
   version "1.2.0"
@@ -1915,10 +2193,24 @@ is-subdir@^1.1.1:
   dependencies:
     better-path-resolve "1.0.0"
 
+is-symbol@^1.0.2, is-symbol@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.4.tgz#a6dac93b635b063ca6872236de88910a57af139c"
+  integrity sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==
+  dependencies:
+    has-symbols "^1.0.2"
+
 is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
+
+is-weakref@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
+  integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
+  dependencies:
+    call-bind "^1.0.2"
 
 is-windows@^1.0.0:
   version "1.0.2"
@@ -1978,6 +2270,13 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
+
+json5@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
+  dependencies:
+    minimist "^1.2.0"
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -2039,6 +2338,14 @@ load-yaml-file@^0.2.0:
     pify "^4.0.1"
     strip-bom "^3.0.0"
 
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  integrity sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=
+  dependencies:
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
+
 locate-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
@@ -2071,7 +2378,7 @@ lodash.startcase@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.startcase/-/lodash.startcase-4.4.0.tgz#9436e34ed26093ed7ffae1936144350915d9add8"
   integrity sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg=
 
-lodash@^4.17.4:
+lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -2184,6 +2491,13 @@ minimatch@^3.0.3:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimist-options@^4.0.2:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-4.1.0.tgz#c0655713c53a8a2ebd77ffa247d342c40f010619"
@@ -2197,6 +2511,11 @@ minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 mixme@^0.5.1:
   version "0.5.4"
@@ -2245,12 +2564,17 @@ mocha@^9.1.1:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3:
+ms@2.1.3, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -2341,10 +2665,34 @@ object-assign@^4.1.0:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
-object-inspect@^1.9.0:
+object-inspect@^1.12.0, object-inspect@^1.9.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.0.tgz#6e2c120e868fd1fd18cb4f18c31741d0d6e776f0"
   integrity sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==
+
+object-keys@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
+object.assign@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
+  integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    has-symbols "^1.0.1"
+    object-keys "^1.1.1"
+
+object.values@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.5.tgz#959f63e3ce9ef108720333082131e4a459b716ac"
+  integrity sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.1"
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -2387,6 +2735,13 @@ p-finally@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
 
+p-limit@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
+  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
+  dependencies:
+    p-try "^1.0.0"
+
 p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -2400,6 +2755,13 @@ p-limit@^3.0.2:
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
   dependencies:
     yocto-queue "^0.1.0"
+
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  integrity sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
+  dependencies:
+    p-limit "^1.1.0"
 
 p-locate@^3.0.0:
   version "3.0.0"
@@ -2426,6 +2788,11 @@ p-map@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
   integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+  integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -2709,6 +3076,15 @@ regenerator-runtime@^0.13.4:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
 
+regexp.prototype.flags@^1.4.1:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
+  integrity sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    functions-have-names "^1.2.2"
+
 regexpp@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
@@ -2734,7 +3110,7 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-resolve@^1.10.0:
+resolve@^1.10.0, resolve@^1.20.0, resolve@^1.22.0:
   version "1.22.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198"
   integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
@@ -2768,6 +3144,13 @@ run-parallel@^1.1.9:
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+rxjs@^6.6.3:
+  version "6.6.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
+  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
+  dependencies:
+    tslib "^1.9.0"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
@@ -2886,6 +3269,11 @@ smartwrap@^1.2.3:
     wcwidth "^1.0.1"
     yargs "^15.1.0"
 
+spawn-command@^0.0.2-1:
+  version "0.0.2-1"
+  resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2-1.tgz#62f5e9466981c1b796dc5929937e11c9c6921bd0"
+  integrity sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=
+
 spawndamnit@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/spawndamnit/-/spawndamnit-2.0.0.tgz#9f762ac5c3476abb994b42ad592b5ad22bb4b0ad"
@@ -2966,6 +3354,24 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
+string.prototype.trimend@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz#914a65baaab25fbdd4ee291ca7dde57e869cb8d0"
+  integrity sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.19.5"
+
+string.prototype.trimstart@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz#5466d93ba58cfa2134839f81d7f42437e8c01fef"
+  integrity sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.19.5"
+
 string_decoder@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
@@ -3028,7 +3434,7 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-supports-color@8.1.1:
+supports-color@8.1.1, supports-color@^8.1.0:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
@@ -3121,12 +3527,27 @@ to-regex-range@^5.0.1:
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
   integrity sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=
 
+tree-kill@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
+  integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
+
 trim-newlines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
-tslib@^1.8.1:
+tsconfig-paths@^3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"
+  integrity sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.6"
+    strip-bom "^3.0.0"
+
+tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -3212,6 +3633,16 @@ uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
+
+unbox-primitive@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"
+  integrity sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==
+  dependencies:
+    call-bind "^1.0.2"
+    has-bigints "^1.0.2"
+    has-symbols "^1.0.3"
+    which-boxed-primitive "^1.0.2"
 
 underscore@^1.12.1:
   version "1.13.2"
@@ -3328,6 +3759,17 @@ wcwidth@^1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+which-boxed-primitive@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
+  integrity sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==
+  dependencies:
+    is-bigint "^1.0.1"
+    is-boolean-object "^1.1.0"
+    is-number-object "^1.0.4"
+    is-string "^1.0.5"
+    is-symbol "^1.0.3"
 
 which-module@^2.0.0:
   version "2.0.0"
@@ -3489,7 +3931,7 @@ yargs-unparser@2.0.0:
     flat "^5.0.2"
     is-plain-obj "^2.1.0"
 
-yargs@16.2.0:
+yargs@16.2.0, yargs@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
   integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==


### PR DESCRIPTION
Pull across the Hardhat eslint rules and apply them.

This required some types changes and fixes, and the change of the structure of the tsconfig files. An additional `server/tsconfig.build.json` is used for builds, so that the base ca apply rules across `src` and `test`.
