### PR TITLE
feat(validation): cache solc input

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -17,9 +17,36 @@
 **/node_modules/
 **/src
 **/test
+**/scripts
 
 client/package.json
 server/package.json
 
 **/docs
 !**/docs/images/hardhat-vscode-logo.png
+
+!server/node_modules/@nomicfoundation/solidity-analyzer/package.json
+!server/node_modules/@nomicfoundation/solidity-analyzer/index.js
+!server/node_modules/@nomicfoundation/solidity-analyzer/index.js
+
+!server/node_modules/@nomicfoundation/solidity-analyzer-darwin-arm64/package.json
+!server/node_modules/@nomicfoundation/solidity-analyzer-darwin-x64/package.json
+!server/node_modules/@nomicfoundation/solidity-analyzer-freebsd-x64/package.json
+!server/node_modules/@nomicfoundation/solidity-analyzer-linux-arm64-gnu/package.json
+!server/node_modules/@nomicfoundation/solidity-analyzer-linux-arm64-musl/package.json
+!server/node_modules/@nomicfoundation/solidity-analyzer-linux-x64-gnu/package.json
+!server/node_modules/@nomicfoundation/solidity-analyzer-linux-x64-musl/package.json
+!server/node_modules/@nomicfoundation/solidity-analyzer-win32-arm64-msvc/package.json
+!server/node_modules/@nomicfoundation/solidity-analyzer-win32-ia32-msvc/package.json
+!server/node_modules/@nomicfoundation/solidity-analyzer-win32-x64-msvc/package.json
+
+!server/node_modules/@nomicfoundation/solidity-analyzer-darwin-arm64/solidity-analyzer.darwin-arm64.node
+!server/node_modules/@nomicfoundation/solidity-analyzer-darwin-x64/solidity-analyzer.darwin-x64.node
+!server/node_modules/@nomicfoundation/solidity-analyzer-freebsd-x64/solidity-analyzer.freebsd-x64.node
+!server/node_modules/@nomicfoundation/solidity-analyzer-linux-arm64-gnu/solidity-analyzer.linux-arm64-gnu.node
+!server/node_modules/@nomicfoundation/solidity-analyzer-linux-arm64-musl/solidity-analyzer.linux-arm64-musl.node
+!server/node_modules/@nomicfoundation/solidity-analyzer-linux-x64-gnu/solidity-analyzer.linux-x64-gnu.node
+!server/node_modules/@nomicfoundation/solidity-analyzer-linux-x64-musl/solidity-analyzer.linux-x64-musl.node
+!server/node_modules/@nomicfoundation/solidity-analyzer-win32-arm64-msvc/solidity-analyzer.win32-arm64-msvc.node
+!server/node_modules/@nomicfoundation/solidity-analyzer-win32-ia32-msvc/solidity-analyzer.win32-ia32-msvc.node
+!server/node_modules/@nomicfoundation/solidity-analyzer-win32-x64-msvc/solidity-analyzer.win32-x64-msvc.node

--- a/client/src/setup/setupLanguageServerHooks.ts
+++ b/client/src/setup/setupLanguageServerHooks.ts
@@ -44,9 +44,10 @@ const startLanguageServer = (extensionState: ExtensionState): void => {
       { scheme: "file", language: "solidity", pattern: `**/*.sol` },
     ],
     synchronize: {
-      fileEvents: workspace.createFileSystemWatcher(
-        "**/hardhat.config.{ts,js}"
-      ),
+      fileEvents: [
+        workspace.createFileSystemWatcher("**/hardhat.config.{ts,js}"),
+        workspace.createFileSystemWatcher("**/contracts/**/*.sol"),
+      ],
     },
     diagnosticCollectionName: "hardhat-language-server",
     outputChannel: extensionState.outputChannel,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "build": "tsc -b ./client/tsconfig.json && tsc -b ./server/tsconfig.build.json && tsc -b",
     "watch": "concurrently -n client,server \"tsc -b -w ./client/tsconfig.json\" \"tsc -b -w ./server/tsconfig.build.json\"",
-    "postinstall": "yarn install --cwd ./client && yarn install --cwd ./server",
+    "postinstall": "yarn install --cwd ./client && yarn install --ignore-platform --cwd ./server",
     "test:integration": "yarn run build && node ./out/test/runTests.js",
     "test:unit": "yarn --cwd ./server run test",
     "test": "yarn run test:unit && yarn run test:integration",

