### PR TITLE
fix(validation): use open docs in preprocessing steps

### DIFF
--- a/server/src/services/validation/worker/initialiseWorkerState.ts
+++ b/server/src/services/validation/worker/initialiseWorkerState.ts
@@ -37,6 +37,7 @@ export async function initialiseWorkerState(
     TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD,
     TASK_COMPILE_SOLIDITY_RUN_SOLCJS,
     TASK_COMPILE_SOLIDITY_RUN_SOLC,
+    TASK_COMPILE_SOLIDITY_READ_FILE,
     // eslint-disable-next-line @typescript-eslint/no-var-requires
   } = require(`${hardhatBase}/builtin-tasks/task-names`);
 
@@ -48,6 +49,9 @@ export async function initialiseWorkerState(
 
   const solidityFilesCachePath = getSolidityFilesCachePath(hre.config.paths);
 
+  const originalReadFileAction =
+    hre.tasks[TASK_COMPILE_SOLIDITY_READ_FILE].action;
+
   return {
     current: null,
     buildQueue: [],
@@ -55,6 +59,7 @@ export async function initialiseWorkerState(
     compilerMetadataCache: {},
 
     hre,
+    originalReadFileAction,
     solidityFilesCachePath,
     SolidityFilesCache,
     tasks: {
@@ -66,6 +71,7 @@ export async function initialiseWorkerState(
       TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD,
       TASK_COMPILE_SOLIDITY_RUN_SOLCJS,
       TASK_COMPILE_SOLIDITY_RUN_SOLC,
+      TASK_COMPILE_SOLIDITY_READ_FILE,
     },
     send,
     logger,

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -6,9 +6,9 @@ import type { Logger } from "@utils/Logger";
 import type { WorkspaceFolder } from "vscode-languageserver-protocol";
 import type { SolFileIndexMap, SolProjectMap, Diagnostic } from "@common/types";
 import type { HardhatProject } from "@analyzer/HardhatProject";
-import type { SolcBuild } from "hardhat/types";
-import { AnalysisResult } from "@nomicfoundation/solidity-analyzer";
-import { SolcInput } from "@services/validation/worker/build/buildInputsToSolc";
+import type { HardhatRuntimeEnvironment, SolcBuild } from "hardhat/types";
+import type { AnalysisResult } from "@nomicfoundation/solidity-analyzer";
+import type { SolcInput } from "@services/validation/worker/build/buildInputsToSolc";
 import type { Telemetry } from "./telemetry/types";
 
 export type CancelResolver = (diagnostics: {
@@ -126,14 +126,6 @@ export interface BuildDetails {
   added: Date;
 }
 
-export interface HardhatRuntimeEnvironment {
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  run: Function;
-  config: {
-    paths: string[];
-  };
-}
-
 export interface WorkerState {
   current: null | BuildJob;
   buildQueue: string[];
@@ -143,6 +135,11 @@ export interface WorkerState {
   previousSolcInput?: SolcInput;
 
   hre: HardhatRuntimeEnvironment;
+  originalReadFileAction: (
+    args: { absolutePath: string },
+    hre: HardhatRuntimeEnvironment,
+    runSuper: () => {}
+  ) => Promise<string>;
   solidityFilesCachePath: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   SolidityFilesCache: any;
@@ -163,6 +160,8 @@ export interface WorkerState {
     TASK_COMPILE_SOLIDITY_RUN_SOLCJS: string;
     // eslint-disable-next-line @typescript-eslint/naming-convention
     TASK_COMPILE_SOLIDITY_RUN_SOLC: string;
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    TASK_COMPILE_SOLIDITY_READ_FILE: string;
   };
   send: (message: ValidationCompleteMessage) => Promise<void>;
   logger: WorkerLogger;


### PR DESCRIPTION
We override hardhat read file task, to read from the passed in open documents array of the build job. This fixes the import line issue with import line errors being based on the disk version rather than the open editor version.

Fixes #201

## Preview

![Jun-10-2022 12-20-15](https://user-images.githubusercontent.com/24030/173054374-277145ef-cd5a-448a-8f42-76d22e60320f.gif)

