### PR TITLE
chore: update displayName to `Solidity`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "hardhat-solidity",
   "publisher": "NomicFoundation",
-  "displayName": "Solidity + Hardhat",
-  "description": "Solidity and Hardhat support for Visual Studio Code",
+  "displayName": "Solidity",
+  "description": "Solidity and Hardhat support by the Hardhat team",
   "license": "MIT",
   "version": "0.5.1",
   "private": true,


### PR DESCRIPTION
As we add more non-hardhat features, we want to emphasize that this extension is focused on `solidity` rather than just `hardhat`. Hence the change to the display name.

The description has been updated as well, as all vscode extensions are "for Visual Studio Code".

## Preview

![image](https://user-images.githubusercontent.com/24030/189082063-a1b2d22c-6259-492b-81ec-b8a300451412.png)