--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -60,7 +60,7 @@ async function main() {
     minifyWhitespace: true,
     minifyIdentifiers: false,
     minifySyntax: true,
-    external: ["vscode"],
+    external: ["vscode", "@nomicfoundation/solidity-analyzer"],
     platform: "node",
     outdir: ".",
     logLevel: "info",

--- a/server/package.json
+++ b/server/package.json
@@ -50,6 +50,7 @@
     "typescript": "4.5.4"
   },
   "dependencies": {
+    "@nomicfoundation/solidity-analyzer": "0.0.3",
     "@sentry/node": "6.19.1",
     "@sentry/tracing": "6.19.1",
     "@solidity-parser/parser": "^0.14.0",

--- a/server/src/services/documents/attachDocumentHooks.ts
+++ b/server/src/services/documents/attachDocumentHooks.ts
@@ -1,9 +1,9 @@
 import { ServerState } from "../../types";
+import { onDidChangeWatchedFiles } from "./onDidChangeWatchedFiles";
 import { onDidChangeContent } from "./onDidChangeContent";
 import { onDidOpen } from "./onDidOpen";
 import { onDidClose } from "./onDidClose";
 import { onDidSave } from "./onDidSave";
-import { onDidChangeWatchedFiles } from "./onDidChangeWatchedFiles";
 
 /**
  * Establish a sync between the client and the `serverState.documents`

--- a/server/src/services/documents/onDidChangeContent.ts
+++ b/server/src/services/documents/onDidChangeContent.ts
@@ -40,19 +40,19 @@ export function onDidChangeContent(serverState: ServerState) {
   };
 
   return (change: TextDocumentChangeEvent<TextDocument>) => {
-    if (change.document.languageId !== "solidity") {
-      return;
-    }
-
-    const { logger } = serverState;
-
-    logger.trace("onDidChangeContent");
-
     try {
+      if (change.document.languageId !== "solidity") {
+        return;
+      }
+
+      const { logger } = serverState;
+
+      logger.trace("onDidChangeContent");
+
       debouncePerDocument(debounceState.analyse, serverState, change);
       debouncePerDocument(debounceState.validate, serverState, change);
     } catch (err) {
-      logger.error(err);
+      serverState.logger.error(err);
     }
   };
 }

--- a/server/src/services/documents/onDidChangeWatchedFiles.ts
+++ b/server/src/services/documents/onDidChangeWatchedFiles.ts
@@ -1,7 +1,8 @@
-import { ClientTrackingState } from "@common/types";
 import { decodeUriAndRemoveFilePrefix } from "@utils/index";
 import { DidChangeWatchedFilesParams } from "vscode-languageserver";
-import { ServerState, WorkerProcess } from "../../types";
+import { ServerState } from "../../types";
+import { restartWorker } from "../validation/restartWorker";
+import { invalidateWorkerPreprocessCache } from "../validation/invalidateWorkerPreprocessCache";
 
 export function onDidChangeWatchedFiles(serverState: ServerState) {
   return async ({
@@ -31,81 +32,4 @@ export function onDidChangeWatchedFiles(serverState: ServerState) {
 
     return results;
   };
-}
-
-async function invalidateWorkerPreprocessCache(
-  serverState: ServerState,
-  uri: string
-) {
-  return serverState.telemetry.trackTiming<boolean>(
-    "worker preprocessing cache invalidate",
-    async () => {
-      serverState.logger.trace(
-        `Invalidating worker preprocessing cache: ${uri}`
-      );
-
-      const entry = serverState.solFileIndex[uri];
-
-      if (entry === undefined) {
-        return { status: "failed_precondition", result: false };
-      }
-
-      if (entry.tracking === ClientTrackingState.TRACKED) {
-        return { status: "ok", result: false };
-      }
-
-      const project = entry.project;
-
-      if (project.type !== "hardhat") {
-        return { status: "ok", result: false };
-      }
-
-      const workerProcess: WorkerProcess | undefined =
-        serverState.workerProcesses[project.basePath];
-
-      if (workerProcess === undefined) {
-        return { status: "failed_precondition", result: false };
-      }
-
-      const result: boolean =
-        await workerProcess.invalidatePreprocessingCache();
-
-      return { status: "ok", result };
-    }
-  );
-}
-
-async function restartWorker(serverState: ServerState, uri: string) {
-  return serverState.telemetry.trackTiming("worker restart", async () => {
-    serverState.logger.trace(`Restarting worker: ${uri}`);
-
-    const project = Object.values(serverState.projects).find(
-      (p) => p.configPath === uri
-    );
-
-    if (project === undefined) {
-      serverState.logger.error(
-        `No project found for changed config file: ${uri}`
-      );
-
-      return { status: "failed_precondition", result: false };
-    }
-
-    const workerProcess: WorkerProcess | undefined =
-      serverState.workerProcesses[project.basePath];
-
-    if (workerProcess === undefined) {
-      serverState.logger.error(
-        new Error(
-          `No worker process for changed config file: ${project.basePath}`
-        )
-      );
-
-      return { status: "failed_precondition", result: false };
-    }
-
-    await workerProcess.restart();
-
-    return { status: "ok", result: true };
-  });
 }

--- a/server/src/services/validation/invalidateWorkerPreprocessCache.ts
+++ b/server/src/services/validation/invalidateWorkerPreprocessCache.ts
@@ -3,7 +3,8 @@ import { ServerState, WorkerProcess } from "../../types";
 
 export async function invalidateWorkerPreprocessCache(
   serverState: ServerState,
-  uri: string
+  uri: string,
+  allowTracked = false
 ) {
   return serverState.telemetry.trackTiming<boolean>(
     "worker preprocessing cache invalidate",
@@ -18,7 +19,7 @@ export async function invalidateWorkerPreprocessCache(
         return { status: "failed_precondition", result: false };
       }
 
-      if (entry.tracking === ClientTrackingState.TRACKED) {
+      if (!allowTracked && entry.tracking === ClientTrackingState.TRACKED) {
         return { status: "ok", result: false };
       }
 

--- a/server/src/services/validation/invalidateWorkerPreprocessCache.ts
+++ b/server/src/services/validation/invalidateWorkerPreprocessCache.ts
@@ -1,0 +1,44 @@
+import { ClientTrackingState } from "@common/types";
+import { ServerState, WorkerProcess } from "../../types";
+
+export async function invalidateWorkerPreprocessCache(
+  serverState: ServerState,
+  uri: string
+) {
+  return serverState.telemetry.trackTiming<boolean>(
+    "worker preprocessing cache invalidate",
+    async () => {
+      serverState.logger.trace(
+        `Invalidating worker preprocessing cache: ${uri}`
+      );
+
+      const entry = serverState.solFileIndex[uri];
+
+      if (entry === undefined) {
+        return { status: "failed_precondition", result: false };
+      }
+
+      if (entry.tracking === ClientTrackingState.TRACKED) {
+        return { status: "ok", result: false };
+      }
+
+      const project = entry.project;
+
+      if (project.type !== "hardhat") {
+        return { status: "ok", result: false };
+      }
+
+      const workerProcess: WorkerProcess | undefined =
+        serverState.workerProcesses[project.basePath];
+
+      if (workerProcess === undefined) {
+        return { status: "failed_precondition", result: false };
+      }
+
+      const result: boolean =
+        await workerProcess.invalidatePreprocessingCache();
+
+      return { status: "ok", result };
+    }
+  );
+}

--- a/server/src/services/validation/restartWorker.ts
+++ b/server/src/services/validation/restartWorker.ts
@@ -1,0 +1,36 @@
+import { ServerState, WorkerProcess } from "../../types";
+
+export async function restartWorker(serverState: ServerState, uri: string) {
+  return serverState.telemetry.trackTiming("worker restart", async () => {
+    serverState.logger.trace(`Restarting worker: ${uri}`);
+
+    const project = Object.values(serverState.projects).find(
+      (p) => p.configPath === uri
+    );
+
+    if (project === undefined) {
+      serverState.logger.error(
+        `No project found for changed config file: ${uri}`
+      );
+
+      return { status: "failed_precondition", result: false };
+    }
+
+    const workerProcess: WorkerProcess | undefined =
+      serverState.workerProcesses[project.basePath];
+
+    if (workerProcess === undefined) {
+      serverState.logger.error(
+        new Error(
+          `No worker process for changed config file: ${project.basePath}`
+        )
+      );
+
+      return { status: "failed_precondition", result: false };
+    }
+
+    await workerProcess.restart();
+
+    return { status: "ok", result: true };
+  });
+}

--- a/server/src/services/validation/worker/build/buildInputsToSolc.ts
+++ b/server/src/services/validation/worker/build/buildInputsToSolc.ts
@@ -1,3 +1,5 @@
+import { analyze } from "@nomicfoundation/solidity-analyzer";
+import { isDeepStrictEqual } from "util";
 import type { SolcBuild } from "hardhat/types";
 import {
   WorkerState,
@@ -9,15 +11,63 @@ export interface SolcInput {
   built: true;
   jobId: number;
   solcVersion: string;
-  input: {};
+  input: {
+    language: "Solidity";
+    sources: { [key: string]: {} };
+    settings?: { optimizer: {}; outputSelection: {} };
+  };
   solcBuild: SolcBuild;
   sourcePaths: string[];
+}
+
+function overwriteWithCurrentChanges(
+  previous: SolcInput,
+  changedUri: string,
+  changedDocumentText: string
+) {
+  const normalizedChangedUri = changedUri.replaceAll("\\", "/");
+  const changedDocKey = Object.keys(previous.input.sources).find((k) =>
+    normalizedChangedUri.endsWith(k)
+  );
+
+  if (changedDocKey === undefined) {
+    return { overwrite: false };
+  }
+
+  previous.input.sources[changedDocKey] = { content: changedDocumentText };
+
+  return { overwrite: true };
 }
 
 export async function buildInputsToSolc(
   workerState: WorkerState,
   buildJob: BuildJob
 ): Promise<{ built: false; result: ValidationCompleteMessage } | SolcInput> {
+  const analysis = analyze(buildJob.documentText);
+
+  if (isDeepStrictEqual(analysis, workerState.previousChangedDocAnalysis)) {
+    if (workerState.previousSolcInput !== undefined) {
+      const { overwrite } = overwriteWithCurrentChanges(
+        workerState.previousSolcInput,
+        buildJob.uri,
+        buildJob.documentText
+      );
+
+      if (!overwrite) {
+        // log and continue
+        workerState.logger.error(
+          `Unable to overwrite changed doc at: ${buildJob.uri}`
+        );
+      } else {
+        buildJob.preprocessingFinished = new Date();
+        buildJob.fromInputCache = true;
+        return workerState.previousSolcInput;
+      }
+    }
+  } else {
+    workerState.previousChangedDocAnalysis = analysis;
+  }
+
   await getSourcePaths(workerState, buildJob);
 
   if (isJobCancelled(buildJob)) {
@@ -70,7 +120,7 @@ export async function buildInputsToSolc(
 
   buildJob.preprocessingFinished = new Date();
 
-  return {
+  const solcInput: SolcInput = {
     built: true,
     solcVersion,
     jobId: buildJob.jobId,
@@ -78,6 +128,10 @@ export async function buildInputsToSolc(
     solcBuild: buildJob.context.solcBuild,
     sourcePaths: buildJob.context.sourcePaths ?? [],
   };
+
+  workerState.previousSolcInput = solcInput;
+
+  return solcInput;
 }
 
 // Gets the paths to the contract files for the project

--- a/server/src/services/validation/worker/build/solcOutputToCompleteMessage.ts
+++ b/server/src/services/validation/worker/build/solcOutputToCompleteMessage.ts
@@ -71,7 +71,7 @@ function logCompletionMessage(
 
   workerState.logger.trace(
     `[WORKER:${buildJob.jobId}] Validation complete - ${passOrFail} ${
-      buildJob.fromInputCache ? "Cached" : ""
+      buildJob.fromInputCache ? "[Cached]" : ""
     } (total: ${timeSinceInSecs(buildJob.added)}, queued: ${timeSinceInSecs(
       buildJob.added,
       buildJob.startTime

--- a/server/src/services/validation/worker/build/solcOutputToCompleteMessage.ts
+++ b/server/src/services/validation/worker/build/solcOutputToCompleteMessage.ts
@@ -70,11 +70,9 @@ function logCompletionMessage(
         )}, solc: ${timeSinceInSecs(buildJob.preprocessingFinished)}`;
 
   workerState.logger.trace(
-    `[WORKER:${
-      buildJob.jobId
-    }] Validation complete - ${passOrFail} (total: ${timeSinceInSecs(
-      buildJob.added
-    )}, queued: ${timeSinceInSecs(
+    `[WORKER:${buildJob.jobId}] Validation complete - ${passOrFail} ${
+      buildJob.fromInputCache ? "Cached" : ""
+    } (total: ${timeSinceInSecs(buildJob.added)}, queued: ${timeSinceInSecs(
       buildJob.added,
       buildJob.startTime
     )}${finalSection})`

--- a/server/src/services/validation/worker/dispatch.ts
+++ b/server/src/services/validation/worker/dispatch.ts
@@ -122,6 +122,8 @@ async function runNextJob(workerState: WorkerState): Promise<void> {
     documentText: lastDetails.documentText,
     openDocuments: lastDetails.openDocuments,
     added: lastDetails.added,
+
+    fromInputCache: false,
   };
 
   workerState.current = buildJob;

--- a/server/src/services/validation/worker/dispatch.ts
+++ b/server/src/services/validation/worker/dispatch.ts
@@ -8,6 +8,7 @@ import type {
 } from "../../../types";
 import { convertErrorToMessage } from "./build/convertErrorToMessage";
 import { hardhatBuild } from "./build/hardhatBuild";
+import { clearPreprocessingCacheState } from "./utils/clearPreprocessingCacheState";
 
 export function dispatch(workerState: WorkerState) {
   return async (command: HardhatWorkerCommand) => {
@@ -56,8 +57,7 @@ export function dispatch(workerState: WorkerState) {
 function invalidatePreprocessingCache(workerState: WorkerState) {
   workerState.logger.trace(`[WORKER] Preprocessing cache cleared`);
 
-  workerState.previousSolcInput = undefined;
-  workerState.previousChangedDocAnalysis = undefined;
+  clearPreprocessingCacheState(workerState);
 }
 
 async function validate(workerState: WorkerState, command: ValidateCommand) {

--- a/server/src/services/validation/worker/initialiseWorkerState.ts
+++ b/server/src/services/validation/worker/initialiseWorkerState.ts
@@ -52,6 +52,8 @@ export async function initialiseWorkerState(
     current: null,
     buildQueue: [],
     buildJobs: {},
+    compilerMetadataCache: {},
+
     hre,
     solidityFilesCachePath,
     SolidityFilesCache,
@@ -65,7 +67,6 @@ export async function initialiseWorkerState(
       TASK_COMPILE_SOLIDITY_RUN_SOLCJS,
       TASK_COMPILE_SOLIDITY_RUN_SOLC,
     },
-    compilerMetadataCache: {},
     send,
     logger,
   };

--- a/server/src/services/validation/worker/setupWorkerLogger.ts
+++ b/server/src/services/validation/worker/setupWorkerLogger.ts
@@ -6,8 +6,6 @@ export function setupWorkerLogger(): WorkerLogger {
   return {
     log: console.log,
     error: console.error,
-    trace: () => {
-      return null;
-    },
+    trace: console.log,
   };
 }

--- a/server/src/services/validation/worker/utils/clearPreprocessingCacheState.ts
+++ b/server/src/services/validation/worker/utils/clearPreprocessingCacheState.ts
@@ -1,0 +1,6 @@
+import { WorkerState } from "../../../../types";
+
+export function clearPreprocessingCacheState(workerState: WorkerState) {
+  workerState.previousSolcInput = undefined;
+  workerState.previousChangedDocAnalysis = undefined;
+}

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -7,6 +7,8 @@ import type { WorkspaceFolder } from "vscode-languageserver-protocol";
 import type { SolFileIndexMap, SolProjectMap, Diagnostic } from "@common/types";
 import type { HardhatProject } from "@analyzer/HardhatProject";
 import type { SolcBuild } from "hardhat/types";
+import { AnalysisResult } from "@nomicfoundation/solidity-analyzer";
+import { SolcInput } from "@services/validation/worker/build/buildInputsToSolc";
 import type { Telemetry } from "./telemetry/types";
 
 export type CancelResolver = (diagnostics: {
@@ -108,6 +110,7 @@ export interface BuildJob {
   added: Date;
 
   preprocessingFinished?: Date;
+  fromInputCache: boolean;
 }
 
 export interface BuildDetails {
@@ -158,6 +161,8 @@ export interface WorkerState {
   };
   send: (message: ValidationCompleteMessage) => Promise<void>;
   compilerMetadataCache: { [key: string]: Promise<SolcBuild> };
+  previousChangedDocAnalysis?: AnalysisResult;
+  previousSolcInput?: SolcInput;
   logger: WorkerLogger;
 }
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -43,6 +43,7 @@ export interface WorkerProcess {
       documentText: string;
     }>;
   }) => Promise<ValidationCompleteMessage>;
+  invalidatePreprocessingCache: () => Promise<boolean>;
   kill: () => void;
   restart: () => Promise<void>;
 }
@@ -137,6 +138,10 @@ export interface WorkerState {
   current: null | BuildJob;
   buildQueue: string[];
   buildJobs: { [key: string]: BuildDetails };
+  compilerMetadataCache: { [key: string]: Promise<SolcBuild> };
+  previousChangedDocAnalysis?: { uri: string; analysis: AnalysisResult };
+  previousSolcInput?: SolcInput;
+
   hre: HardhatRuntimeEnvironment;
   solidityFilesCachePath: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -160,9 +165,6 @@ export interface WorkerState {
     TASK_COMPILE_SOLIDITY_RUN_SOLC: string;
   };
   send: (message: ValidationCompleteMessage) => Promise<void>;
-  compilerMetadataCache: { [key: string]: Promise<SolcBuild> };
-  previousChangedDocAnalysis?: AnalysisResult;
-  previousSolcInput?: SolcInput;
   logger: WorkerLogger;
 }
 
@@ -208,7 +210,13 @@ export interface ValidateCommand {
   }>;
 }
 
-export type HardhatWorkerCommand = ValidateCommand;
+export interface InvalidatePreprocessingCacheMessage {
+  type: "INVALIDATE_PREPROCESSING_CACHE";
+}
+
+export type HardhatWorkerCommand =
+  | ValidateCommand
+  | InvalidatePreprocessingCacheMessage;
 
 export interface HardhatCompilerError {
   component: "general";

--- a/server/test/helpers/setupMockCompilerProcessFactory.ts
+++ b/server/test/helpers/setupMockCompilerProcessFactory.ts
@@ -27,6 +27,10 @@ export function setupMockCompilerProcessFactory(
         return validationMessage;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       }) as any,
+      invalidatePreprocessingCache: sinon.spy(() => {
+        return true;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any,
       kill: sinon.spy(),
       restart: sinon.spy(),
     } as WorkerProcess;

--- a/server/test/services/documents/onDidChangeWatchedFiles.ts
+++ b/server/test/services/documents/onDidChangeWatchedFiles.ts
@@ -1,6 +1,9 @@
+import { NoProject } from "@analyzer/NoProject";
+import { ClientTrackingState, ISolFileEntry } from "@common/types";
 import { onDidChangeWatchedFiles } from "@services/documents/onDidChangeWatchedFiles";
 import { assert } from "chai";
 import sinon from "sinon";
+import { FileChangeType } from "vscode-languageserver-protocol";
 import { ServerState } from "../../../src/types";
 import { setupMockLogger } from "../../helpers/setupMockLogger";
 import { setupMockTelemetry } from "../../helpers/setupMockTelemetry";
@@ -27,7 +30,7 @@ describe("On did change watched files", () => {
       serverState.projects = {};
 
       const [response] = await onDidChangeWatchedFiles(serverState)({
-        changes: [{ type: 1, uri: "/projects/example/hardhat.config.ts" }],
+        changes: [{ type: 1, uri: "/projects/js-example/hardhat.config.js" }],
       });
 
       assert.deepStrictEqual(response, false);
@@ -56,10 +59,162 @@ describe("On did change watched files", () => {
       assert.deepStrictEqual(response, false);
     });
   });
+
+  describe("change to solidity file", () => {
+    let exampleSolFileEntry: ISolFileEntry;
+
+    beforeEach(() => {
+      exampleSolFileEntry = {
+        project: {
+          type: "hardhat",
+          configPath: "/projects/example/hardhat.config.ts",
+          basePath: "/projects/example",
+        },
+        tracking: ClientTrackingState.UNTRACKED,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+    });
+
+    describe("that is untracked", () => {
+      it("should invalidate the preprocessing cache on the worker", async () => {
+        const mockWorkerProcess = {
+          invalidatePreprocessingCache: sinon.spy(() => true),
+        };
+
+        const serverState = setupServerState(mockWorkerProcess);
+
+        serverState.solFileIndex = {
+          "/projects/example/contracts/a-solidity-file.sol":
+            exampleSolFileEntry,
+        };
+
+        const [response] = await onDidChangeWatchedFiles(serverState)({
+          changes: [
+            {
+              type: FileChangeType.Changed,
+              uri: "/projects/example/contracts/a-solidity-file.sol",
+            },
+          ],
+        });
+
+        assert.deepStrictEqual(response, true);
+        assert(mockWorkerProcess.invalidatePreprocessingCache.called);
+      });
+
+      it("should gracefully fail if no entry for the uri", async () => {
+        const serverState = setupServerState();
+
+        serverState.solFileIndex = {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          "/projects/example/contracts/a-solidity-file.sol": undefined as any,
+        };
+
+        serverState.workerProcesses = {};
+
+        const [response] = await onDidChangeWatchedFiles(serverState)({
+          changes: [
+            { type: 1, uri: "/projects/example/contracts/a-solidity-file.sol" },
+          ],
+        });
+
+        assert.deepStrictEqual(response, false);
+      });
+
+      it("should gracefully fail if not in a hardhat project", async () => {
+        const serverState = setupServerState();
+
+        serverState.solFileIndex = {
+          "/projects/example/contracts/a-solidity-file.sol": {
+            ...exampleSolFileEntry,
+            project: new NoProject(),
+          },
+        };
+
+        serverState.workerProcesses = {};
+
+        const [response] = await onDidChangeWatchedFiles(serverState)({
+          changes: [
+            { type: 1, uri: "/projects/example/contracts/a-solidity-file.sol" },
+          ],
+        });
+
+        assert.deepStrictEqual(response, false);
+      });
+
+      it("should gracefully fail if no worker process for config file", async () => {
+        const serverState = setupServerState();
+
+        serverState.solFileIndex = {
+          "/projects/example/contracts/a-solidity-file.sol":
+            exampleSolFileEntry,
+        };
+
+        serverState.workerProcesses = {};
+
+        const [response] = await onDidChangeWatchedFiles(serverState)({
+          changes: [
+            { type: 1, uri: "/projects/example/contracts/a-solidity-file.sol" },
+          ],
+        });
+
+        assert.deepStrictEqual(response, false);
+      });
+
+      it("should gracefully fail on an unexpected exception", async () => {
+        const serverState = setupServerState();
+
+        serverState.solFileIndex = {
+          "/projects/example/contracts/a-solidity-file.sol":
+            exampleSolFileEntry,
+        };
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        serverState.projects["/projects/example"] = undefined as any;
+
+        const [response] = await onDidChangeWatchedFiles(serverState)({
+          changes: [
+            { type: 1, uri: "/projects/example/contracts/a-solidity-file.sol" },
+          ],
+        });
+
+        assert.deepStrictEqual(response, false);
+      });
+    });
+
+    describe("that is tracked", () => {
+      it("should be ignored", async () => {
+        const mockWorkerProcess = {
+          invalidatePreprocessingCache: sinon.spy(() => true),
+        };
+
+        const serverState = setupServerState(mockWorkerProcess);
+
+        serverState.solFileIndex = {
+          "/projects/example/contracts/a-solidity-file.sol": {
+            ...exampleSolFileEntry,
+            tracking: ClientTrackingState.TRACKED,
+          },
+        };
+
+        const [response] = await onDidChangeWatchedFiles(serverState)({
+          changes: [
+            {
+              type: FileChangeType.Changed,
+              uri: "/projects/example/contracts/a-solidity-file.sol",
+            },
+          ],
+        });
+
+        assert.deepStrictEqual(response, false);
+        assert(mockWorkerProcess.invalidatePreprocessingCache.notCalled);
+      });
+    });
+  });
 });
 
 function setupServerState(mockWorkerProcess?: {
-  restart: () => void;
+  restart?: () => void;
+  invalidatePreprocessingCache?: () => void;
 }): ServerState {
   const serverState = {
     projects: {
@@ -67,10 +222,21 @@ function setupServerState(mockWorkerProcess?: {
         configPath: "/projects/example/hardhat.config.ts",
         basePath: "/projects/example",
       },
+      "/projects/js-example": {
+        configPath: "/projects/js-example/hardhat.config.js",
+        basePath: "/projects/js-example",
+      },
     },
     workerProcesses: {
-      "/projects/example": mockWorkerProcess ?? {
+      "/projects/example": {
         restart: sinon.spy(),
+        invalidatePreprocessingCache: sinon.spy(),
+        ...mockWorkerProcess,
+      },
+      "/projects/js-example": {
+        restart: sinon.spy(),
+        invalidatePreprocessingCache: sinon.spy(),
+        ...mockWorkerProcess,
       },
     },
     telemetry: setupMockTelemetry(),

--- a/server/test/services/validation/worker.ts
+++ b/server/test/services/validation/worker.ts
@@ -5,7 +5,12 @@ import sinon from "sinon";
 import { HardhatError as FrameworkHardhatError } from "hardhat/internal/core/errors";
 import { ErrorDescriptor } from "hardhat/internal/core/errors-list";
 import type { SolcBuild } from "hardhat/types";
-import { ValidateCommand, WorkerState } from "../../../src/types";
+import { SolcInput } from "@services/validation/worker/build/buildInputsToSolc";
+import {
+  InvalidatePreprocessingCacheMessage,
+  ValidateCommand,
+  WorkerState,
+} from "../../../src/types";
 
 describe("worker", () => {
   describe("validation job", () => {
@@ -104,6 +109,15 @@ describe("worker", () => {
             outputSelection: {},
           });
         });
+
+        it("should set the solc input cache", async () => {
+          assert.deepStrictEqual(workerState.previousChangedDocAnalysis, {
+            uri: "/projects/example/contracts/first.sol",
+            analysis: { imports: [], versionPragmas: [">=0.8.2 <0.9.0"] },
+          });
+
+          assert.isDefined(workerState.previousSolcInput);
+        });
       });
 
       describe("with solc warnings/errors", () => {
@@ -194,6 +208,137 @@ describe("worker", () => {
             !solcBuildCalled,
             "Solc build should not have been called, the cache should have been used"
           );
+        });
+      });
+
+      describe("with cached solc input", () => {
+        describe("matching the current uri", () => {
+          let solcCompileCalled: boolean;
+          let workerState: WorkerState;
+
+          before(async () => {
+            workerState = setupWorkerState({ errors: [] });
+
+            workerState.hre = setupMockHre({
+              errors: [],
+              interleavedActions: {
+                TASK_COMPILE_SOLIDITY_RUN_SOLC: async () => {
+                  solcCompileCalled = true;
+                },
+              },
+            });
+
+            workerState.previousChangedDocAnalysis = {
+              uri: "/projects/example/contracts/first.sol",
+              analysis: { imports: [], versionPragmas: [">=0.8.2 <0.9.0"] },
+            };
+            workerState.previousSolcInput = {
+              input: {
+                sources: {
+                  "contracts/first.sol": { content: "NOT OVERWRITTEN" },
+                },
+              },
+            } as any;
+
+            await dispatch(workerState)(exampleValidation);
+          });
+
+          it("should not call `solc compile`", async () => {
+            assert(
+              !solcCompileCalled,
+              "Solc compile should not have been called, the cache should have been used"
+            );
+          });
+
+          it("overwrites the solc input", async () => {
+            assert.deepStrictEqual(
+              workerState.previousSolcInput?.input.sources[
+                "contracts/first.sol"
+              ],
+              {
+                content:
+                  "// SPDX-License-Identifier: GPL-3.0\npragma solidity >=0.8.2 <0.9.0;",
+              }
+            );
+          });
+        });
+
+        describe("not matching the current uri", () => {
+          let solcCompileCalled: boolean;
+          let workerState: WorkerState;
+
+          before(async () => {
+            workerState = setupWorkerState({ errors: [] });
+
+            workerState.hre = setupMockHre({
+              errors: [],
+              interleavedActions: {
+                TASK_COMPILE_SOLIDITY_RUN_SOLC: async () => {
+                  solcCompileCalled = true;
+                },
+              },
+            });
+
+            workerState.previousChangedDocAnalysis = {
+              uri: "/projects/example/contracts/some_other.sol",
+              analysis: { imports: [], versionPragmas: [">=0.8.2 <0.9.0"] },
+            };
+
+            await dispatch(workerState)(exampleValidation);
+          });
+
+          it("falls back to `solc compile`", async () => {
+            assert(
+              solcCompileCalled,
+              "Solc compile should have been called, the cache doesn't match"
+            );
+          });
+        });
+      });
+
+      describe("with invalid cached solc input", () => {
+        let solcCompileCalled: boolean;
+        let workerState: WorkerState;
+        let originalSolcInput: SolcInput;
+
+        before(async () => {
+          workerState = setupWorkerState({ errors: [] });
+
+          originalSolcInput = Object.freeze({
+            input: {
+              sources: {
+                invalid: { content: "invalid" },
+              },
+            },
+          } as any);
+
+          workerState.hre = setupMockHre({
+            errors: [],
+            interleavedActions: {
+              TASK_COMPILE_SOLIDITY_RUN_SOLC: async () => {
+                solcCompileCalled = true;
+              },
+            },
+          });
+
+          workerState.previousChangedDocAnalysis = {
+            uri: "/projects/example/contracts/first.sol",
+            analysis: { imports: [], versionPragmas: [">=0.8.2 <0.9.0"] },
+          };
+          workerState.previousSolcInput = originalSolcInput;
+
+          await dispatch(workerState)(exampleValidation);
+        });
+
+        it("should fall back on `solc compile`", async () => {
+          assert(
+            solcCompileCalled,
+            "Solc compile should have been called as the cache was invalid"
+          );
+        });
+
+        it("logs the error", async () => {
+          assert((workerState.logger.error as any).called);
         });
       });
     });
@@ -293,6 +438,9 @@ describe("worker", () => {
             assert.equal(workerState.current, null);
             assert.deepStrictEqual(workerState.buildJobs, {});
             assert.deepStrictEqual(workerState.buildQueue, []);
+            assert.deepStrictEqual(workerState.compilerMetadataCache, {});
+            assert.equal(workerState.previousSolcInput, undefined);
+            assert.equal(workerState.previousChangedDocAnalysis, undefined);
           });
 
           it("should ignore an issue with send", async () => {
@@ -881,6 +1029,35 @@ describe("worker", () => {
           ],
         });
       });
+    });
+  });
+
+  describe("invalidate preprocessing cache", () => {
+    let workerState: WorkerState;
+
+    const exampleInvalidateMessage: InvalidatePreprocessingCacheMessage = {
+      type: "INVALIDATE_PREPROCESSING_CACHE",
+    };
+
+    before(async () => {
+      workerState = setupWorkerState({ errors: [] });
+
+      workerState.previousChangedDocAnalysis = {
+        uri: "/projects/example/contracts/first.sol",
+        analysis: {
+          versionPragmas: ["0.8.0"],
+          imports: ["./example.sol"],
+        },
+      };
+
+      workerState.previousSolcInput = { fake: "input" } as any;
+
+      await dispatch(workerState)(exampleInvalidateMessage);
+    });
+
+    it("should clear the preprocessing cache", async () => {
+      assert.equal(workerState.previousChangedDocAnalysis, undefined);
+      assert.equal(workerState.previousSolcInput, undefined);
     });
   });
 });

--- a/server/test/services/validation/worker.ts
+++ b/server/test/services/validation/worker.ts
@@ -11,7 +11,6 @@ import {
   ValidateCommand,
   WorkerState,
 } from "../../../src/types";
-import { worker } from "cluster";
 
 describe("worker", () => {
   describe("validation job", () => {

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -522,6 +522,72 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@nomicfoundation/solidity-analyzer-darwin-arm64@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/solidity-analyzer-darwin-arm64/-/solidity-analyzer-darwin-arm64-0.0.3.tgz#1d49e4ac028831a3011a9f3dca60bd1963185342"
+  integrity sha512-W+bIiNiZmiy+MTYFZn3nwjyPUO6wfWJ0lnXx2zZrM8xExKObMrhCh50yy8pQING24mHfpPFCn89wEB/iG7vZDw==
+
+"@nomicfoundation/solidity-analyzer-darwin-x64@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/solidity-analyzer-darwin-x64/-/solidity-analyzer-darwin-x64-0.0.3.tgz#c0fccecc5506ff5466225e41e65691abafef3dbe"
+  integrity sha512-HuJd1K+2MgmFIYEpx46uzwEFjvzKAI765mmoMxy4K+Aqq1p+q7hHRlsFU2kx3NB8InwotkkIq3A5FLU1sI1WDw==
+
+"@nomicfoundation/solidity-analyzer-freebsd-x64@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/solidity-analyzer-freebsd-x64/-/solidity-analyzer-freebsd-x64-0.0.3.tgz#8261d033f7172b347490cd005931ef8168ab4d73"
+  integrity sha512-2cR8JNy23jZaO/vZrsAnWCsO73asU7ylrHIe0fEsXbZYqBP9sMr+/+xP3CELDHJxUbzBY8zqGvQt1ULpyrG+Kw==
+
+"@nomicfoundation/solidity-analyzer-linux-arm64-gnu@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/solidity-analyzer-linux-arm64-gnu/-/solidity-analyzer-linux-arm64-gnu-0.0.3.tgz#1ba64b1d76425f8953dedc6367bd7dd46f31dfc5"
+  integrity sha512-Eyv50EfYbFthoOb0I1568p+eqHGLwEUhYGOxcRNywtlTE9nj+c+MT1LA53HnxD9GsboH4YtOOmJOulrjG7KtbA==
+
+"@nomicfoundation/solidity-analyzer-linux-arm64-musl@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/solidity-analyzer-linux-arm64-musl/-/solidity-analyzer-linux-arm64-musl-0.0.3.tgz#8d864c49b55e683f7e3b5cce9d10b628797280ac"
+  integrity sha512-V8grDqI+ivNrgwEt2HFdlwqV2/EQbYAdj3hbOvjrA8Qv+nq4h9jhQUxFpegYMDtpU8URJmNNlXgtfucSrAQwtQ==
+
+"@nomicfoundation/solidity-analyzer-linux-x64-gnu@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/solidity-analyzer-linux-x64-gnu/-/solidity-analyzer-linux-x64-gnu-0.0.3.tgz#16e769500cf1a8bb42ab9498cee3b93c30f78295"
+  integrity sha512-uRfVDlxtwT1vIy7MAExWAkRD4r9M79zMG7S09mCrWUn58DbLs7UFl+dZXBX0/8FTGYWHhOT/1Etw1ZpAf5DTrg==
+
+"@nomicfoundation/solidity-analyzer-linux-x64-musl@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/solidity-analyzer-linux-x64-musl/-/solidity-analyzer-linux-x64-musl-0.0.3.tgz#75f4e1a25526d54c506e4eba63b3d698b6255b8f"
+  integrity sha512-8HPwYdLbhcPpSwsE0yiU/aZkXV43vlXT2ycH+XlOjWOnLfH8C41z0njK8DHRtEFnp4OVN6E7E5lHBBKDZXCliA==
+
+"@nomicfoundation/solidity-analyzer-win32-arm64-msvc@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/solidity-analyzer-win32-arm64-msvc/-/solidity-analyzer-win32-arm64-msvc-0.0.3.tgz#ef6e20cfad5eedfdb145cc34a44501644cd7d015"
+  integrity sha512-5WWcT6ZNvfCuxjlpZOY7tdvOqT1kIQYlDF9Q42wMpZ5aTm4PvjdCmFDDmmTvyXEBJ4WTVmY5dWNWaxy8h/E28g==
+
+"@nomicfoundation/solidity-analyzer-win32-ia32-msvc@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/solidity-analyzer-win32-ia32-msvc/-/solidity-analyzer-win32-ia32-msvc-0.0.3.tgz#98c4e3af9cee68896220fa7e270aefdf7fc89c7b"
+  integrity sha512-P/LWGZwWkyjSwkzq6skvS2wRc3gabzAbk6Akqs1/Iiuggql2CqdLBkcYWL5Xfv3haynhL+2jlNkak+v2BTZI4A==
+
+"@nomicfoundation/solidity-analyzer-win32-x64-msvc@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/solidity-analyzer-win32-x64-msvc/-/solidity-analyzer-win32-x64-msvc-0.0.3.tgz#12da288e7ef17ec14848f19c1e8561fed20d231d"
+  integrity sha512-4AcTtLZG1s/S5mYAIr/sdzywdNwJpOcdStGF3QMBzEt+cGn3MchMaS9b1gyhb2KKM2c39SmPF5fUuWq1oBSQZQ==
+
+"@nomicfoundation/solidity-analyzer@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/solidity-analyzer/-/solidity-analyzer-0.0.3.tgz#d1029f872e66cb1082503b02cc8b0be12f8dd95e"
+  integrity sha512-VFMiOQvsw7nx5bFmrmVp2Q9rhIjw2AFST4DYvWVVO9PMHPE23BY2+kyfrQ4J3xCMFC8fcBbGLt7l4q7m1SlTqg==
+  optionalDependencies:
+    "@nomicfoundation/solidity-analyzer-darwin-arm64" "0.0.3"
+    "@nomicfoundation/solidity-analyzer-darwin-x64" "0.0.3"
+    "@nomicfoundation/solidity-analyzer-freebsd-x64" "0.0.3"
+    "@nomicfoundation/solidity-analyzer-linux-arm64-gnu" "0.0.3"
+    "@nomicfoundation/solidity-analyzer-linux-arm64-musl" "0.0.3"
+    "@nomicfoundation/solidity-analyzer-linux-x64-gnu" "0.0.3"
+    "@nomicfoundation/solidity-analyzer-linux-x64-musl" "0.0.3"
+    "@nomicfoundation/solidity-analyzer-win32-arm64-msvc" "0.0.3"
+    "@nomicfoundation/solidity-analyzer-win32-ia32-msvc" "0.0.3"
+    "@nomicfoundation/solidity-analyzer-win32-x64-msvc" "0.0.3"
+
 "@sentry/core@5.30.0":
   version "5.30.0"
   resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.30.0.tgz#6b203664f69e75106ee8b5a2fe1d717379b331f3"


### PR DESCRIPTION
Within the worker (`workerState`) we retain the last input to solc calculated by the preprocessing steps. If the same uri with the same solc version and imports comes in again, we reuse the same input with an updated content for the one changed file.

This gives a performance improvement (the preprocessing is the larger part of validation in big codebases) for the most common case which is lots of changes in a single file.

Fixes #55

## TODO

* [x] implement caching based on changed doc
* [x] invalidate cache if changes (from file-system) come in on other files
* [x] bundling into vsix
