### PR TITLE
fix(validation): gracefully report no worker

### DIFF
--- a/server/test/helpers/setupMockTelemetry.ts
+++ b/server/test/helpers/setupMockTelemetry.ts
@@ -7,14 +7,22 @@ export function setupMockTelemetry(): Telemetry {
     init: sinon.spy(),
     captureException: sinon.spy(),
     trackTiming: async (_taskName: string, action) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return (await action(sinon.spy() as any)).result;
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (await action(sinon.spy() as any)).result;
+      } catch {
+        return null;
+      }
     },
     trackTimingSync: (_taskName, action) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const actionResponse = action(sinon.spy() as any);
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const actionResponse = action(sinon.spy() as any);
 
-      return actionResponse.result;
+        return actionResponse.result;
+      } catch {
+        return null;
+      }
     },
     startTransaction: (): Transaction => {
       return {

--- a/server/test/services/documents/onDidChangeWatchedFiles.ts
+++ b/server/test/services/documents/onDidChangeWatchedFiles.ts
@@ -1,0 +1,82 @@
+import { onDidChangeWatchedFiles } from "@services/documents/onDidChangeWatchedFiles";
+import { assert } from "chai";
+import sinon from "sinon";
+import { ServerState } from "../../../src/types";
+import { setupMockLogger } from "../../helpers/setupMockLogger";
+import { setupMockTelemetry } from "../../helpers/setupMockTelemetry";
+
+describe("On did change watched files", () => {
+  describe("change to hardhat config file", () => {
+    it("should restart the worker", async () => {
+      const mockWorkerProcess = {
+        restart: sinon.spy(),
+      };
+
+      const serverState = setupServerState(mockWorkerProcess);
+
+      const [response] = await onDidChangeWatchedFiles(serverState)({
+        changes: [{ type: 1, uri: "/projects/example/hardhat.config.ts" }],
+      });
+
+      assert.deepStrictEqual(response, true);
+      assert(mockWorkerProcess.restart.called);
+    });
+
+    it("should gracefully fail if no project for config file", async () => {
+      const serverState = setupServerState();
+      serverState.projects = {};
+
+      const [response] = await onDidChangeWatchedFiles(serverState)({
+        changes: [{ type: 1, uri: "/projects/example/hardhat.config.ts" }],
+      });
+
+      assert.deepStrictEqual(response, false);
+    });
+
+    it("should gracefully fail if no worker process for config file", async () => {
+      const serverState = setupServerState();
+      serverState.workerProcesses = {};
+
+      const [response] = await onDidChangeWatchedFiles(serverState)({
+        changes: [{ type: 1, uri: "/projects/example/hardhat.config.ts" }],
+      });
+
+      assert.deepStrictEqual(response, false);
+    });
+
+    it("should gracefully fail on an unexpected exception", async () => {
+      const serverState = setupServerState();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      serverState.projects["/projects/example"] = undefined as any;
+
+      const [response] = await onDidChangeWatchedFiles(serverState)({
+        changes: [{ type: 1, uri: "/projects/example/hardhat.config.ts" }],
+      });
+
+      assert.deepStrictEqual(response, false);
+    });
+  });
+});
+
+function setupServerState(mockWorkerProcess?: {
+  restart: () => void;
+}): ServerState {
+  const serverState = {
+    projects: {
+      "/projects/example": {
+        configPath: "/projects/example/hardhat.config.ts",
+        basePath: "/projects/example",
+      },
+    },
+    workerProcesses: {
+      "/projects/example": mockWorkerProcess ?? {
+        restart: sinon.spy(),
+      },
+    },
+    telemetry: setupMockTelemetry(),
+    logger: setupMockLogger(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+
+  return serverState;
+}

--- a/server/test/services/validation/validation.ts
+++ b/server/test/services/validation/validation.ts
@@ -20,6 +20,7 @@ import { setupMockConnection } from "../../helpers/setupMockConnection";
 import { setupMockLanguageServer } from "../../helpers/setupMockLanguageServer";
 import { setupMockLogger } from "../../helpers/setupMockLogger";
 import { waitUntil } from "../../helpers/waitUntil";
+import { setupMockTelemetry } from "../../helpers/setupMockTelemetry";
 
 describe("Parser", () => {
   describe("Validation", function () {
@@ -40,12 +41,6 @@ describe("Parser", () => {
     );
 
     let mockConnection: ReturnType<typeof setupMockConnection>;
-
-    const fakeTelemetry = {
-      trackTiming: async (_name: string, action: () => Promise<void>) => {
-        return action();
-      },
-    };
 
     describe("validation fail - solc warnings/errors from worker", () => {
       describe("pass through", () => {
@@ -902,7 +897,7 @@ describe("Parser", () => {
 
           const serverState = {
             solFileIndex: {},
-            telemetry: fakeTelemetry,
+            telemetry: setupMockTelemetry(),
             logger: mockLogger,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
           } as any;
@@ -948,7 +943,7 @@ describe("Parser", () => {
               "/projects/example": undefined,
             },
             logger: mockLogger,
-            telemetry: fakeTelemetry,
+            telemetry: setupMockTelemetry(),
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
           } as any;
 
@@ -1023,11 +1018,7 @@ async function validateReturningWorkerMessage(
           "// ignore"
         ),
     },
-    telemetry: {
-      trackTiming: async (_name: string, action: () => Promise<void>) => {
-        return action();
-      },
-    },
+    telemetry: setupMockTelemetry(),
     logger: mockLogger,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any;


### PR DESCRIPTION
On a config change, the worker is restarted. If the worker for the config can't be found, we should log and return rather than exceptioning on the undefined worker process.

Fixes #193
