### PR TITLE
release:2022-08-11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.5.0 - 2022-08-11
+
+### Added
+
+- Added Quickfix for missing solidity compiler version pragma ([#25](https://github.com/NomicFoundation/hardhat-vscode/issues/25))
+
+### Fixed
+
+- Fix to validation to clear diagnostics when all warnings/errors are in files other than the open editor ([#221](https://github.com/NomicFoundation/hardhat-vscode/issues/221))
+- Fix to formatting to not remove semi-colons on virtual modifiers ([#219](https://github.com/NomicFoundation/hardhat-vscode/issues/219))
+- Fix to completions for `msg.sender` ([#202](https://github.com/NomicFoundation/hardhat-vscode/issues/202))
+
 ## 0.4.6 - 2022-08-04
 
 ### Added
@@ -32,7 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Speed up validation by caching solc input for the same page ([198](https://github.com/NomicFoundation/hardhat-vscode/pull/198))
+- Speed up validation by caching solc input for the same page ([#198](https://github.com/NomicFoundation/hardhat-vscode/pull/198))
 - Speed up validation by removing code generation steps from solc ([#197](https://github.com/NomicFoundation/hardhat-vscode/pull/197))
 
 ## 0.4.1 - 2022-06-08

--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@sentry/node": "6.19.1",
     "prettier": "2.5.1",
-    "prettier-plugin-solidity": "^1.0.0-beta.19",
+    "prettier-plugin-solidity": "1.0.0-beta.24",
     "vscode-languageclient": "^7.0.0"
   }
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -108,10 +108,10 @@
     "@sentry/types" "6.19.1"
     tslib "^1.9.3"
 
-"@solidity-parser/parser@^0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.14.0.tgz#d51f074efb0acce0e953ec48133561ed710cebc0"
-  integrity sha512-cX0JJRcmPtNUJpzD2K7FdA7qQsTOk1UZnFx2k7qAg9ZRvuaH5NBe5IEdBMXGlmf2+FmjhqbygJ26H8l2SV7aKQ==
+"@solidity-parser/parser@^0.14.3":
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.14.3.tgz#0d627427b35a40d8521aaa933cc3df7d07bfa36f"
+  integrity sha512-29g2SZ29HtsqA58pLCtopI1P/cPy5/UAzlcAXO6T/CNJimG6yA8kx4NaseMyJULiC+TEs02Y9/yeHzClqoA0hw==
   dependencies:
     antlr4ts "^0.5.0-alpha.4"
 
@@ -307,10 +307,10 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-emoji-regex@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.0.0.tgz#96559e19f82231b436403e059571241d627c42b8"
-  integrity sha512-KmJa8l6uHi1HrBI34udwlzZY1jOEuID/ft4d8BSSEdRyap7PwBEt910453PJa5MuGvxkLqlt4Uvhu7tttFHViw==
+emoji-regex@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.1.0.tgz#d50e383743c0f7a5945c47087295afc112e3cf66"
+  integrity sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -706,15 +706,15 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier-plugin-solidity@^1.0.0-beta.19:
-  version "1.0.0-beta.19"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.19.tgz#7c3607fc4028f5e6a425259ff03e45eedf733df3"
-  integrity sha512-xxRQ5ZiiZyUoMFLE9h7HnUDXI/daf1tnmL1msEdcKmyh7ZGQ4YklkYLC71bfBpYU2WruTb5/SFLUaEb3RApg5g==
+prettier-plugin-solidity@1.0.0-beta.24:
+  version "1.0.0-beta.24"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.24.tgz#67573ca87098c14f7ccff3639ddd8a4cab2a87eb"
+  integrity sha512-6JlV5BBTWzmDSq4kZ9PTXc3eLOX7DF5HpbqmmaF+kloyUwOZbJ12hIYsUaZh2fVgZdV2t0vWcvY6qhILhlzgqg==
   dependencies:
-    "@solidity-parser/parser" "^0.14.0"
-    emoji-regex "^10.0.0"
+    "@solidity-parser/parser" "^0.14.3"
+    emoji-regex "^10.1.0"
     escape-string-regexp "^4.0.0"
-    semver "^7.3.5"
+    semver "^7.3.7"
     solidity-comments-extractor "^0.0.7"
     string-width "^4.2.3"
 
@@ -755,10 +755,17 @@ rimraf@3.0.2, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-semver@^7.2.1, semver@^7.3.4, semver@^7.3.5:
+semver@^7.2.1, semver@^7.3.4:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.3.7:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
   dependencies:
     lru-cache "^6.0.0"
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Solidity + Hardhat",
   "description": "Solidity and Hardhat support for Visual Studio Code",
   "license": "MIT",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "private": true,
   "main": "./client/out/extension.js",
   "module": "./client/out/extension.js",

--- a/server/package.json
+++ b/server/package.json
@@ -63,7 +63,7 @@
     "js-yaml": "^4.1.0",
     "module-alias": "^2.2.2",
     "prettier": "2.5.1",
-    "prettier-plugin-solidity": "1.0.0-beta.19",
+    "prettier-plugin-solidity": "1.0.0-beta.24",
     "qs": "^6.10.1",
     "serialize-error": "8.1.0",
     "uuid": "^8.3.2",

--- a/server/src/compilerDiagnostics/compilerDiagnostics.ts
+++ b/server/src/compilerDiagnostics/compilerDiagnostics.ts
@@ -5,6 +5,7 @@ import { ConstrainMutability } from "./diagnostics/ConstrainMutability";
 import { ContractCodeSize } from "./diagnostics/ContractCodeSize";
 import { MarkContractAbstract } from "./diagnostics/MarkContractAbstract";
 import { SpecifyVisibility } from "./diagnostics/SpecifyVisibility";
+import { SpecifyCompilerVersion } from "./diagnostics/SpecifyCompilerVersion";
 import { CompilerDiagnostic } from "./types";
 
 export const compilerDiagnostics: { [key: string]: CompilerDiagnostic } = [
@@ -15,4 +16,5 @@ export const compilerDiagnostics: { [key: string]: CompilerDiagnostic } = [
   new ContractCodeSize(),
   new MarkContractAbstract(),
   new SpecifyVisibility(),
+  new SpecifyCompilerVersion(),
 ].reduce((acc, item) => ({ ...acc, [item.code]: item }), {});

--- a/server/src/compilerDiagnostics/diagnostics/SpecifyCompilerVersion.ts
+++ b/server/src/compilerDiagnostics/diagnostics/SpecifyCompilerVersion.ts
@@ -1,0 +1,78 @@
+import { TextDocument } from "vscode-languageserver-textdocument";
+import {
+  CodeAction,
+  CodeActionKind,
+  Diagnostic,
+  Range,
+} from "vscode-languageserver/node";
+import { CompilerDiagnostic, ResolveActionsContext } from "../types";
+import { attemptConstrainToFunctionName } from "../conversions/attemptConstrainToFunctionName";
+import { HardhatCompilerError, ServerState } from "../../types";
+
+/**
+ * This diagnostic is shown when no compiler version is specified
+ * i.e. pragma solidity XXXX;
+ *
+ * The suggested quickfix adds the pragma solidity statement, by
+ * extracting the version from hardhat's warning message.
+ */
+export class SpecifyCompilerVersion implements CompilerDiagnostic {
+  public code = "3420";
+  public blocks: string[] = [];
+
+  public fromHardhatCompilerError(
+    document: TextDocument,
+    error: HardhatCompilerError
+  ): Diagnostic {
+    return attemptConstrainToFunctionName(document, error);
+  }
+
+  public resolveActions(
+    _serverState: ServerState,
+    _diagnostic: Diagnostic,
+    { uri, document }: ResolveActionsContext
+  ): CodeAction[] {
+    // Get the compiler specification code from hardhat warning
+    const regex = /pragma solidity .*;/;
+    const match = _diagnostic.message.match(regex);
+    const pragmaLine = match && match[0];
+
+    if (pragmaLine === null) {
+      return [];
+    }
+
+    // If diagnostic is shown on "// SPDX ..." line, insert on next line.
+    // Otherwise insert on previous line
+    const position = { character: 0, line: _diagnostic.range.end.line };
+
+    const checkRange: Range = {
+      start: _diagnostic.range.start,
+      end: {
+        line: _diagnostic.range.end.line,
+        character: _diagnostic.range.end.character + 1,
+      },
+    };
+
+    if (document.getText(checkRange) === "/") {
+      position.line += 1;
+    }
+
+    return [
+      {
+        title: "Add version specification",
+        kind: CodeActionKind.QuickFix,
+        isPreferred: true,
+        edit: {
+          changes: {
+            [uri]: [
+              {
+                range: Range.create(position, position),
+                newText: `${pragmaLine}\n`,
+              },
+            ],
+          },
+        },
+      },
+    ];
+  }
+}

--- a/server/src/services/completion/defaultCompletion.ts
+++ b/server/src/services/completion/defaultCompletion.ts
@@ -196,6 +196,14 @@ export const globalVariables: GlobalVariablesType = {
     "number",
     "timestamp",
   ],
+  "msg.sender": [
+    "balance",
+    "code",
+    "codehash",
+    "call",
+    "delegatecall",
+    "staticcall",
+  ],
   msg: ["data", "sender", "value"],
   tx: ["gasprice", "origin"],
 };

--- a/server/src/services/documents/onDidChangeContent.ts
+++ b/server/src/services/documents/onDidChangeContent.ts
@@ -40,19 +40,18 @@ export function onDidChangeContent(serverState: ServerState) {
   };
 
   return (change: TextDocumentChangeEvent<TextDocument>) => {
+    const { logger } = serverState;
     try {
       if (change.document.languageId !== "solidity") {
         return;
       }
-
-      const { logger } = serverState;
 
       logger.trace("onDidChangeContent");
 
       debouncePerDocument(debounceState.analyse, serverState, change);
       debouncePerDocument(debounceState.validate, serverState, change);
     } catch (err) {
-      serverState.logger.error(err);
+      logger.error(err);
     }
   };
 }

--- a/server/src/services/validation/validate.ts
+++ b/server/src/services/validation/validate.ts
@@ -333,14 +333,14 @@ function validationFail(
   const diagnostics: { [uri: string]: Diagnostic[] } =
     diagnosticConverter.convertErrors(change.document, message.errors);
 
-  for (const diagnosticUri of Object.keys(diagnostics)) {
-    if (document.uri.includes(diagnosticUri)) {
-      serverState.connection.sendDiagnostics({
-        uri: document.uri,
-        diagnostics: diagnostics[diagnosticUri],
-      });
-    }
-  }
+  const diagnosticsInOpenEditor = Object.entries(diagnostics)
+    .filter(([diagnosticUri]) => document.uri.includes(diagnosticUri))
+    .flatMap(([, diagnostic]) => diagnostic);
+
+  serverState.connection.sendDiagnostics({
+    uri: document.uri,
+    diagnostics: diagnosticsInOpenEditor,
+  });
 
   sendValidationProcessSuccess(
     serverState,

--- a/server/test/services/codeactions/specifyCompilerVersion.ts
+++ b/server/test/services/codeactions/specifyCompilerVersion.ts
@@ -1,43 +1,35 @@
-import * as fs from "fs";
-import * as path from "path";
 import { SpecifyCompilerVersion } from "@compilerDiagnostics/diagnostics/SpecifyCompilerVersion";
 import { assertCodeAction } from "./asserts/assertCodeAction";
 
 describe("Code Actions", () => {
-  const specifyCompilerVersion = new SpecifyCompilerVersion();
+  const codeAction = new SpecifyCompilerVersion();
   let testContractText: string;
 
-  before(async () => {
-    testContractText = (
-      await fs.promises.readFile(
-        path.join(__dirname, "testData", "SpecifyCompilerVersion.sol")
-      )
-    ).toString();
-  });
-
   describe("Specify compiler version", () => {
-    it("adds pragma solidity line", async () => {
-      const diagnostic = {
-        code: "3420",
-        message:
-          'Source file does not specify required compiler version! Consider adding "pragma solidity ^0.8.7;"',
-        range: {
-          start: { line: 0, character: 0 },
-          end: { line: 0, character: 0 },
+    const diagnostic = {
+      code: "3420",
+      message:
+        'Source file does not specify required compiler version! Consider adding "pragma solidity ^0.8.7;"',
+      range: {
+        start: { line: 0, character: 0 },
+        end: { line: 0, character: 0 },
+      },
+      data: {
+        functionSourceLocation: {
+          start: 0,
+          end: 0,
         },
-        data: {
-          functionSourceLocation: {
-            start: 0,
-            end: 0,
-          },
-        },
-      };
+      },
+    };
 
-      await assertCodeAction(
-        specifyCompilerVersion,
-        testContractText,
-        diagnostic,
-        [
+    describe("When first line is license identifier", () => {
+      it("adds pragma solidity statement on the second line", async () => {
+        testContractText = [
+          "// SPDX-License-Identifier: GPL-3.0",
+          "contract SpecifyCompilerVersion {",
+          "}",
+        ].join("");
+        await assertCodeAction(codeAction, testContractText, diagnostic, [
           {
             title: "Add version specification",
             kind: "quickfix",
@@ -58,8 +50,70 @@ describe("Code Actions", () => {
               },
             ],
           },
-        ]
-      );
+        ]);
+      });
+    });
+
+    describe("When first line is a regular comment", () => {
+      it("adds pragma solidity statement on the first line", async () => {
+        testContractText = [
+          "// My contract",
+          "contract SpecifyCompilerVersion {",
+          "}",
+        ].join("");
+
+        await assertCodeAction(codeAction, testContractText, diagnostic, [
+          {
+            title: "Add version specification",
+            kind: "quickfix",
+            isPreferred: true,
+            edits: [
+              {
+                newText: "pragma solidity ^0.8.7;\n",
+                range: {
+                  start: {
+                    line: 0,
+                    character: 0,
+                  },
+                  end: {
+                    line: 0,
+                    character: 0,
+                  },
+                },
+              },
+            ],
+          },
+        ]);
+      });
+    });
+
+    describe("When first line is something else", () => {
+      it("adds pragma solidity statement on the first line", async () => {
+        testContractText = ["contract SpecifyCompilerVersion {", "}"].join("");
+
+        await assertCodeAction(codeAction, testContractText, diagnostic, [
+          {
+            title: "Add version specification",
+            kind: "quickfix",
+            isPreferred: true,
+            edits: [
+              {
+                newText: "pragma solidity ^0.8.7;\n",
+                range: {
+                  start: {
+                    line: 0,
+                    character: 0,
+                  },
+                  end: {
+                    line: 0,
+                    character: 0,
+                  },
+                },
+              },
+            ],
+          },
+        ]);
+      });
     });
   });
 });

--- a/server/test/services/codeactions/specifyCompilerVersion.ts
+++ b/server/test/services/codeactions/specifyCompilerVersion.ts
@@ -1,0 +1,65 @@
+import * as fs from "fs";
+import * as path from "path";
+import { SpecifyCompilerVersion } from "@compilerDiagnostics/diagnostics/SpecifyCompilerVersion";
+import { assertCodeAction } from "./asserts/assertCodeAction";
+
+describe("Code Actions", () => {
+  const specifyCompilerVersion = new SpecifyCompilerVersion();
+  let testContractText: string;
+
+  before(async () => {
+    testContractText = (
+      await fs.promises.readFile(
+        path.join(__dirname, "testData", "SpecifyCompilerVersion.sol")
+      )
+    ).toString();
+  });
+
+  describe("Specify compiler version", () => {
+    it("adds pragma solidity line", async () => {
+      const diagnostic = {
+        code: "3420",
+        message:
+          'Source file does not specify required compiler version! Consider adding "pragma solidity ^0.8.7;"',
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+        },
+        data: {
+          functionSourceLocation: {
+            start: 0,
+            end: 0,
+          },
+        },
+      };
+
+      await assertCodeAction(
+        specifyCompilerVersion,
+        testContractText,
+        diagnostic,
+        [
+          {
+            title: "Add version specification",
+            kind: "quickfix",
+            isPreferred: true,
+            edits: [
+              {
+                newText: "pragma solidity ^0.8.7;\n",
+                range: {
+                  start: {
+                    line: 1,
+                    character: 0,
+                  },
+                  end: {
+                    line: 1,
+                    character: 0,
+                  },
+                },
+              },
+            ],
+          },
+        ]
+      );
+    });
+  });
+});

--- a/server/test/services/codeactions/testData/SpecifyCompilerVersion.sol
+++ b/server/test/services/codeactions/testData/SpecifyCompilerVersion.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
+
+contract SpecifyCompilerVersion {
+}

--- a/server/test/services/codeactions/testData/SpecifyCompilerVersion.sol
+++ b/server/test/services/codeactions/testData/SpecifyCompilerVersion.sol
@@ -1,4 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0
-
-contract SpecifyCompilerVersion {
-}

--- a/server/test/services/completion/completion.ts
+++ b/server/test/services/completion/completion.ts
@@ -166,6 +166,14 @@ describe("Parser", () => {
             "encodeWithSignature",
           ]
         ));
+
+      it("should provide msg.sender completions", () =>
+        assertCompletion(
+          completion,
+          globalVariablesUri,
+          { line: 21, character: 26 },
+          ["balance", "code", "codehash", "call", "delegatecall", "staticcall"]
+        ));
     });
   });
 });

--- a/server/test/services/completion/testData/GlobalVariables.sol
+++ b/server/test/services/completion/testData/GlobalVariables.sol
@@ -17,4 +17,8 @@ contract Test {
     function encode() public pure returns (bytes memory) {
         return abi.// <- cursor
     }
+
+    function withdraw() public {
+        return msg.sender.// <- cursor
+    }
 }

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -770,6 +770,13 @@
   dependencies:
     antlr4ts "^0.5.0-alpha.4"
 
+"@solidity-parser/parser@^0.14.3":
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.14.3.tgz#0d627427b35a40d8521aaa933cc3df7d07bfa36f"
+  integrity sha512-29g2SZ29HtsqA58pLCtopI1P/cPy5/UAzlcAXO6T/CNJimG6yA8kx4NaseMyJULiC+TEs02Y9/yeHzClqoA0hw==
+  dependencies:
+    antlr4ts "^0.5.0-alpha.4"
+
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.6.tgz#b4a914bb62e7c272d4e5989fe4440f812ab1d807"
@@ -1709,10 +1716,10 @@ elliptic@6.5.4, elliptic@^6.5.2, elliptic@^6.5.4:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-emoji-regex@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.0.0.tgz#96559e19f82231b436403e059571241d627c42b8"
-  integrity sha512-KmJa8l6uHi1HrBI34udwlzZY1jOEuID/ft4d8BSSEdRyap7PwBEt910453PJa5MuGvxkLqlt4Uvhu7tttFHViw==
+emoji-regex@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.1.0.tgz#d50e383743c0f7a5945c47087295afc112e3cf66"
+  integrity sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg==
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -3664,15 +3671,15 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier-plugin-solidity@1.0.0-beta.19:
-  version "1.0.0-beta.19"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.19.tgz#7c3607fc4028f5e6a425259ff03e45eedf733df3"
-  integrity sha512-xxRQ5ZiiZyUoMFLE9h7HnUDXI/daf1tnmL1msEdcKmyh7ZGQ4YklkYLC71bfBpYU2WruTb5/SFLUaEb3RApg5g==
+prettier-plugin-solidity@1.0.0-beta.24:
+  version "1.0.0-beta.24"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.24.tgz#67573ca87098c14f7ccff3639ddd8a4cab2a87eb"
+  integrity sha512-6JlV5BBTWzmDSq4kZ9PTXc3eLOX7DF5HpbqmmaF+kloyUwOZbJ12hIYsUaZh2fVgZdV2t0vWcvY6qhILhlzgqg==
   dependencies:
-    "@solidity-parser/parser" "^0.14.0"
-    emoji-regex "^10.0.0"
+    "@solidity-parser/parser" "^0.14.3"
+    emoji-regex "^10.1.0"
     escape-string-regexp "^4.0.0"
-    semver "^7.3.5"
+    semver "^7.3.7"
     solidity-comments-extractor "^0.0.7"
     string-width "^4.2.3"
 
@@ -3924,10 +3931,17 @@ semver@^6.0.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.2.1, semver@^7.3.5:
+semver@^7.2.1:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.3.7:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
## 0.5.0 - 2022-08-11

### Added

- Added Quickfix for missing solidity compiler version pragma ([#25](https://github.com/NomicFoundation/hardhat-vscode/issues/25))

### Fixed

- Fix to validation to clear diagnostics when all warnings/errors are in files other than the open editor ([#221](https://github.com/NomicFoundation/hardhat-vscode/issues/221))
- Fix to formatting to not remove semi-colons on virtual modifiers ([#219](https://github.com/NomicFoundation/hardhat-vscode/issues/219))
- Fix to completions for `msg.sender` ([#202](https://github.com/NomicFoundation/hardhat-vscode/issues/202))