### PR TITLE
feat: enforce input settings for validation

### DIFF
--- a/server/src/services/validation/worker/build/buildInputsToSolc.ts
+++ b/server/src/services/validation/worker/build/buildInputsToSolc.ts
@@ -4,10 +4,12 @@ import {
   BuildJob,
   ValidationCompleteMessage,
 } from "../../../../types";
+
 export interface SolcInput {
   built: true;
+  jobId: number;
   solcVersion: string;
-  input: unknown;
+  input: {};
   solcBuild: SolcBuild;
   sourcePaths: string[];
 }
@@ -66,9 +68,12 @@ export async function buildInputsToSolc(
     return cancel(buildJob);
   }
 
+  buildJob.preprocessingFinished = new Date();
+
   return {
     built: true,
     solcVersion,
+    jobId: buildJob.jobId,
     input: buildJob.context.input,
     solcBuild: buildJob.context.solcBuild,
     sourcePaths: buildJob.context.sourcePaths ?? [],

--- a/server/src/services/validation/worker/build/solcCompile.ts
+++ b/server/src/services/validation/worker/build/solcCompile.ts
@@ -21,14 +21,25 @@ export async function solcCompile(
 ): Promise<SolcResult> {
   let output;
 
+  const originalInput = input as { settings: {} };
+
+  const overriddenInput = {
+    ...originalInput,
+    settings: {
+      ...originalInput.settings,
+      optimizer: { enabled: false, runs: 1 },
+      outputSelection: {},
+    },
+  };
+
   if (solcBuild.isSolcJs) {
     output = await hre.run(TASK_COMPILE_SOLIDITY_RUN_SOLCJS, {
-      input,
+      input: overriddenInput,
       solcJsPath: solcBuild.compilerPath,
     });
   } else {
     output = await hre.run(TASK_COMPILE_SOLIDITY_RUN_SOLC, {
-      input,
+      input: overriddenInput,
       solcPath: solcBuild.compilerPath,
     });
   }

--- a/server/src/services/validation/worker/build/solcCompile.ts
+++ b/server/src/services/validation/worker/build/solcCompile.ts
@@ -27,7 +27,6 @@ export async function solcCompile(
     ...originalInput,
     settings: {
       ...originalInput.settings,
-      optimizer: { enabled: false, runs: 1 },
       outputSelection: {},
     },
   };

--- a/server/src/services/validation/worker/build/solcCompile.ts
+++ b/server/src/services/validation/worker/build/solcCompile.ts
@@ -20,6 +20,7 @@ export async function solcCompile(
   { input, solcBuild }: SolcInput
 ): Promise<SolcResult> {
   let output;
+
   if (solcBuild.isSolcJs) {
     output = await hre.run(TASK_COMPILE_SOLIDITY_RUN_SOLCJS, {
       input,

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -106,6 +106,8 @@ export interface BuildJob {
     documentText: string;
   }>;
   added: Date;
+
+  preprocessingFinished?: Date;
 }
 
 export interface BuildDetails {

--- a/server/test/services/validation/worker.ts
+++ b/server/test/services/validation/worker.ts
@@ -95,11 +95,11 @@ describe("worker", () => {
           });
         });
 
-        it("should pass overriden settings to solc", async () => {
+        it("should pass overriden `outputSelection` settings to solc", async () => {
           assert.deepStrictEqual(capturedOptions.input.settings, {
             optimizer: {
               enabled: false,
-              runs: 1,
+              runs: 200,
             },
             outputSelection: {},
           });

--- a/server/test/services/validation/worker.ts
+++ b/server/test/services/validation/worker.ts
@@ -43,11 +43,21 @@ describe("worker", () => {
       describe("without solc warnings/errors", () => {
         let workerState: WorkerState;
         let send: any;
+        let capturedOptions: any;
 
         before(async () => {
           const errors: unknown[] = [];
 
           workerState = setupWorkerState({ errors });
+
+          workerState.hre = setupMockHre({
+            errors: [],
+            interleavedActions: {
+              TASK_COMPILE_SOLIDITY_RUN_SOLC: async (options) => {
+                capturedOptions = options;
+              },
+            },
+          });
 
           await dispatch(workerState)(exampleValidation);
 
@@ -82,6 +92,16 @@ describe("worker", () => {
             isSolcJs: false,
             version: "0.8.0",
             longVersion: "0.8.0",
+          });
+        });
+
+        it("should pass overriden settings to solc", async () => {
+          assert.deepStrictEqual(capturedOptions.input.settings, {
+            optimizer: {
+              enabled: false,
+              runs: 1,
+            },
+            outputSelection: {},
           });
         });
       });


### PR DESCRIPTION
For validation we do not need solc code generation, just errors and warnings. Nor do we need optimization. We override these setting no matter what the user has in their `hardhat.config.{ts,js}`.

Other settings are passed on without change.