### PR TITLE
fix(validation): clear when errors in other file

### DIFF
--- a/server/src/services/validation/validate.ts
+++ b/server/src/services/validation/validate.ts
@@ -333,14 +333,14 @@ function validationFail(
   const diagnostics: { [uri: string]: Diagnostic[] } =
     diagnosticConverter.convertErrors(change.document, message.errors);
 
-  for (const diagnosticUri of Object.keys(diagnostics)) {
-    if (document.uri.includes(diagnosticUri)) {
-      serverState.connection.sendDiagnostics({
-        uri: document.uri,
-        diagnostics: diagnostics[diagnosticUri],
-      });
-    }
-  }
+  const diagnosticsInOpenEditor = Object.entries(diagnostics)
+    .filter(([diagnosticUri]) => document.uri.includes(diagnosticUri))
+    .flatMap(([, diagnostic]) => diagnostic);
+
+  serverState.connection.sendDiagnostics({
+    uri: document.uri,
+    diagnostics: diagnosticsInOpenEditor,
+  });
 
   sendValidationProcessSuccess(
     serverState,


### PR DESCRIPTION
Solc can report warnings/errors during validation that are against files other than the current open editor file (i.e. an error in a dependency). We where ignoring those dependency errors, but not clearing any previous
diagnostics on the open editor (which had no warnings/errors against it).

We now treat a validation fail with every warning/error in files other than the open editor as the equivalent of a validation pass on the open editor; we clear any previous diagnostics and report validation success against the file.

Fixes #221
