### PR TITLE
feat: Completions for msg.sender (#202)

### DIFF
--- a/server/src/services/completion/defaultCompletion.ts
+++ b/server/src/services/completion/defaultCompletion.ts
@@ -196,6 +196,14 @@ export const globalVariables: GlobalVariablesType = {
     "number",
     "timestamp",
   ],
+  "msg.sender": [
+    "balance",
+    "code",
+    "codehash",
+    "call",
+    "delegatecall",
+    "staticcall",
+  ],
   msg: ["data", "sender", "value"],
   tx: ["gasprice", "origin"],
 };

--- a/server/test/services/completion/completion.ts
+++ b/server/test/services/completion/completion.ts
@@ -166,6 +166,14 @@ describe("Parser", () => {
             "encodeWithSignature",
           ]
         ));
+
+      it("should provide msg.sender completions", () =>
+        assertCompletion(
+          completion,
+          globalVariablesUri,
+          { line: 21, character: 26 },
+          ["balance", "code", "codehash", "call", "delegatecall", "staticcall"]
+        ));
     });
   });
 });

--- a/server/test/services/completion/testData/GlobalVariables.sol
+++ b/server/test/services/completion/testData/GlobalVariables.sol
@@ -17,4 +17,8 @@ contract Test {
     function encode() public pure returns (bytes memory) {
         return abi.// <- cursor
     }
+
+    function withdraw() public {
+        return msg.sender.// <- cursor
+    }
 }


### PR DESCRIPTION
I went with a simple approach of adding the address methods directly on the `msg.sender` global identifier. I think we don't have address type completions in place. 

Please advice on the approach I took for being able to identify the `msg.sender` node, since the existing code would only work for finding single word orphan nodes for globals (e.g. `msg`, `tx`, `abi`). But it wouldn't work for a chain of member access (e.g. `foo.bar.baz`. I did my best to avoid interfering with the existing logic for orphan nodes.

A possible improvement would be to move the logic from `getLastExpressionNode` and `getFullName` from the service module to the node classes themselves (`MemberAccessNode`, `IdentifierNode`, `Node`), but I'm not sure if I have the freedom to do that.

Closes #202 