### PR TITLE
docs: remove usages of hardhat vscode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
-- Remove unnecessary setting for turning off formatting, use vscode formatting config if you want to turn Hardhat VSCode formatting off ([#102](https://github.com/NomicFoundation/hardhat-vscode/issues/102))
+- Remove unnecessary setting for turning off formatting, use vscode formatting config if you want to turn **Hardhat for Visual Studio Code** formatting off ([#102](https://github.com/NomicFoundation/hardhat-vscode/issues/102))
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Join our [Hardhat Support Discord server](https://hardhat.org/discord) to stay u
 
 Contributions are always welcome! Feel free to [open any issue](https://github.com/NomicFoundation/hardhat-vscode/issues) or send a pull request.
 
-Go to [CONTRIBUTING.md](./CONTRIBUTING.md) to learn about how to set up Hardhat VSCode's development environment.
+Go to [CONTRIBUTING.md](./CONTRIBUTING.md) to learn about how to set up **Hardhat for Visual Studio Code**'s development environment.
 
 ## Feedback, help and news
 


### PR DESCRIPTION
We want to use the same way of referring to the extension everywhere, the docs have been updated from `Hardhat VSCode` to `**Hardhat for Visual Studio Code**`.
