### PR TITLE
chore(telemetry): decrease the sampling

### DIFF
--- a/client/src/telemetry/SentryClientTelemetry.ts
+++ b/client/src/telemetry/SentryClientTelemetry.ts
@@ -18,7 +18,7 @@ export class SentryClientTelemetry implements Telemetry {
 
     Sentry.init({
       dsn: this.dsn,
-      tracesSampleRate: this.extensionState.env === "development" ? 1 : 0.01,
+      tracesSampleRate: this.extensionState.env === "development" ? 1 : 0.001,
       release: `${this.extensionState.name}@${this.extensionState.version}`,
       environment: this.extensionState.env,
       initialScope: {

--- a/server/src/telemetry/SentryServerTelemetry.ts
+++ b/server/src/telemetry/SentryServerTelemetry.ts
@@ -42,7 +42,7 @@ export class SentryServerTelemetry implements Telemetry {
 
     Sentry.init({
       dsn: this.dsn,
-      tracesSampleRate: serverState.env === "development" ? 1 : 0.01,
+      tracesSampleRate: serverState.env === "development" ? 1 : 0.001,
       release:
         extensionName !== undefined && extensionVersion !== undefined
           ? `${extensionName}@${extensionVersion}`


### PR DESCRIPTION
We have enough users that we are running up against our transaction limits in Sentry. So we are reducing the sample rate from 1 in 100 to 1 in 1000. This will affect our performance tracking, not our exception capturing.

