### PR TITLE
fix: extension crashing on empty remappings.txt file

### DIFF
--- a/server/src/services/initialization/indexWorkspaceFolders.ts
+++ b/server/src/services/initialization/indexWorkspaceFolders.ts
@@ -119,14 +119,26 @@ async function loadAndParseRemappings(
 }
 
 function parseRemappings(rawRemappings: string, basePath: string) {
-  const remappings = rawRemappings.trim().split("\n");
+  const lines = rawRemappings.trim().split("\n");
+  const remappings: Remapping[] = [];
 
-  return remappings
-    .map((remapping) => {
-      const [from, to] = remapping.split("=", 2);
-      return { from, to: path.join(basePath, to) };
-    })
-    .filter(({ from, to }) => !!from?.length && !!to?.length);
+  for (const line of lines) {
+    const lineTokens = line.split("=", 2);
+
+    if (
+      lineTokens.length !== 2 ||
+      lineTokens[0].length === 0 ||
+      lineTokens[1].length === 0
+    ) {
+      continue;
+    }
+
+    const [from, to] = lineTokens;
+
+    remappings.push({ from, to: path.join(basePath, to) });
+  }
+
+  return remappings;
 }
 
 async function scanForHardhatProjectsAndAppend(

--- a/server/test/services/initialization/indexWorkspaceFolders.ts
+++ b/server/test/services/initialization/indexWorkspaceFolders.ts
@@ -53,6 +53,7 @@ describe("initialization", () => {
             basePath: "/data/example",
             configPath: "/data/example/hardhat.config.ts",
             type: "hardhat",
+            remappings: [],
             workspaceFolder: {
               name: "example",
               uri: "file:///data/example",
@@ -140,6 +141,7 @@ describe("initialization", () => {
             basePath: "/data/example/packages/first",
             configPath: "/data/example/packages/first/hardhat.config.ts",
             type: "hardhat",
+            remappings: [],
             workspaceFolder: {
               name: "example",
               uri: "file:///data/example",
@@ -149,6 +151,7 @@ describe("initialization", () => {
             basePath: "/data/example/packages/second",
             configPath: "/data/example/packages/second/hardhat.config.ts",
             type: "hardhat",
+            remappings: [],
             workspaceFolder: {
               name: "example",
               uri: "file:///data/example",
@@ -270,6 +273,7 @@ describe("initialization", () => {
             basePath: "/data/example/packages/first",
             configPath: "/data/example/packages/first/hardhat.config.ts",
             type: "hardhat",
+            remappings: [],
             workspaceFolder: {
               name: "first",
               uri: "file:///data/example/packages/first",
@@ -279,6 +283,7 @@ describe("initialization", () => {
             basePath: "/data/example/packages/second",
             configPath: "/data/example/packages/second/hardhat.config.js",
             type: "hardhat",
+            remappings: [],
             workspaceFolder: {
               name: "second",
               uri: "file:///data/example/packages/second",
@@ -288,6 +293,7 @@ describe("initialization", () => {
             basePath: "/data/example/packages/third",
             configPath: "/data/example/packages/third/hardhat.config.ts",
             type: "hardhat",
+            remappings: [],
             workspaceFolder: {
               name: "third",
               uri: "file:///data/example/packages/third",
@@ -521,6 +527,7 @@ describe("initialization", () => {
             basePath: "/data/example",
             configPath: "/data/example/hardhat.config.ts",
             type: "hardhat",
+            remappings: [],
             workspaceFolder: {
               name: "example",
               uri: "file:///data/example",


### PR DESCRIPTION
This fixes the extension not working on an empty remappings.txt file and also a couple failing tests.