### PR TITLE
feat: Quickfix for specifying compiler version

### DIFF
--- a/server/src/compilerDiagnostics/compilerDiagnostics.ts
+++ b/server/src/compilerDiagnostics/compilerDiagnostics.ts
@@ -5,6 +5,7 @@ import { ConstrainMutability } from "./diagnostics/ConstrainMutability";
 import { ContractCodeSize } from "./diagnostics/ContractCodeSize";
 import { MarkContractAbstract } from "./diagnostics/MarkContractAbstract";
 import { SpecifyVisibility } from "./diagnostics/SpecifyVisibility";
+import { SpecifyCompilerVersion } from "./diagnostics/SpecifyCompilerVersion";
 import { CompilerDiagnostic } from "./types";
 
 export const compilerDiagnostics: { [key: string]: CompilerDiagnostic } = [
@@ -15,4 +16,5 @@ export const compilerDiagnostics: { [key: string]: CompilerDiagnostic } = [
   new ContractCodeSize(),
   new MarkContractAbstract(),
   new SpecifyVisibility(),
+  new SpecifyCompilerVersion(),
 ].reduce((acc, item) => ({ ...acc, [item.code]: item }), {});

--- a/server/src/compilerDiagnostics/diagnostics/SpecifyCompilerVersion.ts
+++ b/server/src/compilerDiagnostics/diagnostics/SpecifyCompilerVersion.ts
@@ -1,0 +1,78 @@
+import { TextDocument } from "vscode-languageserver-textdocument";
+import {
+  CodeAction,
+  CodeActionKind,
+  Diagnostic,
+  Range,
+} from "vscode-languageserver/node";
+import { CompilerDiagnostic, ResolveActionsContext } from "../types";
+import { attemptConstrainToFunctionName } from "../conversions/attemptConstrainToFunctionName";
+import { HardhatCompilerError, ServerState } from "../../types";
+
+/**
+ * This diagnostic is shown when no compiler version is specified
+ * i.e. pragma solidity XXXX;
+ *
+ * The suggested quickfix adds the pragma solidity statement, by
+ * extracting the version from hardhat's warning message.
+ */
+export class SpecifyCompilerVersion implements CompilerDiagnostic {
+  public code = "3420";
+  public blocks: string[] = [];
+
+  public fromHardhatCompilerError(
+    document: TextDocument,
+    error: HardhatCompilerError
+  ): Diagnostic {
+    return attemptConstrainToFunctionName(document, error);
+  }
+
+  public resolveActions(
+    _serverState: ServerState,
+    _diagnostic: Diagnostic,
+    { uri, document }: ResolveActionsContext
+  ): CodeAction[] {
+    // Get the compiler specification code from hardhat warning
+    const regex = /pragma solidity .*;/;
+    const match = _diagnostic.message.match(regex);
+    const pragmaLine = match && match[0];
+
+    if (pragmaLine === null) {
+      return [];
+    }
+
+    // If diagnostic is shown on "// SPDX ..." line, insert on next line.
+    // Otherwise insert on previous line
+    const position = { character: 0, line: _diagnostic.range.end.line };
+
+    const checkRange: Range = {
+      start: _diagnostic.range.start,
+      end: {
+        line: _diagnostic.range.end.line,
+        character: _diagnostic.range.end.character + 1,
+      },
+    };
+
+    if (document.getText(checkRange) === "/") {
+      position.line += 1;
+    }
+
+    return [
+      {
+        title: "Add version specification",
+        kind: CodeActionKind.QuickFix,
+        isPreferred: true,
+        edit: {
+          changes: {
+            [uri]: [
+              {
+                range: Range.create(position, position),
+                newText: `${pragmaLine}\n`,
+              },
+            ],
+          },
+        },
+      },
+    ];
+  }
+}

--- a/server/src/services/documents/onDidChangeContent.ts
+++ b/server/src/services/documents/onDidChangeContent.ts
@@ -40,19 +40,18 @@ export function onDidChangeContent(serverState: ServerState) {
   };
 
   return (change: TextDocumentChangeEvent<TextDocument>) => {
+    const { logger } = serverState;
     try {
       if (change.document.languageId !== "solidity") {
         return;
       }
-
-      const { logger } = serverState;
 
       logger.trace("onDidChangeContent");
 
       debouncePerDocument(debounceState.analyse, serverState, change);
       debouncePerDocument(debounceState.validate, serverState, change);
     } catch (err) {
-      serverState.logger.error(err);
+      logger.error(err);
     }
   };
 }

