### PR TITLE
async analysis

### DIFF
--- a/server/src/frameworks/Foundry/FoundryProject.ts
+++ b/server/src/frameworks/Foundry/FoundryProject.ts
@@ -85,7 +85,7 @@ export class FoundryProject extends Project {
     }
   }
 
-  public resolveImportPath(file: string, importPath: string) {
+  public async resolveImportPath(file: string, importPath: string) {
     try {
       let transformedPath = importPath;
 

--- a/server/src/frameworks/Hardhat/worker/WorkerProtocol.ts
+++ b/server/src/frameworks/Hardhat/worker/WorkerProtocol.ts
@@ -9,6 +9,8 @@ export enum MessageType {
   ERROR_RESPONSE,
   FILE_BELONGS_REQUEST,
   FILE_BELONGS_RESPONSE,
+  RESOLVE_IMPORT_REQUEST,
+  RESOLVE_IMPORT_RESPONSE,
   BUILD_COMPILATION_REQUEST,
   BUILD_COMPILATION_RESPONSE,
   INITIALIZATION_FAILURE,
@@ -62,6 +64,26 @@ export class FileBelongsRequest extends RequestMessage {
 export class FileBelongsResponse extends ResponseMessage {
   public type = MessageType.FILE_BELONGS_RESPONSE;
   constructor(requestId: number, public belongs: boolean) {
+    super(requestId);
+  }
+}
+
+export class ResolveImportRequest extends RequestMessage {
+  public type = MessageType.RESOLVE_IMPORT_REQUEST;
+
+  constructor(
+    requestId: number,
+    public from: string,
+    public importPath: string,
+    public projectBasePath: string
+  ) {
+    super(requestId);
+  }
+}
+
+export class ResolveImportResponse extends ResponseMessage {
+  public type = MessageType.RESOLVE_IMPORT_RESPONSE;
+  constructor(requestId: number, public path: string | undefined) {
     super(requestId);
   }
 }

--- a/server/src/frameworks/Projectless/ProjectlessProject.ts
+++ b/server/src/frameworks/Projectless/ProjectlessProject.ts
@@ -34,7 +34,7 @@ export class ProjectlessProject extends Project {
     return true;
   }
 
-  public resolveImportPath(file: string, importPath: string) {
+  public async resolveImportPath(file: string, importPath: string) {
     try {
       const resolvedPath = require.resolve(importPath, {
         paths: [fs.realpathSync(path.dirname(file))],

--- a/server/src/frameworks/base/Project.ts
+++ b/server/src/frameworks/base/Project.ts
@@ -20,7 +20,7 @@ export abstract class Project {
   public abstract resolveImportPath(
     file: string,
     importPath: string
-  ): string | undefined;
+  ): Promise<string | undefined>;
 
   // Any tasks the project need to run to be in an operative state
   public abstract initialize(): Promise<void>;

--- a/server/src/frameworks/shared/crawlDependencies.ts
+++ b/server/src/frameworks/shared/crawlDependencies.ts
@@ -27,7 +27,7 @@ export async function getDependenciesAndPragmas(
     );
 
     if (!solFileEntry.isAnalyzed()) {
-      analyzeSolFile(project.serverState, solFileEntry);
+      await analyzeSolFile(project.serverState, solFileEntry);
     }
   }
 
@@ -48,14 +48,14 @@ export async function getDependenciesAndPragmas(
   ];
 
   // Recursively crawl dependencies and append. Skip non-existing imports
-  const importsUris = imports.reduce((list, _import) => {
-    const resolvedImport = project.resolveImportPath(sourceUri, _import);
-    if (resolvedImport === undefined) {
-      return list;
-    } else {
-      return list.concat([resolvedImport]);
+  const importsUris: string[] = [];
+  for (const _import of imports) {
+    const resolvedImport = await project.resolveImportPath(sourceUri, _import);
+
+    if (resolvedImport !== undefined) {
+      importsUris.push(resolvedImport);
     }
-  }, [] as string[]);
+  }
 
   for (const importUri of importsUris) {
     dependencyDetails.push(

--- a/server/src/parser/analyzer/analyzeSolFile.ts
+++ b/server/src/parser/analyzer/analyzeSolFile.ts
@@ -8,11 +8,11 @@ import {
   SolFileState,
 } from "@common/types";
 
-export function analyzeSolFile(
+export async function analyzeSolFile(
   { solFileIndex }: { solFileIndex: SolFileIndexMap },
   solFileEntry: ISolFileEntry,
   newText?: string
-): Node | undefined {
+): Promise<Node | undefined> {
   try {
     solFileEntry.orphanNodes = [];
 
@@ -42,14 +42,16 @@ export function analyzeSolFile(
     }
 
     solFileEntry.status = SolFileState.ANALYZED;
-    solFileEntry.analyzerTree.tree = matcher
-      .find(
-        solFileEntry.ast,
-        solFileEntry.uri,
-        solFileEntry.project.basePath,
-        solFileIndex
-      )
-      .accept(matcher.find, solFileEntry.orphanNodes);
+    const node = await matcher.find(
+      solFileEntry.ast,
+      solFileEntry.uri,
+      solFileEntry.project.basePath,
+      solFileIndex
+    );
+    solFileEntry.analyzerTree.tree = await node.accept(
+      matcher.find,
+      solFileEntry.orphanNodes
+    );
 
     return solFileEntry.analyzerTree.tree;
   } catch {

--- a/server/src/parser/analyzer/nodes/ArrayTypeNameNode.ts
+++ b/server/src/parser/analyzer/nodes/ArrayTypeNameNode.ts
@@ -18,20 +18,26 @@ export class ArrayTypeNameNode extends Node {
     this.astNode = arrayTypeName;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
-    const typeNode = find(
+    const foundTypeNode = await find(
       this.astNode.baseTypeName,
       this.uri,
       this.rootPath,
       this.solFileIndex
-    ).accept(find, orphanNodes, parent, this);
+    );
+    const typeNode = await foundTypeNode.accept(
+      find,
+      orphanNodes,
+      parent,
+      this
+    );
 
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (typeNode) {

--- a/server/src/parser/analyzer/nodes/AssemblyAssignmentNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyAssignmentNode.ts
@@ -18,30 +18,33 @@ export class AssemblyAssignmentNode extends Node {
     this.astNode = assemblyAssignment;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     for (const name of this.astNode.names ?? []) {
-      find(name, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        parent
+      const foundNode = await find(
+        name,
+        this.uri,
+        this.rootPath,
+        this.solFileIndex
       );
+      await foundNode.accept(find, orphanNodes, parent);
     }
 
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this.astNode.expression) {
-      find(
+      const foundNode = await find(
         this.astNode.expression,
         this.uri,
         this.rootPath,
         this.solFileIndex
-      ).accept(find, orphanNodes, parent);
+      );
+      await foundNode.accept(find, orphanNodes, parent);
     }
 
     return this;

--- a/server/src/parser/analyzer/nodes/AssemblyBlockNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyBlockNode.ts
@@ -18,12 +18,12 @@ export class AssemblyBlockNode extends Node {
     this.astNode = assemblyBlock;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (parent) {
@@ -31,11 +31,13 @@ export class AssemblyBlockNode extends Node {
     }
 
     for (const operation of this.astNode.operations ?? []) {
-      find(operation, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        this
+      const foundNode = await find(
+        operation,
+        this.uri,
+        this.rootPath,
+        this.solFileIndex
       );
+      await foundNode.accept(find, orphanNodes, this);
     }
 
     parent?.addChild(this);

--- a/server/src/parser/analyzer/nodes/AssemblyCallNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyCallNode.ts
@@ -28,20 +28,22 @@ export class AssemblyCallNode extends Node {
     this.astNode = assemblyCall;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     for (const argument of this.astNode.arguments ?? []) {
-      find(argument, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        parent
+      const foundNode = await find(
+        argument,
+        this.uri,
+        this.rootPath,
+        this.solFileIndex
       );
+      await foundNode.accept(find, orphanNodes, parent);
     }
 
     if (parent) {

--- a/server/src/parser/analyzer/nodes/AssemblyCaseNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyCaseNode.ts
@@ -13,12 +13,12 @@ export class AssemblyCaseNode extends Node {
     this.astNode = assemblyCase;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (parent) {
@@ -26,19 +26,18 @@ export class AssemblyCaseNode extends Node {
     }
 
     if (this.astNode.value) {
-      find(
+      const foundNode = await find(
         this.astNode.value,
         this.uri,
         this.rootPath,
         this.solFileIndex
-      ).accept(find, orphanNodes, this);
+      );
+      await foundNode.accept(find, orphanNodes, this);
     }
 
-    find(this.astNode.block, this.uri, this.rootPath, this.solFileIndex).accept(
-      find,
-      orphanNodes,
-      this
-    );
+    await (
+      await find(this.astNode.block, this.uri, this.rootPath, this.solFileIndex)
+    ).accept(find, orphanNodes, this);
 
     parent?.addChild(this);
 

--- a/server/src/parser/analyzer/nodes/AssemblyForNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyForNode.ts
@@ -13,39 +13,36 @@ export class AssemblyForNode extends Node {
     this.astNode = assemblyFor;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (parent) {
       this.setParent(parent);
     }
 
-    find(this.astNode.pre, this.uri, this.rootPath, this.solFileIndex).accept(
-      find,
-      orphanNodes,
-      this
-    );
-    find(
-      this.astNode.condition,
-      this.uri,
-      this.rootPath,
-      this.solFileIndex
+    await (
+      await find(this.astNode.pre, this.uri, this.rootPath, this.solFileIndex)
     ).accept(find, orphanNodes, this);
-    find(this.astNode.post, this.uri, this.rootPath, this.solFileIndex).accept(
-      find,
-      orphanNodes,
-      this
-    );
-    find(this.astNode.body, this.uri, this.rootPath, this.solFileIndex).accept(
-      find,
-      orphanNodes,
-      this
-    );
+
+    await (
+      await find(
+        this.astNode.condition,
+        this.uri,
+        this.rootPath,
+        this.solFileIndex
+      )
+    ).accept(find, orphanNodes, this);
+    await (
+      await find(this.astNode.post, this.uri, this.rootPath, this.solFileIndex)
+    ).accept(find, orphanNodes, this);
+    await (
+      await find(this.astNode.body, this.uri, this.rootPath, this.solFileIndex)
+    ).accept(find, orphanNodes, this);
 
     parent?.addChild(this);
 

--- a/server/src/parser/analyzer/nodes/AssemblyFunctionDefinitionNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyFunctionDefinitionNode.ts
@@ -49,12 +49,12 @@ export class AssemblyFunctionDefinitionNode extends Node {
     return this;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (parent) {
@@ -64,29 +64,22 @@ export class AssemblyFunctionDefinitionNode extends Node {
     this._findChildren(orphanNodes);
 
     for (const argument of this.astNode.arguments) {
-      find(argument, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        this
-      );
+      await (
+        await find(argument, this.uri, this.rootPath, this.solFileIndex)
+      ).accept(find, orphanNodes, this);
     }
 
     for (const returnArgument of this.astNode.returnArguments) {
-      const typeNode = find(
-        returnArgument,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      const typeNode = await (
+        await find(returnArgument, this.uri, this.rootPath, this.solFileIndex)
       ).accept(find, orphanNodes, this);
 
       this.addTypeNode(typeNode);
     }
 
-    find(this.astNode.body, this.uri, this.rootPath, this.solFileIndex).accept(
-      find,
-      orphanNodes,
-      this
-    );
+    await (
+      await find(this.astNode.body, this.uri, this.rootPath, this.solFileIndex)
+    ).accept(find, orphanNodes, this);
 
     parent?.addChild(this);
 

--- a/server/src/parser/analyzer/nodes/AssemblyFunctionReturnsNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyFunctionReturnsNode.ts
@@ -19,12 +19,12 @@ export class AssemblyFunctionReturnsNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
     // TO-DO: Method not implemented
     return this;

--- a/server/src/parser/analyzer/nodes/AssemblyIfNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyIfNode.ts
@@ -13,30 +13,30 @@ export class AssemblyIfNode extends Node {
     this.astNode = assemblyIf;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (parent) {
       this.setParent(parent);
     }
 
-    find(
-      this.astNode.condition,
-      this.uri,
-      this.rootPath,
-      this.solFileIndex
+    await (
+      await find(
+        this.astNode.condition,
+        this.uri,
+        this.rootPath,
+        this.solFileIndex
+      )
     ).accept(find, orphanNodes, this);
 
-    find(this.astNode.body, this.uri, this.rootPath, this.solFileIndex).accept(
-      find,
-      orphanNodes,
-      this
-    );
+    await (
+      await find(this.astNode.body, this.uri, this.rootPath, this.solFileIndex)
+    ).accept(find, orphanNodes, this);
 
     parent?.addChild(this);
 

--- a/server/src/parser/analyzer/nodes/AssemblyLiteralNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyLiteralNode.ts
@@ -19,12 +19,12 @@ export class AssemblyLiteralNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
     // TO-DO: Method not implemented
     return this;

--- a/server/src/parser/analyzer/nodes/AssemblyLocalDefinitionNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyLocalDefinitionNode.ts
@@ -39,16 +39,16 @@ export class AssemblyLocalDefinitionNode extends Node {
     return this;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     for (const name of this.astNode.names ?? []) {
-      const identifierNode = find(
+      const identifierNode = await find(
         name,
         this.uri,
         this.rootPath,
@@ -66,11 +66,13 @@ export class AssemblyLocalDefinitionNode extends Node {
     }
 
     if (this.astNode.expression) {
-      find(
-        this.astNode.expression,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      await (
+        await find(
+          this.astNode.expression,
+          this.uri,
+          this.rootPath,
+          this.solFileIndex
+        )
       ).accept(find, orphanNodes, parent);
     }
 

--- a/server/src/parser/analyzer/nodes/AssemblyMemberAccessNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyMemberAccessNode.ts
@@ -19,12 +19,12 @@ export class AssemblyMemberAccessNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
     // TO-DO: Method not implemented
     return this;

--- a/server/src/parser/analyzer/nodes/AssemblyStackAssignmentNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblyStackAssignmentNode.ts
@@ -19,12 +19,12 @@ export class AssemblyStackAssignmentNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
     // TO-DO: Method not implemented
     return this;

--- a/server/src/parser/analyzer/nodes/AssemblySwitchNode.ts
+++ b/server/src/parser/analyzer/nodes/AssemblySwitchNode.ts
@@ -18,31 +18,31 @@ export class AssemblySwitchNode extends Node {
     this.astNode = assemblySwitch;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (parent) {
       this.setParent(parent);
     }
 
-    find(
-      this.astNode.expression,
-      this.uri,
-      this.rootPath,
-      this.solFileIndex
+    await (
+      await find(
+        this.astNode.expression,
+        this.uri,
+        this.rootPath,
+        this.solFileIndex
+      )
     ).accept(find, orphanNodes, this);
 
     for (const caseNode of this.astNode.cases) {
-      find(caseNode, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        this
-      );
+      await (
+        await find(caseNode, this.uri, this.rootPath, this.solFileIndex)
+      ).accept(find, orphanNodes, this);
     }
 
     parent?.addChild(this);

--- a/server/src/parser/analyzer/nodes/BinaryOperationNode.ts
+++ b/server/src/parser/analyzer/nodes/BinaryOperationNode.ts
@@ -18,24 +18,20 @@ export class BinaryOperationNode extends Node {
     this.astNode = binaryOperation;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
-    find(this.astNode.left, this.uri, this.rootPath, this.solFileIndex).accept(
-      find,
-      orphanNodes,
-      parent
-    );
-    find(this.astNode.right, this.uri, this.rootPath, this.solFileIndex).accept(
-      find,
-      orphanNodes,
-      parent
-    );
+    await (
+      await find(this.astNode.left, this.uri, this.rootPath, this.solFileIndex)
+    ).accept(find, orphanNodes, parent);
+    await (
+      await find(this.astNode.right, this.uri, this.rootPath, this.solFileIndex)
+    ).accept(find, orphanNodes, parent);
 
     return this;
   }

--- a/server/src/parser/analyzer/nodes/BlockNode.ts
+++ b/server/src/parser/analyzer/nodes/BlockNode.ts
@@ -17,20 +17,18 @@ export class BlockNode extends Node {
     return undefined;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     for (const statement of this.astNode.statements) {
-      find(statement, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        parent
-      );
+      await (
+        await find(statement, this.uri, this.rootPath, this.solFileIndex)
+      ).accept(find, orphanNodes, parent);
     }
 
     return this;

--- a/server/src/parser/analyzer/nodes/BooleanLiteralNode.ts
+++ b/server/src/parser/analyzer/nodes/BooleanLiteralNode.ts
@@ -19,12 +19,12 @@ export class BooleanLiteralNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
     // TO-DO: Method not implemented
     return this;

--- a/server/src/parser/analyzer/nodes/BreakNode.ts
+++ b/server/src/parser/analyzer/nodes/BreakNode.ts
@@ -14,12 +14,12 @@ export class BreakNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
     // TO-DO: Method not implemented
     return this;

--- a/server/src/parser/analyzer/nodes/BreakStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/BreakStatementNode.ts
@@ -19,12 +19,12 @@ export class BreakStatementNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
     // TO-DO: Method not implemented
     return this;

--- a/server/src/parser/analyzer/nodes/CatchClauseNode.ts
+++ b/server/src/parser/analyzer/nodes/CatchClauseNode.ts
@@ -13,12 +13,12 @@ export class CatchClauseNode extends Node {
     this.astNode = catchClause;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (parent) {
@@ -26,18 +26,14 @@ export class CatchClauseNode extends Node {
     }
 
     for (const param of this.astNode.parameters || []) {
-      find(param, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        this
-      );
+      await (
+        await find(param, this.uri, this.rootPath, this.solFileIndex)
+      ).accept(find, orphanNodes, this);
     }
 
-    find(this.astNode.body, this.uri, this.rootPath, this.solFileIndex).accept(
-      find,
-      orphanNodes,
-      this
-    );
+    await (
+      await find(this.astNode.body, this.uri, this.rootPath, this.solFileIndex)
+    ).accept(find, orphanNodes, this);
 
     parent?.addChild(this);
 

--- a/server/src/parser/analyzer/nodes/ConditionalNode.ts
+++ b/server/src/parser/analyzer/nodes/ConditionalNode.ts
@@ -13,41 +13,47 @@ export class ConditionalNode extends Node {
     this.astNode = conditional;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this.astNode.condition) {
-      find(
-        this.astNode.condition,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      await (
+        await find(
+          this.astNode.condition,
+          this.uri,
+          this.rootPath,
+          this.solFileIndex
+        )
       ).accept(find, orphanNodes, parent);
     }
 
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this.astNode.trueExpression) {
-      find(
-        this.astNode.trueExpression,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      await (
+        await find(
+          this.astNode.trueExpression,
+          this.uri,
+          this.rootPath,
+          this.solFileIndex
+        )
       ).accept(find, orphanNodes, parent);
     }
 
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this.astNode.falseExpression) {
-      find(
-        this.astNode.falseExpression,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      await (
+        await find(
+          this.astNode.falseExpression,
+          this.uri,
+          this.rootPath,
+          this.solFileIndex
+        )
       ).accept(find, orphanNodes, parent);
     }
 

--- a/server/src/parser/analyzer/nodes/ContinueNode.ts
+++ b/server/src/parser/analyzer/nodes/ContinueNode.ts
@@ -14,12 +14,12 @@ export class ContinueNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
     // TO-DO: Method not implemented
     return this;

--- a/server/src/parser/analyzer/nodes/ContinueStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/ContinueStatementNode.ts
@@ -19,12 +19,12 @@ export class ContinueStatementNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
     // TO-DO: Method not implemented
     return this;

--- a/server/src/parser/analyzer/nodes/ContractDefinitionNode.ts
+++ b/server/src/parser/analyzer/nodes/ContractDefinitionNode.ts
@@ -68,12 +68,12 @@ export class ContractDefinitionNode extends AbstractContractDefinitionNode {
     return this;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     const searcher = this.solFileIndex[this.uri]?.searcher;
@@ -83,11 +83,8 @@ export class ContractDefinitionNode extends AbstractContractDefinitionNode {
     }
 
     for (const baseContract of this.astNode.baseContracts) {
-      const inheritanceNode = find(
-        baseContract,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      const inheritanceNode = await (
+        await find(baseContract, this.uri, this.rootPath, this.solFileIndex)
       ).accept(find, orphanNodes, this);
 
       const inheritanceNodeDefinition = inheritanceNode.getDefinitionNode();
@@ -101,11 +98,9 @@ export class ContractDefinitionNode extends AbstractContractDefinitionNode {
     }
 
     for (const subNode of this.astNode.subNodes) {
-      find(subNode, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        this
-      );
+      await (
+        await find(subNode, this.uri, this.rootPath, this.solFileIndex)
+      ).accept(find, orphanNodes, this);
     }
 
     // Find parent for orphanNodes from this contract in inheritance Nodes

--- a/server/src/parser/analyzer/nodes/CustomErrorDefinitionNode.ts
+++ b/server/src/parser/analyzer/nodes/CustomErrorDefinitionNode.ts
@@ -53,12 +53,12 @@ export class CustomErrorDefinitionNode extends Node {
     return this;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     const searcher = this.solFileIndex[this.uri]?.searcher;
@@ -68,11 +68,9 @@ export class CustomErrorDefinitionNode extends Node {
     }
 
     for (const parameter of this.astNode.parameters) {
-      find(parameter, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        this
-      );
+      await (
+        await find(parameter, this.uri, this.rootPath, this.solFileIndex)
+      ).accept(find, orphanNodes, this);
     }
 
     const rootNode = findSourceUnitNode(parent);

--- a/server/src/parser/analyzer/nodes/DecimalNumberNode.ts
+++ b/server/src/parser/analyzer/nodes/DecimalNumberNode.ts
@@ -19,12 +19,12 @@ export class DecimalNumberNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
     // TO-DO: Method not implemented
     return this;

--- a/server/src/parser/analyzer/nodes/DoWhileStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/DoWhileStatementNode.ts
@@ -22,30 +22,30 @@ export class DoWhileStatementNode extends Node {
     return undefined;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (parent) {
       this.setParent(parent);
     }
 
-    find(
-      this.astNode.condition,
-      this.uri,
-      this.rootPath,
-      this.solFileIndex
+    await (
+      await find(
+        this.astNode.condition,
+        this.uri,
+        this.rootPath,
+        this.solFileIndex
+      )
     ).accept(find, orphanNodes, this);
 
-    find(this.astNode.body, this.uri, this.rootPath, this.solFileIndex).accept(
-      find,
-      orphanNodes,
-      this
-    );
+    await (
+      await find(this.astNode.body, this.uri, this.rootPath, this.solFileIndex)
+    ).accept(find, orphanNodes, this);
 
     parent?.addChild(this);
 

--- a/server/src/parser/analyzer/nodes/ElementaryTypeNameNode.ts
+++ b/server/src/parser/analyzer/nodes/ElementaryTypeNameNode.ts
@@ -25,12 +25,12 @@ export class ElementaryTypeNameNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
     // TO-DO: Method not implemented
     return this;

--- a/server/src/parser/analyzer/nodes/EmitStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/EmitStatementNode.ts
@@ -18,19 +18,21 @@ export class EmitStatementNode extends Node {
     this.astNode = emitStatement;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
-    find(
-      this.astNode.eventCall,
-      this.uri,
-      this.rootPath,
-      this.solFileIndex
+    await (
+      await find(
+        this.astNode.eventCall,
+        this.uri,
+        this.rootPath,
+        this.solFileIndex
+      )
     ).accept(find, orphanNodes, parent, this);
 
     return this;

--- a/server/src/parser/analyzer/nodes/EnumDefinitionNode.ts
+++ b/server/src/parser/analyzer/nodes/EnumDefinitionNode.ts
@@ -53,12 +53,12 @@ export class EnumDefinitionNode extends Node {
     return this;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     const searcher = this.solFileIndex[this.uri]?.searcher;
@@ -68,11 +68,9 @@ export class EnumDefinitionNode extends Node {
     }
 
     for (const member of this.astNode.members) {
-      find(member, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        this
-      );
+      await (
+        await find(member, this.uri, this.rootPath, this.solFileIndex)
+      ).accept(find, orphanNodes, this);
     }
 
     const rootNode = findSourceUnitNode(parent);

--- a/server/src/parser/analyzer/nodes/EnumValueNode.ts
+++ b/server/src/parser/analyzer/nodes/EnumValueNode.ts
@@ -28,12 +28,12 @@ export class EnumValueNode extends Node {
     return this;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (parent) {

--- a/server/src/parser/analyzer/nodes/EventDefinitionNode.ts
+++ b/server/src/parser/analyzer/nodes/EventDefinitionNode.ts
@@ -53,12 +53,12 @@ export class EventDefinitionNode extends Node {
     return this;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     const searcher = this.solFileIndex[this.uri]?.searcher;
@@ -68,11 +68,9 @@ export class EventDefinitionNode extends Node {
     }
 
     for (const parameter of this.astNode.parameters) {
-      find(parameter, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        this
-      );
+      await (
+        await find(parameter, this.uri, this.rootPath, this.solFileIndex)
+      ).accept(find, orphanNodes, this);
     }
 
     const rootNode = findSourceUnitNode(parent);

--- a/server/src/parser/analyzer/nodes/ExpressionStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/ExpressionStatementNode.ts
@@ -18,20 +18,22 @@ export class ExpressionStatementNode extends Node {
     this.astNode = expressionStatement;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (this.astNode.expression) {
-      find(
-        this.astNode.expression,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      await (
+        await find(
+          this.astNode.expression,
+          this.uri,
+          this.rootPath,
+          this.solFileIndex
+        )
       ).accept(find, orphanNodes, parent);
     }
 

--- a/server/src/parser/analyzer/nodes/FileLevelConstantNode.ts
+++ b/server/src/parser/analyzer/nodes/FileLevelConstantNode.ts
@@ -44,12 +44,12 @@ export class FileLevelConstantNode extends Node {
     return this;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (parent) {
@@ -58,11 +58,13 @@ export class FileLevelConstantNode extends Node {
 
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this.astNode.typeName) {
-      let typeNode = find(
-        this.astNode.typeName,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      let typeNode = await (
+        await find(
+          this.astNode.typeName,
+          this.uri,
+          this.rootPath,
+          this.solFileIndex
+        )
       ).accept(find, orphanNodes, this);
 
       this.addTypeNode(typeNode);
@@ -79,11 +81,13 @@ export class FileLevelConstantNode extends Node {
 
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this.astNode.initialValue) {
-      find(
-        this.astNode.initialValue,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      await (
+        await find(
+          this.astNode.initialValue,
+          this.uri,
+          this.rootPath,
+          this.solFileIndex
+        )
       ).accept(find, orphanNodes, parent);
     }
 

--- a/server/src/parser/analyzer/nodes/ForStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/ForStatementNode.ts
@@ -17,12 +17,12 @@ export class ForStatementNode extends Node {
     return undefined;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (parent) {
@@ -30,38 +30,42 @@ export class ForStatementNode extends Node {
     }
 
     if (this.astNode.initExpression) {
-      find(
-        this.astNode.initExpression,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      await (
+        await find(
+          this.astNode.initExpression,
+          this.uri,
+          this.rootPath,
+          this.solFileIndex
+        )
       ).accept(find, orphanNodes, this);
     }
 
     if (this.astNode.conditionExpression) {
-      find(
-        this.astNode.conditionExpression,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      await (
+        await find(
+          this.astNode.conditionExpression,
+          this.uri,
+          this.rootPath,
+          this.solFileIndex
+        )
       ).accept(find, orphanNodes, this);
     }
 
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this.astNode.loopExpression) {
-      find(
-        this.astNode.loopExpression,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      await (
+        await find(
+          this.astNode.loopExpression,
+          this.uri,
+          this.rootPath,
+          this.solFileIndex
+        )
       ).accept(find, orphanNodes, this);
     }
 
-    find(this.astNode.body, this.uri, this.rootPath, this.solFileIndex).accept(
-      find,
-      orphanNodes,
-      this
-    );
+    await (
+      await find(this.astNode.body, this.uri, this.rootPath, this.solFileIndex)
+    ).accept(find, orphanNodes, this);
 
     parent?.addChild(this);
 

--- a/server/src/parser/analyzer/nodes/FunctionCallNode.ts
+++ b/server/src/parser/analyzer/nodes/FunctionCallNode.ts
@@ -19,38 +19,38 @@ export class FunctionCallNode extends Node {
     this.astNode = functionCall;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (expression?.type !== "EmitStatement") {
       expression = this;
     }
 
-    const expressionNode = find(
-      this.astNode.expression,
-      this.uri,
-      this.rootPath,
-      this.solFileIndex
+    const expressionNode = await (
+      await find(
+        this.astNode.expression,
+        this.uri,
+        this.rootPath,
+        this.solFileIndex
+      )
     ).accept(find, orphanNodes, parent, expression);
 
     for (const argument of this.astNode.arguments) {
-      find(argument, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        parent
-      );
+      await (
+        await find(argument, this.uri, this.rootPath, this.solFileIndex)
+      ).accept(find, orphanNodes, parent);
     }
 
     const definitionTypes = expressionNode.getTypeNodes();
     const searcher = this.solFileIndex[this.uri]?.searcher;
 
     for (const identifier of this.astNode.identifiers) {
-      const identifierNode = find(
+      const identifierNode = await find(
         identifier,
         this.uri,
         this.rootPath,

--- a/server/src/parser/analyzer/nodes/FunctionDefinitionNode.ts
+++ b/server/src/parser/analyzer/nodes/FunctionDefinitionNode.ts
@@ -80,12 +80,12 @@ export class FunctionDefinitionNode extends AbstractFunctionDefinitionNode {
     return this;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (parent) {
@@ -102,49 +102,41 @@ export class FunctionDefinitionNode extends AbstractFunctionDefinitionNode {
     this._findChildren(orphanNodes);
 
     for (const override of this.astNode.override || []) {
-      find(override, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        this
-      );
+      await (
+        await find(override, this.uri, this.rootPath, this.solFileIndex)
+      ).accept(find, orphanNodes, this);
     }
 
     for (const param of this.astNode.parameters) {
-      find(param, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        this
-      );
+      await (
+        await find(param, this.uri, this.rootPath, this.solFileIndex)
+      ).accept(find, orphanNodes, this);
     }
 
     for (const returnParam of this.astNode.returnParameters ?? []) {
-      const typeNode = find(
-        returnParam,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      const typeNode = await (
+        await find(returnParam, this.uri, this.rootPath, this.solFileIndex)
       ).accept(find, orphanNodes, this);
 
       this.addTypeNode(typeNode);
     }
 
     for (const modifier of this.astNode.modifiers ?? []) {
-      const typeNode = find(
-        modifier,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      const typeNode = await (
+        await find(modifier, this.uri, this.rootPath, this.solFileIndex)
       ).accept(find, orphanNodes, this);
 
       this.addTypeNode(typeNode);
     }
 
     if (this.astNode.body) {
-      find(
-        this.astNode.body,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      await (
+        await find(
+          this.astNode.body,
+          this.uri,
+          this.rootPath,
+          this.solFileIndex
+        )
       ).accept(find, orphanNodes, this);
     }
 

--- a/server/src/parser/analyzer/nodes/FunctionTypeNameNode.ts
+++ b/server/src/parser/analyzer/nodes/FunctionTypeNameNode.ts
@@ -19,12 +19,12 @@ export class FunctionTypeNameNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
     // TO-DO: Method not implemented
     return this;

--- a/server/src/parser/analyzer/nodes/HexLiteralNode.ts
+++ b/server/src/parser/analyzer/nodes/HexLiteralNode.ts
@@ -14,12 +14,12 @@ export class HexLiteralNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
     // TO-DO: Method not implemented
     return this;

--- a/server/src/parser/analyzer/nodes/HexNumberNode.ts
+++ b/server/src/parser/analyzer/nodes/HexNumberNode.ts
@@ -14,12 +14,12 @@ export class HexNumberNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
     // TO-DO: Method not implemented
     return this;

--- a/server/src/parser/analyzer/nodes/IdentifierNode.ts
+++ b/server/src/parser/analyzer/nodes/IdentifierNode.ts
@@ -68,12 +68,12 @@ export class IdentifierNode extends AbstractIdentifierNode {
     }
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (expression?.type === "ImportDirective" && parent) {

--- a/server/src/parser/analyzer/nodes/IfStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/IfStatementNode.ts
@@ -17,37 +17,43 @@ export class IfStatementNode extends Node {
     return undefined;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (parent) {
       this.setParent(parent);
     }
 
-    find(
-      this.astNode.condition,
-      this.uri,
-      this.rootPath,
-      this.solFileIndex
-    ).accept(find, orphanNodes, this);
-    find(
-      this.astNode.trueBody,
-      this.uri,
-      this.rootPath,
-      this.solFileIndex
-    ).accept(find, orphanNodes, this);
-
-    if (this.astNode.falseBody) {
-      find(
-        this.astNode.falseBody,
+    await (
+      await find(
+        this.astNode.condition,
         this.uri,
         this.rootPath,
         this.solFileIndex
+      )
+    ).accept(find, orphanNodes, this);
+    await (
+      await find(
+        this.astNode.trueBody,
+        this.uri,
+        this.rootPath,
+        this.solFileIndex
+      )
+    ).accept(find, orphanNodes, this);
+
+    if (this.astNode.falseBody) {
+      await (
+        await find(
+          this.astNode.falseBody,
+          this.uri,
+          this.rootPath,
+          this.solFileIndex
+        )
       ).accept(find, orphanNodes, this);
     }
 

--- a/server/src/parser/analyzer/nodes/IndexAccessNode.ts
+++ b/server/src/parser/analyzer/nodes/IndexAccessNode.ts
@@ -13,25 +13,20 @@ export class IndexAccessNode extends Node {
     this.astNode = indexAccess;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
-    const typeNode = find(
-      this.astNode.base,
-      this.uri,
-      this.rootPath,
-      this.solFileIndex
+    const typeNode = await (
+      await find(this.astNode.base, this.uri, this.rootPath, this.solFileIndex)
     ).accept(find, orphanNodes, parent, this);
-    find(this.astNode.index, this.uri, this.rootPath, this.solFileIndex).accept(
-      find,
-      orphanNodes,
-      parent
-    );
+    await (
+      await find(this.astNode.index, this.uri, this.rootPath, this.solFileIndex)
+    ).accept(find, orphanNodes, parent);
 
     return typeNode;
   }

--- a/server/src/parser/analyzer/nodes/IndexRangeAccessNode.ts
+++ b/server/src/parser/analyzer/nodes/IndexRangeAccessNode.ts
@@ -18,36 +18,37 @@ export class IndexRangeAccessNode extends Node {
     this.astNode = indexRangeAccess;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
-    const typeNode = find(
-      this.astNode.base,
-      this.uri,
-      this.rootPath,
-      this.solFileIndex
+    const typeNode = await (
+      await find(this.astNode.base, this.uri, this.rootPath, this.solFileIndex)
     ).accept(find, orphanNodes, parent, this);
 
     if (this.astNode.indexStart) {
-      find(
-        this.astNode.indexStart,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      await (
+        await find(
+          this.astNode.indexStart,
+          this.uri,
+          this.rootPath,
+          this.solFileIndex
+        )
       ).accept(find, orphanNodes, parent);
     }
 
     if (this.astNode.indexEnd) {
-      find(
-        this.astNode.indexEnd,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      await (
+        await find(
+          this.astNode.indexEnd,
+          this.uri,
+          this.rootPath,
+          this.solFileIndex
+        )
       ).accept(find, orphanNodes, parent);
     }
 

--- a/server/src/parser/analyzer/nodes/InheritanceSpecifierNode.ts
+++ b/server/src/parser/analyzer/nodes/InheritanceSpecifierNode.ts
@@ -18,27 +18,27 @@ export class InheritanceSpecifierNode extends Node {
     this.astNode = inheritanceSpecifier;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
-    const baseNode = find(
-      this.astNode.baseName,
-      this.uri,
-      this.rootPath,
-      this.solFileIndex
+    const baseNode = await (
+      await find(
+        this.astNode.baseName,
+        this.uri,
+        this.rootPath,
+        this.solFileIndex
+      )
     ).accept(find, orphanNodes, parent);
 
     for (const argument of this.astNode.arguments) {
-      find(argument, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        parent
-      );
+      await (
+        await find(argument, this.uri, this.rootPath, this.solFileIndex)
+      ).accept(find, orphanNodes, parent);
     }
 
     return baseNode;

--- a/server/src/parser/analyzer/nodes/InlineAssemblyStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/InlineAssemblyStatementNode.ts
@@ -18,21 +18,23 @@ export class InlineAssemblyStatementNode extends Node {
     this.astNode = inlineAssemblyStatement;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this.astNode.body) {
-      find(
-        this.astNode.body,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      await (
+        await find(
+          this.astNode.body,
+          this.uri,
+          this.rootPath,
+          this.solFileIndex
+        )
       ).accept(find, orphanNodes, parent);
     }
 

--- a/server/src/parser/analyzer/nodes/LabelDefinitionNode.ts
+++ b/server/src/parser/analyzer/nodes/LabelDefinitionNode.ts
@@ -27,12 +27,12 @@ export class LabelDefinitionNode extends Node {
     return this;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
     // TO-DO: Method not implemented
     return this;

--- a/server/src/parser/analyzer/nodes/MappingNode.ts
+++ b/server/src/parser/analyzer/nodes/MappingNode.ts
@@ -13,25 +13,29 @@ export class MappingNode extends Node {
     this.astNode = mapping;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
-    find(
-      this.astNode.keyType,
-      this.uri,
-      this.rootPath,
-      this.solFileIndex
+    await (
+      await find(
+        this.astNode.keyType,
+        this.uri,
+        this.rootPath,
+        this.solFileIndex
+      )
     ).accept(find, orphanNodes, parent);
-    const typeNode = find(
-      this.astNode.valueType,
-      this.uri,
-      this.rootPath,
-      this.solFileIndex
+    const typeNode = await (
+      await find(
+        this.astNode.valueType,
+        this.uri,
+        this.rootPath,
+        this.solFileIndex
+      )
     ).accept(find, orphanNodes, parent);
 
     this.addTypeNode(typeNode);

--- a/server/src/parser/analyzer/nodes/MemberAccessNode.ts
+++ b/server/src/parser/analyzer/nodes/MemberAccessNode.ts
@@ -60,19 +60,21 @@ export class MemberAccessNode extends IMemberAccessNode {
     }
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
-    const expressionNode = find(
-      this.astNode.expression,
-      this.uri,
-      this.rootPath,
-      this.solFileIndex
+    const expressionNode = await (
+      await find(
+        this.astNode.expression,
+        this.uri,
+        this.rootPath,
+        this.solFileIndex
+      )
     ).accept(find, orphanNodes, parent, this);
     this.setPreviousMemberAccessNode(expressionNode);
 

--- a/server/src/parser/analyzer/nodes/ModifierDefinitionNode.ts
+++ b/server/src/parser/analyzer/nodes/ModifierDefinitionNode.ts
@@ -53,12 +53,12 @@ export class ModifierDefinitionNode extends Node {
     return this;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (parent) {
@@ -66,27 +66,25 @@ export class ModifierDefinitionNode extends Node {
     }
 
     for (const override of this.astNode.override || []) {
-      find(override, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        this
-      );
+      await (
+        await find(override, this.uri, this.rootPath, this.solFileIndex)
+      ).accept(find, orphanNodes, this);
     }
 
     for (const param of this.astNode.parameters || []) {
-      find(param, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        this
-      );
+      await (
+        await find(param, this.uri, this.rootPath, this.solFileIndex)
+      ).accept(find, orphanNodes, this);
     }
 
     if (this.astNode.body) {
-      find(
-        this.astNode.body,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      await (
+        await find(
+          this.astNode.body,
+          this.uri,
+          this.rootPath,
+          this.solFileIndex
+        )
       ).accept(find, orphanNodes, this);
     }
 

--- a/server/src/parser/analyzer/nodes/ModifierInvocationNode.ts
+++ b/server/src/parser/analyzer/nodes/ModifierInvocationNode.ts
@@ -41,20 +41,18 @@ export class ModifierInvocationNode extends Node {
     }
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     for (const argument of this.astNode.arguments || []) {
-      find(argument, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        parent
-      );
+      await (
+        await find(argument, this.uri, this.rootPath, this.solFileIndex)
+      ).accept(find, orphanNodes, parent);
     }
 
     if (!parent) {

--- a/server/src/parser/analyzer/nodes/NameValueExpressionNode.ts
+++ b/server/src/parser/analyzer/nodes/NameValueExpressionNode.ts
@@ -18,25 +18,29 @@ export class NameValueExpressionNode extends Node {
     this.astNode = nameValueExpression;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
-    find(
-      this.astNode.expression,
-      this.uri,
-      this.rootPath,
-      this.solFileIndex
+    await (
+      await find(
+        this.astNode.expression,
+        this.uri,
+        this.rootPath,
+        this.solFileIndex
+      )
     ).accept(find, orphanNodes, parent);
-    find(
-      this.astNode.arguments,
-      this.uri,
-      this.rootPath,
-      this.solFileIndex
+    await (
+      await find(
+        this.astNode.arguments,
+        this.uri,
+        this.rootPath,
+        this.solFileIndex
+      )
     ).accept(find, orphanNodes, parent);
 
     return this;

--- a/server/src/parser/analyzer/nodes/NameValueListNode.ts
+++ b/server/src/parser/analyzer/nodes/NameValueListNode.ts
@@ -18,20 +18,18 @@ export class NameValueListNode extends Node {
     this.astNode = nameValueList;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     for (const identifier of this.astNode.identifiers) {
-      find(identifier, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        parent
-      );
+      await (
+        await find(identifier, this.uri, this.rootPath, this.solFileIndex)
+      ).accept(find, orphanNodes, parent);
     }
     return this;
   }

--- a/server/src/parser/analyzer/nodes/NewExpressionNode.ts
+++ b/server/src/parser/analyzer/nodes/NewExpressionNode.ts
@@ -18,21 +18,23 @@ export class NewExpressionNode extends Node {
     this.astNode = newExpression;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this.astNode.typeName) {
-      find(
-        this.astNode.typeName,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      await (
+        await find(
+          this.astNode.typeName,
+          this.uri,
+          this.rootPath,
+          this.solFileIndex
+        )
       ).accept(find, orphanNodes, parent);
     }
 

--- a/server/src/parser/analyzer/nodes/NumberLiteralNode.ts
+++ b/server/src/parser/analyzer/nodes/NumberLiteralNode.ts
@@ -19,12 +19,12 @@ export class NumberLiteralNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
     // TO-DO: Method not implemented
     return this;

--- a/server/src/parser/analyzer/nodes/PragmaDirectiveNode.ts
+++ b/server/src/parser/analyzer/nodes/PragmaDirectiveNode.ts
@@ -19,12 +19,12 @@ export class PragmaDirectiveNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
     // TO-DO: Method not implemented
     return this;

--- a/server/src/parser/analyzer/nodes/ReturnStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/ReturnStatementNode.ts
@@ -18,20 +18,22 @@ export class ReturnStatementNode extends Node {
     this.astNode = returnStatement;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (this.astNode.expression) {
-      find(
-        this.astNode.expression,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      await (
+        await find(
+          this.astNode.expression,
+          this.uri,
+          this.rootPath,
+          this.solFileIndex
+        )
       ).accept(find, orphanNodes, parent);
     }
 

--- a/server/src/parser/analyzer/nodes/RevertStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/RevertStatementNode.ts
@@ -18,19 +18,21 @@ export class RevertStatementNode extends Node {
     this.astNode = revertStatement;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
-    find(
-      this.astNode.revertCall,
-      this.uri,
-      this.rootPath,
-      this.solFileIndex
+    await (
+      await find(
+        this.astNode.revertCall,
+        this.uri,
+        this.rootPath,
+        this.solFileIndex
+      )
     ).accept(find, orphanNodes, parent, this);
 
     return this;

--- a/server/src/parser/analyzer/nodes/SourceUnitNode.ts
+++ b/server/src/parser/analyzer/nodes/SourceUnitNode.ts
@@ -23,12 +23,12 @@ export class SourceUnitNode extends AbstractSourceUnitNode {
     return undefined;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     const documentAnalyzer = this.solFileIndex[this.uri];
@@ -47,11 +47,9 @@ export class SourceUnitNode extends AbstractSourceUnitNode {
     }
 
     for (const child of this.astNode.children) {
-      find(child, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        this
-      );
+      await (
+        await find(child, this.uri, this.rootPath, this.solFileIndex)
+      ).accept(find, orphanNodes, this);
     }
 
     return this;

--- a/server/src/parser/analyzer/nodes/StateVariableDeclarationNode.ts
+++ b/server/src/parser/analyzer/nodes/StateVariableDeclarationNode.ts
@@ -28,28 +28,28 @@ export class StateVariableDeclarationNode extends Node {
     return this;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     for (const variable of this.astNode.variables) {
-      find(variable, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        parent
-      );
+      await (
+        await find(variable, this.uri, this.rootPath, this.solFileIndex)
+      ).accept(find, orphanNodes, parent);
     }
 
     if (this.astNode.initialValue) {
-      find(
-        this.astNode.initialValue,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      await (
+        await find(
+          this.astNode.initialValue,
+          this.uri,
+          this.rootPath,
+          this.solFileIndex
+        )
       ).accept(find, orphanNodes, parent);
     }
 

--- a/server/src/parser/analyzer/nodes/StringLiteralNode.ts
+++ b/server/src/parser/analyzer/nodes/StringLiteralNode.ts
@@ -19,12 +19,12 @@ export class StringLiteralNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
     // TO-DO: Method not implemented
     return this;

--- a/server/src/parser/analyzer/nodes/StructDefinitionNode.ts
+++ b/server/src/parser/analyzer/nodes/StructDefinitionNode.ts
@@ -57,12 +57,12 @@ export class StructDefinitionNode extends Node {
     return this;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (parent) {
@@ -70,11 +70,9 @@ export class StructDefinitionNode extends Node {
     }
 
     for (const member of this.astNode.members) {
-      find(member, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        this
-      );
+      await (
+        await find(member, this.uri, this.rootPath, this.solFileIndex)
+      ).accept(find, orphanNodes, this);
     }
 
     const rootNode = findSourceUnitNode(parent);

--- a/server/src/parser/analyzer/nodes/SubAssemblyNode.ts
+++ b/server/src/parser/analyzer/nodes/SubAssemblyNode.ts
@@ -14,12 +14,12 @@ export class SubAssemblyNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
     // TO-DO: Method not implemented
     return this;

--- a/server/src/parser/analyzer/nodes/ThrowStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/ThrowStatementNode.ts
@@ -19,12 +19,12 @@ export class ThrowStatementNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
     // TO-DO: Method not implemented
     return this;

--- a/server/src/parser/analyzer/nodes/TryStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/TryStatementNode.ts
@@ -13,45 +13,41 @@ export class TryStatementNode extends Node {
     this.astNode = tryStatement;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (parent) {
       this.setParent(parent);
     }
 
-    find(
-      this.astNode.expression,
-      this.uri,
-      this.rootPath,
-      this.solFileIndex
+    await (
+      await find(
+        this.astNode.expression,
+        this.uri,
+        this.rootPath,
+        this.solFileIndex
+      )
     ).accept(find, orphanNodes, this);
 
     for (const returnParameter of this.astNode.returnParameters || []) {
-      find(returnParameter, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        this
-      );
+      await (
+        await find(returnParameter, this.uri, this.rootPath, this.solFileIndex)
+      ).accept(find, orphanNodes, this);
     }
 
-    find(this.astNode.body, this.uri, this.rootPath, this.solFileIndex).accept(
-      find,
-      orphanNodes,
-      this
-    );
+    await (
+      await find(this.astNode.body, this.uri, this.rootPath, this.solFileIndex)
+    ).accept(find, orphanNodes, this);
 
     for (const catchClause of this.astNode.catchClauses ?? []) {
-      find(catchClause, this.uri, this.rootPath, this.solFileIndex).accept(
-        find,
-        orphanNodes,
-        this
-      );
+      await (
+        await find(catchClause, this.uri, this.rootPath, this.solFileIndex)
+      ).accept(find, orphanNodes, this);
     }
 
     parent?.addChild(this);

--- a/server/src/parser/analyzer/nodes/TupleExpressionNode.ts
+++ b/server/src/parser/analyzer/nodes/TupleExpressionNode.ts
@@ -18,21 +18,19 @@ export class TupleExpressionNode extends Node {
     this.astNode = tupleExpression;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     for (const component of this.astNode.components) {
       if (component) {
-        find(component, this.uri, this.rootPath, this.solFileIndex).accept(
-          find,
-          orphanNodes,
-          parent
-        );
+        await (
+          await find(component, this.uri, this.rootPath, this.solFileIndex)
+        ).accept(find, orphanNodes, parent);
       }
     }
 

--- a/server/src/parser/analyzer/nodes/TypeDefinitionNode.ts
+++ b/server/src/parser/analyzer/nodes/TypeDefinitionNode.ts
@@ -53,12 +53,12 @@ export class TypeDefinitionNode extends Node {
     return this;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     const searcher = this.solFileIndex[this.uri]?.searcher;

--- a/server/src/parser/analyzer/nodes/TypeNameExpressionNode.ts
+++ b/server/src/parser/analyzer/nodes/TypeNameExpressionNode.ts
@@ -19,12 +19,12 @@ export class TypeNameExpressionNode extends Node {
     // TO-DO: Implement name location for rename
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
     // TO-DO: Method not implemented
     return this;

--- a/server/src/parser/analyzer/nodes/UnaryOperationNode.ts
+++ b/server/src/parser/analyzer/nodes/UnaryOperationNode.ts
@@ -18,19 +18,21 @@ export class UnaryOperationNode extends Node {
     this.astNode = unaryOperation;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
-    find(
-      this.astNode.subExpression,
-      this.uri,
-      this.rootPath,
-      this.solFileIndex
+    await (
+      await find(
+        this.astNode.subExpression,
+        this.uri,
+        this.rootPath,
+        this.solFileIndex
+      )
     ).accept(find, orphanNodes, parent);
 
     return this;

--- a/server/src/parser/analyzer/nodes/UncheckedStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/UncheckedStatementNode.ts
@@ -18,21 +18,23 @@ export class UncheckedStatementNode extends Node {
     this.astNode = uncheckedStatement;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this.astNode.block) {
-      find(
-        this.astNode.block,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      await (
+        await find(
+          this.astNode.block,
+          this.uri,
+          this.rootPath,
+          this.solFileIndex
+        )
       ).accept(find, orphanNodes, parent);
     }
 

--- a/server/src/parser/analyzer/nodes/UserDefinedTypeNameNode.ts
+++ b/server/src/parser/analyzer/nodes/UserDefinedTypeNameNode.ts
@@ -66,12 +66,12 @@ export class UserDefinedTypeNameNode extends Node {
     }
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (!parent) {

--- a/server/src/parser/analyzer/nodes/UsingForDeclarationNode.ts
+++ b/server/src/parser/analyzer/nodes/UsingForDeclarationNode.ts
@@ -42,20 +42,22 @@ export class UsingForDeclarationNode extends Node {
     }
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (this.astNode.typeName) {
-      find(
-        this.astNode.typeName,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      await (
+        await find(
+          this.astNode.typeName,
+          this.uri,
+          this.rootPath,
+          this.solFileIndex
+        )
       ).accept(find, orphanNodes, parent);
     }
 

--- a/server/src/parser/analyzer/nodes/VariableDeclarationNode.ts
+++ b/server/src/parser/analyzer/nodes/VariableDeclarationNode.ts
@@ -56,12 +56,12 @@ export class VariableDeclarationNode extends AbstractVariableDeclarationNode {
     return this;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (parent) {
@@ -69,11 +69,13 @@ export class VariableDeclarationNode extends AbstractVariableDeclarationNode {
     }
 
     if (this.astNode.typeName) {
-      let typeNode = find(
-        this.astNode.typeName,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      let typeNode = await (
+        await find(
+          this.astNode.typeName,
+          this.uri,
+          this.rootPath,
+          this.solFileIndex
+        )
       ).accept(find, orphanNodes, this);
 
       this.addTypeNode(typeNode);

--- a/server/src/parser/analyzer/nodes/VariableDeclarationStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/VariableDeclarationStatementNode.ts
@@ -28,30 +28,30 @@ export class VariableDeclarationStatementNode extends Node {
     return this;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     for (const variable of this.astNode.variables) {
       if (variable) {
-        find(variable, this.uri, this.rootPath, this.solFileIndex).accept(
-          find,
-          orphanNodes,
-          parent
-        );
+        await (
+          await find(variable, this.uri, this.rootPath, this.solFileIndex)
+        ).accept(find, orphanNodes, parent);
       }
     }
 
     if (this.astNode.initialValue) {
-      find(
-        this.astNode.initialValue,
-        this.uri,
-        this.rootPath,
-        this.solFileIndex
+      await (
+        await find(
+          this.astNode.initialValue,
+          this.uri,
+          this.rootPath,
+          this.solFileIndex
+        )
       ).accept(find, orphanNodes, parent);
     }
 

--- a/server/src/parser/analyzer/nodes/WhileStatementNode.ts
+++ b/server/src/parser/analyzer/nodes/WhileStatementNode.ts
@@ -22,29 +22,29 @@ export class WhileStatementNode extends Node {
     return undefined;
   }
 
-  public accept(
+  public async accept(
     find: FinderType,
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     this.setExpressionNode(expression);
 
     if (parent) {
       this.setParent(parent);
     }
 
-    find(
-      this.astNode.condition,
-      this.uri,
-      this.rootPath,
-      this.solFileIndex
+    await (
+      await find(
+        this.astNode.condition,
+        this.uri,
+        this.rootPath,
+        this.solFileIndex
+      )
     ).accept(find, orphanNodes, this);
-    find(this.astNode.body, this.uri, this.rootPath, this.solFileIndex).accept(
-      find,
-      orphanNodes,
-      this
-    );
+    await (
+      await find(this.astNode.body, this.uri, this.rootPath, this.solFileIndex)
+    ).accept(find, orphanNodes, this);
 
     parent?.addChild(this);
 

--- a/server/src/parser/common/types/index.ts
+++ b/server/src/parser/common/types/index.ts
@@ -430,7 +430,7 @@ export type FinderType = (
   uri: string,
   rootPath: string,
   documentsAnalyzer: SolFileIndexMap
-) => Node;
+) => Promise<Node>;
 
 /**
  * documentsAnalyzer Map { [uri: string]: DocumentAnalyzer } have all documentsAnalyzer class instances used for handle imports on first project start.
@@ -538,13 +538,13 @@ export abstract class Node {
     baseASTNode: BaseASTNode | EmptyNodeType,
     uri: string,
     rootPath: string,
-    documentsAnalyzer: SolFileIndexMap,
+    solFileIndex: SolFileIndexMap,
     name: string | undefined
   ) {
     this.type = baseASTNode.type;
     this.uri = uri;
     this.rootPath = rootPath;
-    this.solFileIndex = documentsAnalyzer;
+    this.solFileIndex = solFileIndex;
     this.name = name;
   }
 
@@ -677,7 +677,7 @@ export abstract class Node {
     orphanNodes: Node[],
     parent?: Node,
     expression?: Node
-  ): Node;
+  ): Promise<Node>;
 }
 
 export class EmptyNode extends Node {
@@ -693,7 +693,7 @@ export class EmptyNode extends Node {
     this.astNode = emptyNode;
   }
 
-  public accept(
+  public async accept(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     find: FinderType,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -702,7 +702,7 @@ export class EmptyNode extends Node {
     parent?: Node,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     expression?: Node
-  ): Node {
+  ): Promise<Node> {
     return this;
   }
 }

--- a/server/src/services/completion/onCompletion.ts
+++ b/server/src/services/completion/onCompletion.ts
@@ -30,14 +30,14 @@ import { globalVariables, defaultCompletion } from "./defaultCompletion";
 import { arrayCompletions } from "./arrayCompletions";
 
 export const onCompletion = (serverState: ServerState) => {
-  return (params: CompletionParams): CompletionList | null => {
+  return async (params: CompletionParams): Promise<CompletionList | null> => {
     const { logger } = serverState;
 
     logger.trace("onCompletion");
 
-    return serverState.telemetry.trackTimingSync("onCompletion", () => {
+    return serverState.telemetry.trackTiming("onCompletion", async () => {
       const { found, errorMessage, documentAnalyzer, document } =
-        applyEditToDocumentAnalyzer(
+        await applyEditToDocumentAnalyzer(
           serverState,
           params.textDocument.uri,
           (doc) => resolveChangedDocText(params, doc)

--- a/server/src/services/documents/onDidOpen.ts
+++ b/server/src/services/documents/onDidOpen.ts
@@ -6,7 +6,7 @@ import { analyzeSolFile } from "@analyzer/analyzeSolFile";
 import { ServerState } from "../../types";
 
 export function onDidOpen(serverState: ServerState) {
-  return (change: TextDocumentChangeEvent<TextDocument>) => {
+  return async (change: TextDocumentChangeEvent<TextDocument>) => {
     if (change.document.languageId !== "solidity") {
       return;
     }
@@ -19,6 +19,6 @@ export function onDidOpen(serverState: ServerState) {
     const solFileEntry = getOrInitialiseSolFileEntry(serverState, uri);
 
     // Ensure it is analysed
-    analyzeSolFile(serverState, solFileEntry, solFileText);
+    await analyzeSolFile(serverState, solFileEntry, solFileText);
   };
 }

--- a/server/src/services/initialization/indexWorkspaceFolders.ts
+++ b/server/src/services/initialization/indexWorkspaceFolders.ts
@@ -223,7 +223,7 @@ async function analyzeSolFiles(
         );
 
         if (!solFileEntry.isAnalyzed()) {
-          analyzeSolFile({ solFileIndex }, solFileEntry);
+          await analyzeSolFile({ solFileIndex }, solFileEntry);
         }
       } catch (err) {
         logger.error(err);

--- a/server/src/services/validation/analyse.ts
+++ b/server/src/services/validation/analyse.ts
@@ -5,7 +5,7 @@ import { analyzeSolFile } from "@analyzer/analyzeSolFile";
 import { decodeUriAndRemoveFilePrefix } from "../../utils/index";
 import { ServerState } from "../../types";
 
-export function analyse(
+export async function analyse(
   serverState: ServerState,
   { document: changeDoc }: TextDocumentChangeEvent<TextDocument>
 ) {
@@ -15,7 +15,7 @@ export function analyse(
     const internalUri = decodeUriAndRemoveFilePrefix(changeDoc.uri);
     const solFileEntry = getOrInitialiseSolFileEntry(serverState, internalUri);
 
-    analyzeSolFile(serverState, solFileEntry, changeDoc.getText());
+    await analyzeSolFile(serverState, solFileEntry, changeDoc.getText());
   } catch (err) {
     serverState.logger.error(err);
   }

--- a/server/src/utils/applyEditToDocumentAnalyzer.ts
+++ b/server/src/utils/applyEditToDocumentAnalyzer.ts
@@ -5,11 +5,11 @@ import { ServerState } from "../types";
 import { LookupResult } from "./lookupEntryForUri";
 import { getUriFromDocument } from "./index";
 
-export function applyEditToDocumentAnalyzer(
+export async function applyEditToDocumentAnalyzer(
   serverState: ServerState,
   uri: string,
   edit: (document: TextDocument) => string
-): LookupResult {
+): Promise<LookupResult> {
   const document = serverState.documents.get(uri);
 
   if (!document) {
@@ -23,7 +23,7 @@ export function applyEditToDocumentAnalyzer(
   const newDocumentText = edit(document);
 
   const solFileEntry = getOrInitialiseSolFileEntry(serverState, documentURI);
-  analyzeSolFile(serverState, solFileEntry, newDocumentText);
+  await analyzeSolFile(serverState, solFileEntry, newDocumentText);
 
   if (!solFileEntry.isAnalyzed()) {
     return {

--- a/server/test/services/codeactions/asserts/assertCodeAction.ts
+++ b/server/test/services/codeactions/asserts/assertCodeAction.ts
@@ -42,7 +42,7 @@ export async function assertCodeAction(
 
   const solFileEntry = getOrInitialiseSolFileEntry(serverState, exampleUri);
 
-  analyzeSolFile(serverState, solFileEntry, docText);
+  await analyzeSolFile(serverState, solFileEntry, docText);
 
   const actions = compilerDiagnostic.resolveActions(
     serverState as ServerState,

--- a/server/test/services/documentation/documentation.ts
+++ b/server/test/services/documentation/documentation.ts
@@ -1,6 +1,7 @@
 import { assert } from "chai";
 import * as path from "path";
 import { SignatureHelp } from "vscode-languageserver/node";
+import { sleep } from "../../../src/utils/sleep";
 import { forceToUnixStyle } from "../../helpers/forceToUnixStyle";
 import {
   setupMockLanguageServer,
@@ -24,6 +25,7 @@ describe("Parser", () => {
     });
 
     it("should return signature info", async () => {
+      await sleep(500);
       const response = (await signatureHelp({
         textDocument: { uri: basicUri },
         position: { line: 21, character: 21 },

--- a/server/test/services/navigation/definition.ts
+++ b/server/test/services/navigation/definition.ts
@@ -226,7 +226,6 @@ describe("Parser", () => {
             documents: [
               { uri: parentUri, analyze: true },
               { uri: childUri, analyze: true },
-              { uri: parentUri, analyze: true },
             ],
             errors: [],
           }));

--- a/test/integration/projects/main/contracts/definition/Circular1.sol
+++ b/test/integration/projects/main/contracts/definition/Circular1.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.4;
+
+import "./Circular2.sol";
+
+contract Circular1 {
+  Circular2 c2;
+}

--- a/test/integration/projects/main/contracts/definition/Circular2.sol
+++ b/test/integration/projects/main/contracts/definition/Circular2.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.4;
+
+import "./Circular1.sol";
+
+contract Circular2 {
+  Circular1 c1;
+}

--- a/test/integration/tests/definition/definition.test.ts
+++ b/test/integration/tests/definition/definition.test.ts
@@ -16,6 +16,13 @@ suite("Single-file Navigation", function () {
     "main/contracts/definition/ImportTest.sol"
   );
 
+  const circular1Uri = getTestContractUri(
+    "main/contracts/definition/Circular1.sol"
+  );
+  const circular2Uri = getTestContractUri(
+    "main/contracts/definition/Circular2.sol"
+  );
+
   test("[Single-file] - Go to Definition", async () => {
     await openFileInEditor(testUri);
 
@@ -105,6 +112,30 @@ suite("Single-file Navigation", function () {
     assertPositionEqual(
       getCurrentEditor().selection.active,
       new vscode.Position(3, 0)
+    );
+  });
+
+  test("Circular dependencies navigation", async () => {
+    await openFileInEditor(circular1Uri);
+
+    goToPosition(new vscode.Position(6, 6));
+
+    await vscode.commands.executeCommand("editor.action.goToDeclaration");
+
+    await assertCurrentTabFile(circular2Uri.fsPath);
+    assertPositionEqual(
+      getCurrentEditor().selection.active,
+      new vscode.Position(5, 9)
+    );
+
+    goToPosition(new vscode.Position(3, 14));
+
+    await vscode.commands.executeCommand("editor.action.goToDeclaration");
+
+    await assertCurrentTabFile(circular1Uri.fsPath);
+    assertPositionEqual(
+      getCurrentEditor().selection.active,
+      new vscode.Position(1, 0)
     );
   });
 });


### PR DESCRIPTION
This changes our projects' `resolveImportPath()` , and everything related to import resolution involved in the parser, to be async. This allows us to use hardhat on import resolution. What this enables us in the short term is supporting the plugin `hardhat-foundry`, which makes use of that async import transforming task.