### PR TITLE
chore: link to error file on status item (#238)

### DIFF
--- a/client/src/languageitems/hardhatProject.ts
+++ b/client/src/languageitems/hardhatProject.ts
@@ -1,6 +1,7 @@
 import { languages, LanguageStatusSeverity } from "vscode";
 import { RequestType } from "vscode-languageclient/node";
 import { ExtensionState } from "../types";
+import { ensureFilePrefix } from "../utils/files";
 
 interface GetSolFileDetailsParams {
   uri: string;
@@ -77,16 +78,4 @@ export function clearHardhatConfigState(extensionState: ExtensionState): void {
 
   extensionState.hardhatConfigStatusItem.dispose();
   extensionState.hardhatConfigStatusItem = null;
-}
-
-function ensureFilePrefix(path: string) {
-  if (path.startsWith("file://")) {
-    return path;
-  }
-
-  if (path.startsWith("/")) {
-    return `file://${path}`;
-  } else {
-    return `file:///${path}`;
-  }
 }

--- a/client/src/popups/setupValidationJobHooks.ts
+++ b/client/src/popups/setupValidationJobHooks.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import { LanguageStatusItem, languages, LanguageStatusSeverity } from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
 import { ExtensionState } from "../types";
@@ -13,6 +14,7 @@ export interface ValidationJobFailureNotification {
   reason: string;
   displayText: string;
   projectBasePath: string;
+  errorFile?: string;
 }
 
 export type ValidationJobStatusNotification =
@@ -65,6 +67,18 @@ function updateValidationStatusItem(
     ? "Solc Version"
     : notification.displayText;
   statusItem.busy = false;
+
+  if (!notification.validationRun && notification.errorFile !== undefined) {
+    statusItem.command = {
+      title: "Open file",
+      command: "vscode.open",
+      arguments: [
+        path.join(notification.projectBasePath, notification.errorFile),
+      ],
+    };
+  } else {
+    statusItem.command = undefined;
+  }
 
   return statusItem;
 }

--- a/client/src/popups/setupValidationJobHooks.ts
+++ b/client/src/popups/setupValidationJobHooks.ts
@@ -1,4 +1,3 @@
-import path from "path";
 import { LanguageStatusItem, languages, LanguageStatusSeverity } from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
 import { ExtensionState } from "../types";
@@ -72,9 +71,7 @@ function updateValidationStatusItem(
     statusItem.command = {
       title: "Open file",
       command: "vscode.open",
-      arguments: [
-        path.join(notification.projectBasePath, notification.errorFile),
-      ],
+      arguments: [notification.errorFile],
     };
   } else {
     statusItem.command = undefined;

--- a/client/src/utils/files.ts
+++ b/client/src/utils/files.ts
@@ -1,0 +1,11 @@
+export function ensureFilePrefix(path: string) {
+  if (path.startsWith("file://")) {
+    return path;
+  }
+
+  if (path.startsWith("/")) {
+    return `file://${path}`;
+  } else {
+    return `file:///${path}`;
+  }
+}

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -187,7 +187,17 @@ export interface UnknownHardhatError {
   messageArguments?: unknown;
 }
 
-export type HardhatError = UnknownHardhatError | HardhatImportLineError;
+export interface HardhatSourceImportError extends UnknownHardhatError {
+  messageArguments: {
+    imported: string;
+    from: string;
+  };
+}
+
+export type HardhatError =
+  | UnknownHardhatError
+  | HardhatImportLineError
+  | HardhatSourceImportError;
 
 export interface ValidateCommand {
   type: "VALIDATE";
@@ -324,6 +334,7 @@ export interface ValidationJobFailureNotification {
   projectBasePath: string;
   reason: string;
   displayText: string;
+  errorFile?: string;
 }
 
 export type ValidationJobStatusNotification =

--- a/server/test/services/validation/validation.ts
+++ b/server/test/services/validation/validation.ts
@@ -648,6 +648,14 @@ describe("Parser", () => {
           let sendDiagnostics: sinon.SinonSpy<unknown[], unknown>;
           let sendNotification: sinon.SinonSpy<unknown[], unknown>;
           let logger: Logger;
+          const projectBasePath =
+            os.platform() === "win32"
+              ? "c:/projects/example"
+              : "/projects/example";
+          const errorFile =
+            os.platform() === "win32"
+              ? "/c:/projects/example/importing.sol"
+              : "/projects/example/importing.sol";
 
           before(async () => {
             sendDiagnostics = sinon.spy();
@@ -658,7 +666,7 @@ describe("Parser", () => {
               type: "VALIDATION_COMPLETE",
               status: "HARDHAT_ERROR",
               jobId: 1,
-              projectBasePath: "/projects/example",
+              projectBasePath,
               hardhatError: {
                 name: "HardhatError",
                 errorDescriptor: {
@@ -704,10 +712,10 @@ describe("Parser", () => {
 
             const expectedFailureStatus: ValidationJobStatusNotification = {
               validationRun: false,
-              projectBasePath: "/projects/example",
+              projectBasePath,
               reason: "non-import line hardhat error",
               displayText: "Example error",
-              errorFile: "importing.sol",
+              errorFile,
             };
 
             assert.deepStrictEqual(

--- a/server/test/services/validation/validation.ts
+++ b/server/test/services/validation/validation.ts
@@ -662,11 +662,15 @@ describe("Parser", () => {
               hardhatError: {
                 name: "HardhatError",
                 errorDescriptor: {
-                  number: 123,
+                  number: 404,
                   message: "This is an example errror",
                   title: "Example error",
                   description: "This is an example error",
                   shouldBeReported: false,
+                },
+                messageArguments: {
+                  from: "importing.sol",
+                  imported: "nonexistent.sol",
                 },
               },
             };
@@ -703,6 +707,7 @@ describe("Parser", () => {
               projectBasePath: "/projects/example",
               reason: "non-import line hardhat error",
               displayText: "Example error",
+              errorFile: "importing.sol",
             };
 
             assert.deepStrictEqual(

--- a/test/integration/helpers/editor.ts
+++ b/test/integration/helpers/editor.ts
@@ -89,5 +89,5 @@ const deleteFile = (file: vscode.Uri): void => {
 // Some editor commands return immediately but the effect happens asynchronously
 // This ensures the effect takes place before continuing execution
 const waitForUI = async () => {
-  await sleep(400);
+  await sleep(500);
 };


### PR DESCRIPTION
Added a link on the status item linking to the file that is importing a non existent file.

The way hardhat works, is that the project cannot be compiled if the dependency graph cannot be built successfully (e.g. on an incorrect import). The extension already shows a diagnostic if the import line is on the current file, but just a status item if the error is on another file. This change adds a link to that status item

Closes #238 