### PR TITLE
feat:  Support intermediary stars in block comments #75

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -31,5 +31,53 @@
     ["{", "}"],
     ["[", "]"],
     ["(", ")"]
+  ],
+  "onEnterRules": [
+    {
+      // e.g. /** | */
+      "beforeText": {
+        "pattern": "^\\s*/\\*\\*(?!/)([^\\*]|\\*(?!/))*$"
+      },
+      "afterText": {
+        "pattern": "^\\s*\\*/$"
+      },
+      "action": {
+        "indent": "indentOutdent",
+        "appendText": " * "
+      }
+    },
+    {
+      // e.g. /** ...|
+      "beforeText": {
+        "pattern": "^\\s*/\\*\\*(?!/)([^\\*]|\\*(?!/))*$"
+      },
+      "action": {
+        "indent": "none",
+        "appendText": " * "
+      }
+    },
+    {
+      // e.g.  * ...|
+      "beforeText": {
+        "pattern": "^(\\t|[ ])*[ ]\\*([ ]([^\\*]|\\*(?!/))*)?$"
+      },
+      "previousLineText": {
+        "pattern": "(?=^(\\s*(/\\*\\*|\\*)).*)(?=(?!(\\s*\\*/)))"
+      },
+      "action": {
+        "indent": "none",
+        "appendText": "* "
+      }
+    },
+    {
+      // e.g.  */|
+      "beforeText": {
+        "pattern": "^(\\t|[ ])*[ ]\\*/\\s*$"
+      },
+      "action": {
+        "indent": "none",
+        "removeText": 1
+      }
+    }
   ]
 }

--- a/test/integration/client.ts
+++ b/test/integration/client.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import * as lsclient from "vscode-languageclient/node";
 
-import { sleep } from "./common/helper";
+import { sleep } from "./helpers/misc";
 import { Client as IClient } from "./common/types";
 
 let client: Client | null = null;

--- a/test/integration/client.ts
+++ b/test/integration/client.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import * as lsclient from "vscode-languageclient/node";
 
-import { sleep } from "./helpers/misc";
+import { sleep } from "./helpers/sleep";
 import { Client as IClient } from "./common/types";
 
 let client: Client | null = null;

--- a/test/integration/common/assertLspCommand.ts
+++ b/test/integration/common/assertLspCommand.ts
@@ -3,7 +3,7 @@ import * as vscode from "vscode";
 import * as assert from "assert";
 
 import { Client, Action } from "../common/types";