--- a/server/test/services/codeactions/specifyCompilerVersion.ts
+++ b/server/test/services/codeactions/specifyCompilerVersion.ts
@@ -1,43 +1,35 @@
-import * as fs from "fs";
-import * as path from "path";
 import { SpecifyCompilerVersion } from "@compilerDiagnostics/diagnostics/SpecifyCompilerVersion";
 import { assertCodeAction } from "./asserts/assertCodeAction";
 
 describe("Code Actions", () => {
-  const specifyCompilerVersion = new SpecifyCompilerVersion();
+  const codeAction = new SpecifyCompilerVersion();
   let testContractText: string;
 
-  before(async () => {
-    testContractText = (
-      await fs.promises.readFile(
-        path.join(__dirname, "testData", "SpecifyCompilerVersion.sol")
-      )
-    ).toString();
-  });
-
   describe("Specify compiler version", () => {
-    it("adds pragma solidity line", async () => {
-      const diagnostic = {
-        code: "3420",
-        message:
-          'Source file does not specify required compiler version! Consider adding "pragma solidity ^0.8.7;"',
-        range: {
-          start: { line: 0, character: 0 },
-          end: { line: 0, character: 0 },
+    const diagnostic = {
+      code: "3420",
+      message:
+        'Source file does not specify required compiler version! Consider adding "pragma solidity ^0.8.7;"',
+      range: {
+        start: { line: 0, character: 0 },
+        end: { line: 0, character: 0 },
+      },
+      data: {
+        functionSourceLocation: {
+          start: 0,
+          end: 0,
         },
-        data: {
-          functionSourceLocation: {
-            start: 0,
-            end: 0,
-          },
-        },
-      };
+      },
+    };
 
-      await assertCodeAction(
-        specifyCompilerVersion,
-        testContractText,
-        diagnostic,
-        [
+    describe("When first line is license identifier", () => {
+      it("adds pragma solidity statement on the second line", async () => {
+        testContractText = [
+          "// SPDX-License-Identifier: GPL-3.0",
+          "contract SpecifyCompilerVersion {",
+          "}",
+        ].join("");
+        await assertCodeAction(codeAction, testContractText, diagnostic, [
           {
             title: "Add version specification",
             kind: "quickfix",
@@ -58,8 +50,70 @@ describe("Code Actions", () => {
               },
             ],
           },
-        ]
-      );
+        ]);
+      });
+    });
+
+    describe("When first line is a regular comment", () => {
+      it("adds pragma solidity statement on the first line", async () => {
+        testContractText = [
+          "// My contract",
+          "contract SpecifyCompilerVersion {",
+          "}",
+        ].join("");
+
+        await assertCodeAction(codeAction, testContractText, diagnostic, [
+          {
+            title: "Add version specification",
+            kind: "quickfix",
+            isPreferred: true,
+            edits: [
+              {
+                newText: "pragma solidity ^0.8.7;\n",
+                range: {
+                  start: {
+                    line: 0,
+                    character: 0,
+                  },
+                  end: {
+                    line: 0,
+                    character: 0,
+                  },
+                },
+              },
+            ],
+          },
+        ]);
+      });
+    });
+
+    describe("When first line is something else", () => {
+      it("adds pragma solidity statement on the first line", async () => {
+        testContractText = ["contract SpecifyCompilerVersion {", "}"].join("");
+
+        await assertCodeAction(codeAction, testContractText, diagnostic, [
+          {
+            title: "Add version specification",
+            kind: "quickfix",
+            isPreferred: true,
+            edits: [
+              {
+                newText: "pragma solidity ^0.8.7;\n",
+                range: {
+                  start: {
+                    line: 0,
+                    character: 0,
+                  },
+                  end: {
+                    line: 0,
+                    character: 0,
+                  },
+                },
+              },
+            ],
+          },
+        ]);
+      });
     });
   });
 });

--- a/server/test/services/codeactions/specifyCompilerVersion.ts
+++ b/server/test/services/codeactions/specifyCompilerVersion.ts
@@ -1,0 +1,65 @@
+import * as fs from "fs";
+import * as path from "path";
+import { SpecifyCompilerVersion } from "@compilerDiagnostics/diagnostics/SpecifyCompilerVersion";
+import { assertCodeAction } from "./asserts/assertCodeAction";
+
+describe("Code Actions", () => {
+  const specifyCompilerVersion = new SpecifyCompilerVersion();
+  let testContractText: string;
+
+  before(async () => {
+    testContractText = (
+      await fs.promises.readFile(
+        path.join(__dirname, "testData", "SpecifyCompilerVersion.sol")
+      )
+    ).toString();
+  });
+
+  describe("Specify compiler version", () => {
+    it("adds pragma solidity line", async () => {
+      const diagnostic = {
+        code: "3420",
+        message:
+          'Source file does not specify required compiler version! Consider adding "pragma solidity ^0.8.7;"',
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+        },
+        data: {
+          functionSourceLocation: {
+            start: 0,
+            end: 0,
+          },
+        },
+      };
+
+      await assertCodeAction(
+        specifyCompilerVersion,
+        testContractText,
+        diagnostic,
+        [
+          {
+            title: "Add version specification",
+            kind: "quickfix",
+            isPreferred: true,
+            edits: [
+              {
+                newText: "pragma solidity ^0.8.7;\n",
+                range: {
+                  start: {
+                    line: 1,
+                    character: 0,
+                  },
+                  end: {
+                    line: 1,
+                    character: 0,
+                  },
+                },
+              },
+            ],
+          },
+        ]
+      );
+    });
+  });
+});

--- a/server/test/services/codeactions/testData/SpecifyCompilerVersion.sol
+++ b/server/test/services/codeactions/testData/SpecifyCompilerVersion.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
+
+contract SpecifyCompilerVersion {
+}

--- a/server/test/services/codeactions/testData/SpecifyCompilerVersion.sol
+++ b/server/test/services/codeactions/testData/SpecifyCompilerVersion.sol
@@ -1,4 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0
-
-contract SpecifyCompilerVersion {
-}


### PR DESCRIPTION
Closes #25 

We make use of the solc warning for code 3420 (Source file does not specify required compiler version! Consider adding "pragma solidity ^0.8.7;") to extract the pragma line and insert it into the contract code.