### PR TITLE
release:2022-12-01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.6.3 - 2022-12-01
+
+### Fixed
+
+- Fixed validation with solcjs ([#294](https://github.com/NomicFoundation/hardhat-vscode/issues/294))
+- Suppress output channel warnings around worker exit codes ([#298](https://github.com/NomicFoundation/hardhat-vscode/pull/298))
+
+### Changed
+
+- cache solc compiler paths for all adapters ([#299](https://github.com/NomicFoundation/hardhat-vscode/pull/299))
+
 ## 0.6.2 - 2022-11-25
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Solidity",
   "description": "Solidity and Hardhat support by the Hardhat team",
   "license": "MIT",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "main": "./client/out/extension.js",
   "module": "./client/out/extension.js",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -63,6 +63,7 @@ function setupUninitializedServerState(
     validationCount: 0,
     lastValidationId: {},
     workspaceFileRetriever,
+    cachedCompilerInfo: {},
   };
 
   return serverState;

--- a/server/src/services/validation/CompilationService.ts
+++ b/server/src/services/validation/CompilationService.ts
@@ -16,17 +16,27 @@ export class CompilationService {
     delete (input.settings as any).outputSelection;
 
     // Find or download solc compiler
-    const { compilerPath } = await hre.run("compile:solidity:solc:get-build", {
-      solcVersion: compilationDetails.solcVersion,
-      quiet: true,
-    });
+    const { compilerPath, isSolcJs } = await hre.run(
+      "compile:solidity:solc:get-build",
+      {
+        solcVersion: compilationDetails.solcVersion,
+        quiet: true,
+      }
+    );
 
     // Compile
-    const output = await hre.run("compile:solidity:solc:run", {
-      input,
-      solcPath: compilerPath,
-    });
-
+    let output;
+    if (isSolcJs) {
+      output = await hre.run("compile:solidity:solcjs:run", {
+        input,
+        solcJsPath: compilerPath,
+      });
+    } else {
+      output = await hre.run("compile:solidity:solc:run", {
+        input,
+        solcPath: compilerPath,
+      });
+    }
     // Normalize errors' sourceLocation to use utf-8 offsets instead of byte offsets
     for (const error of output.errors || []) {
       const source = input.sources[error.sourceLocation?.file];

--- a/server/src/services/validation/validate.ts
+++ b/server/src/services/validation/validate.ts
@@ -95,7 +95,10 @@ export async function validate(
 
       // Use bundled hardhat to compile
       await logger.trackTime("Compiling", async () => {
-        compilerOutput = await CompilationService.compile(compilationDetails!);
+        compilerOutput = await CompilationService.compile(
+          serverState,
+          compilationDetails!
+        );
       });
 
       validationResult = OutputConverter.getValidationResults(

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -31,6 +31,9 @@ export interface ServerState {
   validationCount: number;
   lastValidationId: { [uri: string]: number };
   workspaceFileRetriever: WorkspaceFileRetriever;
+  cachedCompilerInfo: {
+    [solcVersion: string]: { isSolcJs: boolean; compilerPath: string };
+  };
 }
 
 export interface SolcError {

--- a/test/integration/projects/projectless/src/Bar.sol
+++ b/test/integration/projects/projectless/src/Bar.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0
 
-pragma solidity ^0.8.7;
+pragma solidity 0.8.8;
 
 import "./Baz.sol";
 
 contract Bar {
-    function magic() public pure returns (uint) {
-        return 12345;
-    }
+  function magic() public pure returns (uint) {
+    return 12345;
+  }
 }

--- a/test/integration/projects/projectless/src/Foo.sol
+++ b/test/integration/projects/projectless/src/Foo.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
-pragma solidity ^0.8.7;
+pragma solidity 0.8.8;
 
 import "./Bar.sol";
 import "./Baz.sol";

--- a/test/integration/tests/projectless/projectless.test.ts
+++ b/test/integration/tests/projectless/projectless.test.ts
@@ -10,13 +10,8 @@ import {
   assertPositionEqual,
   checkOrWaitDiagnostic,
 } from "../../helpers/assertions";
-import { sleep } from "../../helpers/sleep";
 
 suite("projectless", function () {
-  this.beforeEach(async () => {
-    await sleep(2000);
-  });
-
   test("[navigation] jump to definition", async () => {
     const importerUri = getTestContractUri("projectless/src/Foo.sol");
     const importedUri = getTestContractUri("projectless/lib/Quz.sol");


### PR DESCRIPTION
## 0.6.3 - 2022-12-01

### Fixed

- Fixed validation with solcjs ([#294](https://github.com/NomicFoundation/hardhat-vscode/issues/294))
- Suppress output channel warnings around worker exit codes ([#298](https://github.com/NomicFoundation/hardhat-vscode/pull/298))

### Changed

- cache solc compiler paths for all adapters ([#299](https://github.com/NomicFoundation/hardhat-vscode/pull/299))