-import { isArray, isDefined, rangeEqual, uriEqual } from "./helper";
+import { isArray, isDefined, rangeEqual, uriEqual } from "../helpers/misc";
 
 export async function assertLspCommand(client: Client, action: Action) {
   await ensureValidationOfDoc(client, action);

--- a/test/integration/common/assertLspCommand.ts
+++ b/test/integration/common/assertLspCommand.ts
@@ -3,7 +3,12 @@ import * as vscode from "vscode";
 import * as assert from "assert";
 
 import { Client, Action } from "../common/types";
-import { isArray, isDefined, rangeEqual, uriEqual } from "../helpers/misc";
+import {
+  isArray,
+  isDefined,
+  rangeEqual,
+  uriEqual,
+} from "../helpers/assertions";
 
 export async function assertLspCommand(client: Client, action: Action) {
   await ensureValidationOfDoc(client, action);

--- a/test/integration/helpers/assertions.ts
+++ b/test/integration/helpers/assertions.ts
@@ -1,26 +1,6 @@
 "use strict";
-
-import * as path from "path";
 import * as vscode from "vscode";
 import * as assert from "assert";
-import * as os from "os";
-
-export async function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-export function getDocPath(dirname: string, p: string): string {
-  // TO-DO: Refactor this
-  return path.join(
-    dirname.replace("/out/", "/").replace("\\out\\", "\\"),
-    "testdata",
-    p
-  );
-}
-
-export function getDocUri(dirname: string, p: string): vscode.Uri {
-  return vscode.Uri.file(getDocPath(dirname, p));
-}
 
 export function rangeEqual(
   range: vscode.Range,
@@ -82,9 +62,3 @@ export function isArray<T>(
   );
   assert.strictEqual(value.length, length, "value invalid length");
 }
-
-/**
- * OS-independant line joining
- */
-export const joinLines = (...args: string[]) =>
-  args.join(os.platform() === "win32" ? "\r\n" : "\n");

--- a/test/integration/helpers/commands.ts
+++ b/test/integration/helpers/commands.ts
@@ -1,0 +1,28 @@
+import * as vscode from "vscode";
+
+const onDocumentChange = (
+  doc: vscode.TextDocument
+): Promise<vscode.TextDocument> => {
+  return new Promise<vscode.TextDocument>((resolve) => {
+    const disposable = vscode.workspace.onDidChangeTextDocument((e) => {
+      if (e.document !== doc) {
+        return;
+      }
+      disposable.dispose();
+      resolve(e.document);
+    });
+  });
+};
+
+/**
+ * Simulate typing on the editor
+ */
+export const type = async (
+  document: vscode.TextDocument,
+  text: string
+): Promise<vscode.TextDocument> => {
+  const onChange = onDocumentChange(document);
+  await vscode.commands.executeCommand("type", { text });
+  await onChange;
+  return document;
+};

--- a/test/integration/helpers/docPaths.ts
+++ b/test/integration/helpers/docPaths.ts
@@ -1,0 +1,16 @@
+"use strict";
+import * as path from "path";
+import * as vscode from "vscode";
+
+export function getDocPath(dirname: string, p: string): string {
+  // TO-DO: Refactor this
+  return path.join(
+    dirname.replace("/out/", "/").replace("\\out\\", "\\"),
+    "testdata",
+    p
+  );
+}
+
+export function getDocUri(dirname: string, p: string): vscode.Uri {
+  return vscode.Uri.file(getDocPath(dirname, p));
+}

--- a/test/integration/helpers/files.ts
+++ b/test/integration/helpers/files.ts
@@ -18,7 +18,7 @@ export const withRandomFileEditor = async (
     editor: vscode.TextEditor,
     document: vscode.TextDocument
   ) => Promise<void>
-): Promise<boolean> => {
+): Promise<void> => {
   const cursorIndex = text.indexOf(CURSOR);
   const file = await createRandomFile(text.replace(CURSOR, ""), fileExtension);
   const document = await vscode.workspace.openTextDocument(file);
@@ -32,39 +32,19 @@ export const withRandomFileEditor = async (
   await sleep(200); // Wait a bit, otherwise onEnterRules randomly don't work on test scenarios
 
   await run(editor, document);
-  if (document.isDirty) {
-    return document.save().then(() => {
-      return deleteFile(file);
-    });
-  } else {
-    return deleteFile(file);
-  }
+
+  deleteFile(file);
 };
 
-const createRandomFile = (
-  contents = "",
-  fileExtension = "txt"
+const createRandomFile = async (
+  contents: string,
+  fileExtension: string
 ): Promise<vscode.Uri> => {
-  return new Promise((resolve, reject) => {
-    const tmpFile = join(os.tmpdir(), `${Math.random()}.${fileExtension}`);
-    fs.writeFile(tmpFile, contents, (error) => {
-      if (error) {
-        return reject(error);
-      }
-
-      resolve(vscode.Uri.file(tmpFile));
-    });
-  });
+  const tmpFile = join(os.tmpdir(), `${Math.random()}.${fileExtension}`);
+  fs.writeFileSync(tmpFile, contents);
+  return vscode.Uri.file(tmpFile);
 };
 
-const deleteFile = (file: vscode.Uri): Promise<boolean> => {
-  return new Promise((resolve, reject) => {
-    fs.unlink(file.fsPath, (err) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(true);
-      }
-    });
-  });
+const deleteFile = (file: vscode.Uri): void => {
+  fs.unlinkSync(file.fsPath);
 };

--- a/test/integration/helpers/files.ts
+++ b/test/integration/helpers/files.ts
@@ -1,0 +1,70 @@
+"use strict";
+import * as vscode from "vscode";
+import { join } from "path";
+import * as fs from "fs";
+import * as os from "os";
+import { sleep } from "./misc";
+
+export const CURSOR = "$$CURSOR$$";
+
+/**
+ * Create a temporary file with a given text and file extension
+ * Provides a callback for manipulating the document
+ */
+export const withRandomFileEditor = async (
+  text: string,
+  fileExtension: string,
+  run: (
+    editor: vscode.TextEditor,
+    document: vscode.TextDocument
+  ) => Promise<void>
+): Promise<boolean> => {
+  const cursorIndex = text.indexOf(CURSOR);
+  const file = await createRandomFile(text.replace(CURSOR, ""), fileExtension);
+  const document = await vscode.workspace.openTextDocument(file);
+  const editor = await vscode.window.showTextDocument(document);
+
+  if (cursorIndex >= 0) {
+    const position = document.positionAt(cursorIndex);
+    editor.selection = new vscode.Selection(position, position);
+  }
+
+  await sleep(200); // Wait a bit, otherwise onEnterRules randomly don't work on test scenarios
+
+  await run(editor, document);
+  if (document.isDirty) {
+    return document.save().then(() => {
+      return deleteFile(file);
+    });
+  } else {
+    return deleteFile(file);
+  }
+};
+
+const createRandomFile = (
+  contents = "",
+  fileExtension = "txt"
+): Promise<vscode.Uri> => {
+  return new Promise((resolve, reject) => {
+    const tmpFile = join(os.tmpdir(), `${Math.random()}.${fileExtension}`);
+    fs.writeFile(tmpFile, contents, (error) => {
+      if (error) {
+        return reject(error);
+      }
+
+      resolve(vscode.Uri.file(tmpFile));
+    });
+  });
+};
+
+const deleteFile = (file: vscode.Uri): Promise<boolean> => {
+  return new Promise((resolve, reject) => {
+    fs.unlink(file.fsPath, (err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(true);
+      }
+    });
+  });
+};

--- a/test/integration/helpers/files.ts
+++ b/test/integration/helpers/files.ts
@@ -3,7 +3,7 @@ import * as vscode from "vscode";
 import { join } from "path";
 import * as fs from "fs";
 import * as os from "os";
-import { sleep } from "./misc";
+import { sleep } from "./sleep";
 
 export const CURSOR = "$$CURSOR$$";
 

--- a/test/integration/helpers/joinLines.ts
+++ b/test/integration/helpers/joinLines.ts
@@ -1,0 +1,9 @@
+"use strict";
+import * as os from "os";
+
+/**
+ * OS-independant line joining
+ */
+
+export const joinLines = (...args: string[]) =>
+  args.join(os.platform() === "win32" ? "\r\n" : "\n");

--- a/test/integration/helpers/misc.ts
+++ b/test/integration/helpers/misc.ts
@@ -3,6 +3,7 @@
 import * as path from "path";
 import * as vscode from "vscode";
 import * as assert from "assert";
+import * as os from "os";
 
 export async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -81,3 +82,9 @@ export function isArray<T>(
   );
   assert.strictEqual(value.length, length, "value invalid length");
 }
