### PR TITLE
optimization: cache solc compiler paths

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -63,6 +63,7 @@ function setupUninitializedServerState(
     validationCount: 0,
     lastValidationId: {},
     workspaceFileRetriever,
+    cachedCompilerInfo: {},
   };
 
   return serverState;

--- a/server/src/services/validation/validate.ts
+++ b/server/src/services/validation/validate.ts
@@ -95,7 +95,10 @@ export async function validate(
 
       // Use bundled hardhat to compile
       await logger.trackTime("Compiling", async () => {
-        compilerOutput = await CompilationService.compile(compilationDetails!);
+        compilerOutput = await CompilationService.compile(
+          serverState,
+          compilationDetails!
+        );
       });
 
       validationResult = OutputConverter.getValidationResults(

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -31,6 +31,9 @@ export interface ServerState {
   validationCount: number;
   lastValidationId: { [uri: string]: number };
   workspaceFileRetriever: WorkspaceFileRetriever;
+  cachedCompilerInfo: {
+    [solcVersion: string]: { isSolcJs: boolean; compilerPath: string };
+  };
 }
 
 export interface SolcError {


### PR DESCRIPTION
This optimization was lost during the refactor so it's being brought back. It avoids checking/checksumming the compiler on each validation job.