### PR TITLE
fix: open hardhat.config fails on vscode web (#227)

### DIFF
--- a/client/src/languageitems/hardhatProject.ts
+++ b/client/src/languageitems/hardhatProject.ts
@@ -1,4 +1,4 @@
-import { languages, LanguageStatusSeverity } from "vscode";
+import { languages, LanguageStatusSeverity, Uri } from "vscode";
 import { RequestType } from "vscode-languageclient/node";
 import { ExtensionState } from "../types";
 import { ensureFilePrefix } from "../utils/files";
@@ -62,7 +62,7 @@ export async function updateHardhatProjectLanguageItem(
     extensionState.hardhatConfigStatusItem.command = {
       title: "Open config file",
       command: "vscode.open",
-      arguments: [ensureFilePrefix(response.configPath)],
+      arguments: [Uri.file(response.configPath)],
     };
 
     return;


### PR DESCRIPTION
The command `vscode.open` has better multi-platform support when passing a URI object instead of a path string.

Tested on linux, windows and gitpod.

Closes #227 