### PR TITLE
feat(analyzer): add support for remappings.txt

### DIFF
--- a/server/src/parser/analyzer/HardhatProject.ts
+++ b/server/src/parser/analyzer/HardhatProject.ts
@@ -1,4 +1,4 @@
-import { ISolProject } from "@common/types";
+import { ISolProject, Remapping } from "@common/types";
 import { WorkspaceFolder } from "vscode-languageserver-protocol";
 
 export function isHardhatProject(
@@ -9,17 +9,11 @@ export function isHardhatProject(
 
 export class HardhatProject implements ISolProject {
   public type: "hardhat" = "hardhat";
-  public basePath: string;
-  public configPath: string;
-  public workspaceFolder: WorkspaceFolder;
 
   constructor(
-    basePath: string,
-    configPath: string,
-    workspaceFolder: WorkspaceFolder
-  ) {
-    this.basePath = basePath;
-    this.configPath = configPath;
-    this.workspaceFolder = workspaceFolder;
-  }
+    public basePath: string,
+    public configPath: string,
+    public workspaceFolder: WorkspaceFolder,
+    public remappings: Remapping[] = []
+  ) {}
 }

--- a/server/src/parser/analyzer/NoProject.ts
+++ b/server/src/parser/analyzer/NoProject.ts
@@ -7,16 +7,10 @@ export function isNoProject(project: ISolProject): project is NoProject {
 
 export class NoProject implements ISolProject {
   public type: SolProjectType = "none";
-  public basePath: string;
-  public configPath: string;
-  public workspaceFolder: WorkspaceFolder;
-
-  constructor() {
-    this.basePath = "";
-    this.configPath = "";
-    this.workspaceFolder = {
-      name: "none",
-      uri: "",
-    };
-  }
+  public basePath = "";
+  public configPath = "";
+  public workspaceFolder: WorkspaceFolder = {
+    name: "none",
+    uri: "",
+  };
 }

--- a/server/src/parser/analyzer/WorkspaceFileRetriever.ts
+++ b/server/src/parser/analyzer/WorkspaceFileRetriever.ts
@@ -20,6 +20,15 @@ export class WorkspaceFileRetriever {
     );
   }
 
+  public async fileExists(documentUri: string): Promise<boolean> {
+    try {
+      await fs.promises.access(documentUri, fs.constants.R_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   public async readFile(documentUri: string): Promise<string> {
     return (await fs.promises.readFile(documentUri)).toString();
   }

--- a/server/src/parser/analyzer/nodes/ImportDirectiveNode.ts
+++ b/server/src/parser/analyzer/nodes/ImportDirectiveNode.ts
@@ -33,12 +33,15 @@ export class ImportDirectiveNode extends AbstractImportDirectiveNode {
       documentsAnalyzer,
       importDirective.path
     );
+
     this.realUri = toUnixStyle(fs.realpathSync(uri));
+    const remappings = documentsAnalyzer[this.realUri]?.project.remappings;
 
     try {
       this.uri = resolveDependency(
-        path.resolve(this.realUri, ".."),
-        importDirective
+        path.dirname(this.realUri),
+        importDirective.path,
+        remappings
       );
     } catch (err) {
       this.uri = "";

--- a/server/src/parser/analyzer/resolver/index.ts
+++ b/server/src/parser/analyzer/resolver/index.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-import path from "node:path";
+import * as path from "path";
 import { Remapping } from "@common/types";
 import { toUnixStyle } from "../../../utils";
 

--- a/server/src/parser/analyzer/resolver/index.ts
+++ b/server/src/parser/analyzer/resolver/index.ts
@@ -3,27 +3,21 @@ import path from "node:path";
 import { Remapping } from "@common/types";
 import { toUnixStyle } from "../../../utils";
 
-function applyPathRemapping(originalPath: string, pathRemappings: Remapping[]) {
-  if (!pathRemappings.length || originalPath.startsWith(".")) {
-    return originalPath;
-  }
-
-  for (const { from, to } of pathRemappings) {
-    if (originalPath.startsWith(from)) {
-      return path.join(to, originalPath.slice(from.length));
-    }
-  }
-
-  return originalPath;
-}
-
 export function resolveDependency(
   cwd: string,
   originalPath: string,
   pathRemappings: Remapping[] = []
 ): string {
-  const remappedPath = applyPathRemapping(originalPath, pathRemappings);
-  const resolvedPath = require.resolve(remappedPath, {
+  if (pathRemappings.length && !originalPath.startsWith(".")) {
+    for (const { from, to } of pathRemappings) {
+      if (originalPath.startsWith(from)) {
+        const remappedPath = path.join(to, originalPath.slice(from.length));
+        return toUnixStyle(fs.realpathSync(remappedPath));
+      }
+    }
+  }
+
+  const resolvedPath = require.resolve(originalPath, {
     paths: [fs.realpathSync(cwd)],
   });
 

--- a/server/src/parser/analyzer/resolver/index.ts
+++ b/server/src/parser/analyzer/resolver/index.ts
@@ -1,12 +1,29 @@
 import * as fs from "fs";
-import { ImportDirective } from "@common/types";
+import path from "node:path";
+import { Remapping } from "@common/types";
 import { toUnixStyle } from "../../../utils";
+
+function applyPathRemapping(originalPath: string, pathRemappings: Remapping[]) {
+  if (!pathRemappings.length || originalPath.startsWith(".")) {
+    return originalPath;
+  }
+
+  for (const { from, to } of pathRemappings) {
+    if (originalPath.startsWith(from)) {
+      return path.join(to, originalPath.slice(from.length));
+    }
+  }
+
+  return originalPath;
+}
 
 export function resolveDependency(
   cwd: string,
-  importDirective: ImportDirective
+  originalPath: string,
+  pathRemappings: Remapping[] = []
 ): string {
-  const resolvedPath = require.resolve(importDirective.path, {
+  const remappedPath = applyPathRemapping(originalPath, pathRemappings);
+  const resolvedPath = require.resolve(remappedPath, {
     paths: [fs.realpathSync(cwd)],
   });
 

--- a/server/src/parser/common/types/index.ts
+++ b/server/src/parser/common/types/index.ts
@@ -365,6 +365,11 @@ export enum ClientTrackingState {
 
 export type SolProjectType = "hardhat" | "none";
 
+export interface Remapping {
+  from: string;
+  to: string;
+}
+
 export interface ISolProject {
   type: SolProjectType;
   /**
@@ -373,6 +378,7 @@ export interface ISolProject {
   basePath: string;
   configPath: string;
   workspaceFolder: WorkspaceFolder;
+  remappings?: Remapping[];
 }
 
 export interface SolProjectMap {

--- a/server/test/helpers/setupMockWorkspaceFileRetriever.ts
+++ b/server/test/helpers/setupMockWorkspaceFileRetriever.ts
@@ -39,8 +39,13 @@ export function setupMockWorkspaceFileRetriever(
     return "";
   };
 
+  const fileExists = async () => {
+    return false;
+  };
+
   return {
     findFiles: sinon.spy(findFiles),
     readFile: sinon.spy(readFile),
+    fileExists: sinon.spy(fileExists),
   };
 }

--- a/server/test/parser/analyzer.ts
+++ b/server/test/parser/analyzer.ts
@@ -136,6 +136,7 @@ async function runIndexing(
       return foundSolFiles.map((fsf) => path.join(baseUri ?? "", fsf));
     },
     readFile: async () => "",
+    fileExists: async () => false,
   };
 
   await indexWorkspaceFolders(

--- a/server/test/services/validation/hardhatWorker.ts
+++ b/server/test/services/validation/hardhatWorker.ts
@@ -9,6 +9,7 @@ describe("Hardhat Worker", () => {
     type: "hardhat",
     basePath: "/example",
     configPath: "/example/hardhat.config.js",
+    remappings: [],
     workspaceFolder: {
       name: "example",
       uri: "/example",


### PR DESCRIPTION
Hi. Sorry for not opening an issue beforehand. I discussed this with @fvictorio on Discord a bit earlier today and thought I'd go ahead and experiment a bit.

This adds support for `remappings.txt` on a per-project basis. It looks for remappings.txt files beides hardhat config files. 

This is probably not the ideal solution but there's no clear documentation from dapptools or foundry where these remappings files are supposed to be and how they are supposed to be interpreted (e.g. are they supposed to be next to a project config file like hardhat.config, foundry.toml, etc.)? 

Generally, it seems like foundry is actually moving away from remappings.txt towards having those defined in the foundry.toml directly. In that case, the best solution might be to look for foundry.toml files and run the `forge remappings` commands to have them resolved by forge instead of attempting to do that ourselves.