### PR TITLE
chore(telemetry): track transaction success/failure

### DIFF
--- a/server/src/services/codeactions/onCodeAction.ts
+++ b/server/src/services/codeactions/onCodeAction.ts
@@ -8,25 +8,23 @@ export function onCodeAction(serverState: ServerState) {
 
     logger.trace("onCodeAction");
 
-    try {
-      return serverState.telemetry.trackTimingSync("onCodeAction", () => {
+    return (
+      serverState.telemetry.trackTimingSync("onCodeAction", () => {
         const document = documents.get(params.textDocument.uri);
 
         if (!document || params.context.diagnostics.length === 0) {
-          return [];
+          return { status: "failed_precondition", result: [] };
         }
 
-        return resolveQuickFixes(
+        const quickfixes = resolveQuickFixes(
           serverState,
           params.textDocument.uri,
           document,
           params.context.diagnostics
         );
-      });
-    } catch (err) {
-      logger.error(err);
 
-      return [];
-    }
+        return { status: "ok", result: quickfixes };
+      }) ?? []
+    );
   };
 }

--- a/server/src/services/initialization/onInitialized.ts
+++ b/server/src/services/initialization/onInitialized.ts
@@ -32,13 +32,15 @@ export const onInitialized = (
       });
     }
 
-    await serverState.telemetry.trackTimingSync("indexing", () =>
-      indexWorkspaceFolders(
+    await serverState.telemetry.trackTiming("indexing", async () => {
+      await indexWorkspaceFolders(
         { ...serverState, workspaceFolders: [] },
         workspaceFileRetriever,
         serverState.workspaceFolders
-      )
-    );
+      );
+
+      return { status: "ok", result: null };
+    });
 
     logger.info("Language server ready");
   };

--- a/server/src/telemetry/types.ts
+++ b/server/src/telemetry/types.ts
@@ -1,5 +1,11 @@
+import { SpanStatusType } from "@sentry/tracing";
 import type { Transaction } from "@sentry/types";
 import { ServerState } from "../types";
+
+export interface TrackingResult<T> {
+  status: SpanStatusType;
+  result: T | null;
+}
 
 export interface Telemetry {
   init(
@@ -9,7 +15,14 @@ export interface Telemetry {
     serverState: ServerState
   ): void;
   captureException(err: unknown): void;
-  trackTimingSync<T>(taskName: string, action: () => T): T;
+  trackTiming<T>(
+    taskName: string,
+    action: (transaction: Transaction) => Promise<TrackingResult<T>>
+  ): Promise<T | null>;
+  trackTimingSync<T>(
+    taskName: string,
+    action: (transaction: Transaction) => TrackingResult<T>
+  ): T | null;
   startTransaction({ op, name }: { op: string; name: string }): Transaction;
   enableHeartbeat(): void;
   close(): Promise<boolean>;

--- a/server/src/utils/onCommand.ts
+++ b/server/src/utils/onCommand.ts
@@ -18,13 +18,13 @@ export function onCommand<T>(
       lookupEntryForUri(serverState, uri);
 
     if (!found || !documentAnalyzer || !document) {
-      logger.error(
-        new Error(`Error analyzing doc within ${commandName}: ${errorMessage}`)
-      );
+      if (errorMessage !== undefined) {
+        logger.trace(errorMessage);
+      }
 
-      return null;
+      return { status: "failed_precondition", result: null };
     }
 
-    return action(documentAnalyzer, document);
+    return { status: "ok", result: action(documentAnalyzer, document) };
   });
 }

--- a/server/test/helpers/setupMockTelemetry.ts
+++ b/server/test/helpers/setupMockTelemetry.ts
@@ -6,8 +6,15 @@ export function setupMockTelemetry(): Telemetry {
   return {
     init: sinon.spy(),
     captureException: sinon.spy(),
-    trackTimingSync: (_taskName: string, action) => {
-      return action();
+    trackTiming: async (_taskName: string, action) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (await action(sinon.spy() as any)).result;
+    },
+    trackTimingSync: (_taskName, action) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const actionResponse = action(sinon.spy() as any);
+
+      return actionResponse.result;
     },
     startTransaction: (): Transaction => {
       return {

--- a/server/test/services/completion/imports.ts
+++ b/server/test/services/completion/imports.ts
@@ -62,7 +62,7 @@ describe("Parser", () => {
           },
         });
 
-        assert(response === undefined);
+        assert(response === null);
       });
 
       describe("empty (neither relative/direct)", () => {


### PR DESCRIPTION
The telemetry tracking method now captures exceptions on action, and records failure of the transaction (for our telemetry tracking). The action can also return a failure status directly.

We leverage this new telemetry feature to no longer send command fails due to an analyzed file, instead we mark the command as a failed command (and so track it through our performance telemetry).

This should allow us to track the quality of lsp commands while reducing the number of exceptions sent to telemetry.