### PR TITLE
fix: iterating output.errors on undefined

### DIFF
--- a/server/src/services/validation/worker/build/solcCompile.ts
+++ b/server/src/services/validation/worker/build/solcCompile.ts
@@ -44,7 +44,7 @@ export async function solcCompile(
   }
 
   // Normalize errors' sourceLocation to use utf-8 offsets instead of byte offsets
-  for (const error of output.errors) {
+  for (const error of output.errors || []) {
     const source = input.sources[error.sourceLocation?.file];
 
     if (source === undefined) {


### PR DESCRIPTION
Since we don't have typing for solc output, we missed the case for output.errors being undefined