### PR TITLE
fix: Open files not being analyzed because of validator starting

### DIFF
--- a/server/src/services/initialization/onInitialized.ts
+++ b/server/src/services/initialization/onInitialized.ts
@@ -66,7 +66,8 @@ function setupWorkerProcesses(serverState: ServerState) {
 
     const workerProcess = serverState.compProcessFactory(
       project,
-      serverState.logger
+      serverState.logger,
+      serverState.connection
     );
 
     workerProcesses[project.basePath] = workerProcess;

--- a/server/src/services/validation/compilerProcessFactory.ts
+++ b/server/src/services/validation/compilerProcessFactory.ts
@@ -1,12 +1,14 @@
 /* istanbul ignore file: top level dependency injection */
 import { HardhatProject } from "@analyzer/HardhatProject";
 import { Logger } from "@utils/Logger";
+import { Connection } from "vscode-languageserver";
 import { WorkerProcess } from "../../types";
 import { createProcessFor, HardhatWorker } from "./HardhatWorker";
 
 export function compilerProcessFactory(
   project: HardhatProject,
-  logger: Logger
+  logger: Logger,
+  connection: Connection
 ): WorkerProcess {
-  return new HardhatWorker(project, createProcessFor, logger);
+  return new HardhatWorker(project, createProcessFor, logger, connection);
 }

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -28,7 +28,8 @@ export interface CompilerProcess {
 
 export type CompilerProcessFactory = (
   project: HardhatProject,
-  logger: Logger
+  logger: Logger,
+  connection: Connection
 ) => WorkerProcess;
 
 export interface WorkerProcess {


### PR DESCRIPTION
Closes #229

Open files were being sent for validation before the validation workers were operational.

I introduced a new notification sent from the server for each validation worker that got up and running. The client will revalidate files within the project associated to each given worker.