### PR TITLE
chore: add missing `sig` attribute on `msg`

### DIFF
--- a/server/src/services/completion/defaultCompletion.ts
+++ b/server/src/services/completion/defaultCompletion.ts
@@ -204,7 +204,7 @@ export const globalVariables: GlobalVariablesType = {
     "delegatecall",
     "staticcall",
   ],
-  msg: ["data", "sender", "value"],
+  msg: ["data", "sender", "sig", "value"],
   tx: ["gasprice", "origin"],
 };
 

--- a/server/test/services/completion/completion.ts
+++ b/server/test/services/completion/completion.ts
@@ -126,7 +126,7 @@ describe("Parser", () => {
           completion,
           globalVariablesUri,
           { line: 5, character: 19 },
-          ["data", "sender", "value"]
+          ["data", "sender", "sig", "value"]
         ));
 
       it("should provide block completions", () =>


### PR DESCRIPTION
Other completions were already available, just missing `msg.sig`

Closes #105