### PR TITLE
fix: validation file name mismatch because of casing on windows

### DIFF
--- a/server/src/queries/getOpenDocumentsInProject.ts
+++ b/server/src/queries/getOpenDocumentsInProject.ts
@@ -1,4 +1,3 @@
-import os from "os";
 import { isHardhatProject } from "@analyzer/HardhatProject";
 import {
   ClientTrackingState,
@@ -7,6 +6,7 @@ import {
   TextDocument,
 } from "@common/types";
 import { ServerState } from "../types";
+import { runningOnWindows } from "../utils/operatingSystem";
 
 export function getOpenDocumentsInProject(
   serverState: ServerState,
@@ -38,10 +38,9 @@ function lookupDocForSolFileEntry(
   serverState: ServerState,
   solFile: ISolFileEntry
 ): TextDocument | undefined {
-  const convertedUri =
-    os.platform() === "win32"
-      ? `file:///${solFile.uri.replace(":", "%3A")}`
-      : `file://${solFile.uri}`;
+  const convertedUri = runningOnWindows()
+    ? `file:///${solFile.uri.replace(":", "%3A")}`
+    : `file://${solFile.uri}`;
 
   return serverState.documents.get(convertedUri);
 }

--- a/server/src/services/validation/validate.ts
+++ b/server/src/services/validation/validate.ts
@@ -1,4 +1,3 @@
-import os from "os";
 import { Diagnostic, TextDocumentChangeEvent } from "vscode-languageserver";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { isHardhatProject } from "@analyzer/HardhatProject";
@@ -22,6 +21,7 @@ import {
   WorkerProcess,
 } from "../../types";
 import { getOpenDocumentsInProject } from "../../queries/getOpenDocumentsInProject";
+import { runningOnWindows } from "../../utils/operatingSystem";
 import { DiagnosticConverter } from "./DiagnosticConverter";
 import { convertHardhatErrorToDiagnostic } from "./convertHardhatErrorToDiagnostic";
 
@@ -314,7 +314,7 @@ function validationPass(
   message: ValidationPass
 ): void {
   for (const source of message.sources) {
-    const uri = os.platform() === "win32" ? `/${source}` : source;
+    const uri = runningOnWindows() ? `/${source}` : source;
 
     serverState.connection.sendDiagnostics({
       uri,
@@ -387,7 +387,7 @@ function resolveErrorFilePath(
     path.join(projectBasePath, hardhatError.messageArguments.from)
   );
 
-  const osPath = os.platform() === "win32" ? `/${errorPath}` : errorPath;
+  const osPath = runningOnWindows() ? `/${errorPath}` : errorPath;
 
   return osPath;
 }

--- a/server/src/services/validation/worker/build/buildInputsToSolc.ts
+++ b/server/src/services/validation/worker/build/buildInputsToSolc.ts
@@ -10,6 +10,7 @@ import {
   BuildJob,
   ValidationCompleteMessage,
 } from "../../../../types";
+import { runningOnWindows } from "../../../../utils/operatingSystem";
 
 export interface SolcInput {
   built: true;
@@ -204,9 +205,8 @@ function getValidationFile(
 ): void {
   context.file = context.dependencyGraph
     .getResolvedFiles()
-    .filter(
-      (f: { absolutePath: string }) =>
-        f.absolutePath.replaceAll("\\", "/") === uri
+    .filter((f: { absolutePath: string }) =>
+      uriEquals(f.absolutePath.replaceAll("\\", "/"), uri)
     )[0];
 }
 
@@ -344,4 +344,10 @@ function cancel({ jobId, projectBasePath }: BuildJob): {
 
 function isJobCancelled(buildJob: BuildJob) {
   return buildJob.status === "cancelled";
+}
+
+function uriEquals(uri1: string, uri2: string) {
+  return runningOnWindows()
+    ? uri1.toLowerCase() === uri2.toLowerCase()
+    : uri1 === uri2;
 }

--- a/server/src/utils/index.ts
+++ b/server/src/utils/index.ts
@@ -1,6 +1,6 @@
-import * as os from "os";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { TextDocumentIdentifier } from "vscode-languageserver-protocol";
+import { runningOnWindows } from "./operatingSystem";
 
 export function getUriFromDocument(
   document: TextDocument | TextDocumentIdentifier
@@ -17,7 +17,7 @@ export function lowercaseDriveLetter(uri: string) {
 }
 
 export function decodeUriAndRemoveFilePrefix(uri: string): string {
-  if (os.platform() === "win32" && uri && uri.includes("file:///")) {
+  if (runningOnWindows() && uri && uri.includes("file:///")) {
     uri = uri.replace("file:///", "");
   } else if (uri && uri.includes("file://")) {
     uri = uri.replace("file://", "");

--- a/server/src/utils/operatingSystem.ts
+++ b/server/src/utils/operatingSystem.ts
@@ -1,0 +1,5 @@
+import os from "os";
+
+export function runningOnWindows() {
+  return os.platform() === "win32";
+}

--- a/server/test/services/validation/validation.ts
+++ b/server/test/services/validation/validation.ts
@@ -1,4 +1,3 @@
-import os from "os";
 import { validate } from "@services/validation/validate";
 import { Logger } from "@utils/Logger";
 import { assert } from "chai";
@@ -22,6 +21,7 @@ import { setupMockLanguageServer } from "../../helpers/setupMockLanguageServer";
 import { setupMockLogger } from "../../helpers/setupMockLogger";
 import { waitUntil } from "../../helpers/waitUntil";
 import { setupMockTelemetry } from "../../helpers/setupMockTelemetry";
+import { runningOnWindows } from "../../../src/utils/operatingSystem";
 
 describe("Parser", () => {
   describe("Validation", function () {
@@ -520,7 +520,7 @@ describe("Parser", () => {
           version: "0.8.0",
           projectBasePath: "/projects/example",
           sources: [
-            os.platform() === "win32"
+            runningOnWindows()
               ? "c:/projects/example/contracts/first.sol"
               : "/projects/example/contracts/first.sol",
           ],
@@ -537,10 +537,9 @@ describe("Parser", () => {
         assert(sendDiagnostics.called);
         assert.deepStrictEqual(sendDiagnostics.args[0][0], {
           diagnostics: [],
-          uri:
-            os.platform() === "win32"
-              ? "/c:/projects/example/contracts/first.sol"
-              : "/projects/example/contracts/first.sol",
+          uri: runningOnWindows()
+            ? "/c:/projects/example/contracts/first.sol"
+            : "/projects/example/contracts/first.sol",
         });
       });
 
@@ -648,14 +647,12 @@ describe("Parser", () => {
           let sendDiagnostics: sinon.SinonSpy<unknown[], unknown>;
           let sendNotification: sinon.SinonSpy<unknown[], unknown>;
           let logger: Logger;
-          const projectBasePath =
-            os.platform() === "win32"
-              ? "c:/projects/example"
-              : "/projects/example";
-          const errorFile =
-            os.platform() === "win32"
-              ? "/c:/projects/example/importing.sol"
-              : "/projects/example/importing.sol";
+          const projectBasePath = runningOnWindows()
+            ? "c:/projects/example"
+            : "/projects/example";
+          const errorFile = runningOnWindows()
+            ? "/c:/projects/example/importing.sol"
+            : "/projects/example/importing.sol";
 
           before(async () => {
             sendDiagnostics = sinon.spy();

--- a/server/test/solFileDetails/getSolFileDetails.ts
+++ b/server/test/solFileDetails/getSolFileDetails.ts
@@ -1,13 +1,13 @@
 import { lowercaseDriveLetter, toUnixStyle } from "@utils/index";
 import * as assert from "assert";
 import * as path from "path";
-import os from "os";
 import { forceToUnixStyle } from "../helpers/forceToUnixStyle";
 import { prependWithSlash } from "../helpers/prependWithSlash";
 import {
   OnRequest,
   setupMockLanguageServer,
 } from "../helpers/setupMockLanguageServer";
+import { runningOnWindows } from "../../src/utils/operatingSystem";
 
 describe("Solidity Language Server", () => {
   describe("get sol file details", () => {
@@ -82,7 +82,5 @@ describe("Solidity Language Server", () => {
 });
 
 function prependWithFilePrefix(filePath: string) {
-  return os.platform() === "win32"
-    ? `file:///${filePath}`
-    : `file://${filePath}`;
+  return runningOnWindows() ? `file:///${filePath}` : `file://${filePath}`;
 }

--- a/server/test/utils/decodeUriAndRemoveFilePrefix.ts
+++ b/server/test/utils/decodeUriAndRemoveFilePrefix.ts
@@ -1,11 +1,11 @@
-import os from "os";
 import { assert } from "chai";
 import { decodeUriAndRemoveFilePrefix } from "@utils/index";
+import { runningOnWindows } from "../../src/utils/operatingSystem";
 
 describe("utils", () => {
   describe("decodeUriAndRemoveFilePrefix", () => {
     it("should strip the file prefix", () => {
-      if (os.platform() === "win32") {
+      if (runningOnWindows()) {
         assertDecode(
           "file:///c:/Users/example/somefile.sol",
           "c:/Users/example/somefile.sol"


### PR DESCRIPTION
Closes #264

Starting from a recent version (at least 2.11.2), the list of files resolved from hardhat's GET_DEPENDENCY_GRAPH task have the drive letter as upper case on windows. This made our `buildInputsToSolc` process to fail because string comparison was strict. I added a check to perform a case insensitive comparison on windows systems on this step.