+
+/**
+ * OS-independant line joining
+ */
+export const joinLines = (...args: string[]) =>
+  args.join(os.platform() === "win32" ? "\r\n" : "\n");

--- a/test/integration/helpers/sleep.ts
+++ b/test/integration/helpers/sleep.ts
@@ -1,0 +1,5 @@
+"use strict";
+
+export async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/test/integration/tests/definition/definition.test.ts
+++ b/test/integration/tests/definition/definition.test.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import { getClient } from "../../client";
 import { Client } from "../../common/types";
 import { assertLspCommand } from "../../common/assertLspCommand";
-import { getDocUri } from "../../common/helper";
+import { getDocUri } from "../../helpers/misc";
 
 suite("Single-file Navigation", function () {
   this.timeout(10000);

--- a/test/integration/tests/definition/definition.test.ts
+++ b/test/integration/tests/definition/definition.test.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import { getClient } from "../../client";
 import { Client } from "../../common/types";
 import { assertLspCommand } from "../../common/assertLspCommand";
-import { getDocUri } from "../../helpers/misc";
+import { getDocUri } from "../../helpers/docPaths";
 
 suite("Single-file Navigation", function () {
   this.timeout(10000);

--- a/test/integration/tests/implementation/implementation.test.ts
+++ b/test/integration/tests/implementation/implementation.test.ts
@@ -1,7 +1,7 @@
 import { getClient } from "../../client";
 import { Client } from "../../common/types";
 import { assertLspCommand } from "../../common/assertLspCommand";
-import { getDocUri } from "../../common/helper";
+import { getDocUri } from "../../helpers/misc";
 
 suite("Single-file Navigation", function () {
   this.timeout(10000);

--- a/test/integration/tests/implementation/implementation.test.ts
+++ b/test/integration/tests/implementation/implementation.test.ts
@@ -1,7 +1,7 @@
 import { getClient } from "../../client";
 import { Client } from "../../common/types";
 import { assertLspCommand } from "../../common/assertLspCommand";
-import { getDocUri } from "../../helpers/misc";
+import { getDocUri } from "../../helpers/docPaths";
 
 suite("Single-file Navigation", function () {
   this.timeout(10000);

--- a/test/integration/tests/language-configuration/onEnterRules.test.ts
+++ b/test/integration/tests/language-configuration/onEnterRules.test.ts
@@ -5,7 +5,7 @@ import { type } from "../../helpers/commands";
 
 suite("onEnterRules", function () {
   test("[onEnterRules] - Multi line comment - first line with closing", async () => {
-    return withRandomFileEditor(
+    await withRandomFileEditor(
       `/**${CURSOR} */`,
       "sol",
       async (_editor, document) => {
@@ -16,7 +16,7 @@ suite("onEnterRules", function () {
   });
 
   test("[onEnterRules] - Multi line comment - first line without closing", async () => {
-    return withRandomFileEditor(
+    await withRandomFileEditor(
       `/**${CURSOR}`,
       "sol",
       async (_editor, document) => {
@@ -27,7 +27,7 @@ suite("onEnterRules", function () {
   });
 
   test("[onEnterRules] - Multi line comment - line in middle", async () => {
-    return withRandomFileEditor(
+    await withRandomFileEditor(
       joinLines(`/**`, ` * a line${CURSOR}`),
       "sol",
       async (_editor, document) => {
@@ -41,7 +41,7 @@ suite("onEnterRules", function () {
   });
 
   test("[onEnterRules] - Multi line comment - remove space when closing", async () => {
-    return withRandomFileEditor(
+    await withRandomFileEditor(
       joinLines(`  /**`, `   * a line`, `   */${CURSOR}`),
       "sol",
       async (_editor, document) => {

--- a/test/integration/tests/language-configuration/onEnterRules.test.ts
+++ b/test/integration/tests/language-configuration/onEnterRules.test.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import { joinLines } from "../../helpers/misc";
+import { joinLines } from "../../helpers/joinLines";
 import { CURSOR, withRandomFileEditor } from "../../helpers/files";
 import { type } from "../../helpers/commands";
 

--- a/test/integration/tests/language-configuration/onEnterRules.test.ts
+++ b/test/integration/tests/language-configuration/onEnterRules.test.ts
@@ -1,0 +1,56 @@
+import * as assert from "assert";
+import { joinLines } from "../../helpers/misc";
+import { CURSOR, withRandomFileEditor } from "../../helpers/files";
+import { type } from "../../helpers/commands";
+
+suite("onEnterRules", function () {
+  test("[onEnterRules] - Multi line comment - first line with closing", async () => {
+    return withRandomFileEditor(
+      `/**${CURSOR} */`,
+      "sol",
+      async (_editor, document) => {
+        await type(document, "\nx");
+        assert.strictEqual(document.getText(), joinLines(`/**`, ` * x`, ` */`));
+      }
+    );
+  });
+
+  test("[onEnterRules] - Multi line comment - first line without closing", async () => {
+    return withRandomFileEditor(
+      `/**${CURSOR}`,
+      "sol",
+      async (_editor, document) => {
+        await type(document, "\nx");
+        assert.strictEqual(document.getText(), joinLines(`/**`, ` * x`));
+      }
+    );
+  });
+
+  test("[onEnterRules] - Multi line comment - line in middle", async () => {
+    return withRandomFileEditor(
+      joinLines(`/**`, ` * a line${CURSOR}`),
+      "sol",
+      async (_editor, document) => {
+        await type(document, "\nx");
+        assert.strictEqual(
+          document.getText(),
+          joinLines(`/**`, ` * a line`, ` * x`)
+        );
+      }
+    );
+  });
+
+  test("[onEnterRules] - Multi line comment - remove space when closing", async () => {
+    return withRandomFileEditor(
+      joinLines(`  /**`, `   * a line`, `   */${CURSOR}`),
+      "sol",
+      async (_editor, document) => {
+        await type(document, "\nx");
+        assert.strictEqual(
+          document.getText(),
+          joinLines(`  /**`, `   * a line`, `   */`, `  x`)
+        );
+      }
+    );
+  });
+});

--- a/test/integration/tests/references/references.test.ts
+++ b/test/integration/tests/references/references.test.ts
@@ -1,7 +1,7 @@
 import { getClient } from "../../client";
 import { Client } from "../../common/types";
 import { assertLspCommand } from "../../common/assertLspCommand";
-import { getDocUri } from "../../common/helper";
+import { getDocUri } from "../../helpers/misc";
 
 suite("Single-file Navigation", function () {
   this.timeout(10000);

--- a/test/integration/tests/references/references.test.ts
+++ b/test/integration/tests/references/references.test.ts
@@ -1,7 +1,7 @@
 import { getClient } from "../../client";
 import { Client } from "../../common/types";
 import { assertLspCommand } from "../../common/assertLspCommand";
-import { getDocUri } from "../../helpers/misc";
+import { getDocUri } from "../../helpers/docPaths";
 
 suite("Single-file Navigation", function () {
   this.timeout(10000);

--- a/test/integration/tests/rename/rename.test.ts
+++ b/test/integration/tests/rename/rename.test.ts
@@ -1,7 +1,7 @@
 import { getClient } from "../../client";
 import { Client } from "../../common/types";
 import { assertLspCommand } from "../../common/assertLspCommand";
-import { getDocUri } from "../../common/helper";
+import { getDocUri } from "../../helpers/misc";
 
 suite("Single-file Navigation", function () {
   this.timeout(10000);

--- a/test/integration/tests/rename/rename.test.ts
+++ b/test/integration/tests/rename/rename.test.ts
@@ -1,7 +1,7 @@
 import { getClient } from "../../client";
 import { Client } from "../../common/types";
 import { assertLspCommand } from "../../common/assertLspCommand";
-import { getDocUri } from "../../helpers/misc";
+import { getDocUri } from "../../helpers/docPaths";
 
 suite("Single-file Navigation", function () {
   this.timeout(10000);

--- a/test/integration/tests/typedefinition/typedefinition.test.ts
+++ b/test/integration/tests/typedefinition/typedefinition.test.ts
@@ -1,7 +1,7 @@
 import { getClient } from "../../client";
 import { Client } from "../../common/types";
 import { assertLspCommand } from "../../common/assertLspCommand";
-import { getDocUri } from "../../common/helper";
+import { getDocUri } from "../../helpers/misc";
 
 suite("Single-file Navigation", function () {
   this.timeout(10000);

--- a/test/integration/tests/typedefinition/typedefinition.test.ts
+++ b/test/integration/tests/typedefinition/typedefinition.test.ts
@@ -1,7 +1,7 @@
 import { getClient } from "../../client";
 import { Client } from "../../common/types";
 import { assertLspCommand } from "../../common/assertLspCommand";
-import { getDocUri } from "../../helpers/misc";
+import { getDocUri } from "../../helpers/docPaths";
 
 suite("Single-file Navigation", function () {
   this.timeout(10000);


### PR DESCRIPTION
When using multiline comments, intermediate stars (*) are added automatically with correct indentation.

Closes #75 