### PR TITLE
Improve analytics

### DIFF
--- a/coc/src/index.ts
+++ b/coc/src/index.ts
@@ -1,5 +1,9 @@
 import { ExtensionContext, LanguageClient, services } from "coc.nvim";
 import * as coc from "coc.nvim";
+import * as packageJson from "../package.json";
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { machineId } = require("./vendor/machineId");
 
 export async function activate(context: ExtensionContext): Promise<void> {
   await showTelemetryPrompt(context);
@@ -26,9 +30,11 @@ export async function activate(context: ExtensionContext): Promise<void> {
       },
       initializationOptions: {
         extensionName: "@ignored/coc-solidity",
+        extensionVersion: packageJson.version,
         env: "production",
         globalTelemetryEnabled: true,
         hardhatTelemetryEnabled: telemetryEnabled,
+        machineId: await machineId(),
       },
     }
   );

--- a/coc/src/vendor/machineId.ts
+++ b/coc/src/vendor/machineId.ts
@@ -1,10 +1,10 @@
+// This code was adapted from node-machine-id and is distributed under their license: https://github.com/automation-stack/node-machine-id/blob/f580f9f20668582e9087d92cea2511c972f2e6aa/LICENSE
+// For the original context see: https://github.com/automation-stack/node-machine-id/blob/f580f9f20668582e9087d92cea2511c972f2e6aa/index.js
+
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable no-useless-escape */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable no-prototype-builtins */
-
-// This code was adapted from node-machine-id and is distributed under their license: https://github.com/automation-stack/node-machine-id/blob/f580f9f20668582e9087d92cea2511c972f2e6aa/LICENSE
-// For the original context see: https://github.com/automation-stack/node-machine-id/blob/f580f9f20668582e9087d92cea2511c972f2e6aa/index.js
 
 import { exec, execSync } from "child_process";
 import { createHash } from "crypto";

--- a/coc/src/vendor/machineId.ts
+++ b/coc/src/vendor/machineId.ts
@@ -1,0 +1,95 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable no-useless-escape */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable no-prototype-builtins */
+
+// This code was adapted from node-machine-id and is distributed under their license: https://github.com/automation-stack/node-machine-id/blob/f580f9f20668582e9087d92cea2511c972f2e6aa/LICENSE
+// For the original context see: https://github.com/automation-stack/node-machine-id/blob/f580f9f20668582e9087d92cea2511c972f2e6aa/index.js
+
+import { exec, execSync } from "child_process";
+import { createHash } from "crypto";
+
+const { platform } = process;
+const win32RegBinPath: any = {
+  native: "%windir%\\System32",
+  mixed: "%windir%\\sysnative\\cmd.exe /c %windir%\\System32",
+};
+const guid: any = {
+  darwin: "ioreg -rd1 -c IOPlatformExpertDevice",
+  win32:
+    `${
+      win32RegBinPath[isWindowsProcessMixedOrNativeArchitecture()]
+    }\\REG.exe ` +
+    "QUERY HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography " +
+    "/v MachineGuid",
+  linux:
+    "( cat /var/lib/dbus/machine-id /etc/machine-id 2> /dev/null || hostname ) | head -n 1 || :",
+  freebsd: "kenv -q smbios.system.uuid || sysctl -n kern.hostuuid",
+};
+
+function isWindowsProcessMixedOrNativeArchitecture(): string {
+  // detect if the node binary is the same arch as the Windows OS.
+  // or if this is 32 bit node on 64 bit windows.
+  if (process.platform !== "win32") {
+    return "";
+  }
+  if (
+    process.arch === "ia32" &&
+    process.env.hasOwnProperty("PROCESSOR_ARCHITEW6432")
+  ) {
+    return "mixed";
+  }
+  return "native";
+}
+
+function hash(theGuid: string): string {
+  return createHash("sha256").update(theGuid).digest("hex");
+}
+
+function expose(result: string): string {
+  switch (platform) {
+    case "darwin":
+      return result
+        .split("IOPlatformUUID")[1]
+        .split("\n")[0]
+        .replace(/\=|\s+|\"/gi, "")
+        .toLowerCase();
+    case "win32":
+      return result
+        .toString()
+        .split("REG_SZ")[1]
+        .replace(/\r+|\n+|\s+/gi, "")
+        .toLowerCase();
+    case "linux":
+      return result
+        .toString()
+        .replace(/\r+|\n+|\s+/gi, "")
+        .toLowerCase();
+    case "freebsd":
+      return result
+        .toString()
+        .replace(/\r+|\n+|\s+/gi, "")
+        .toLowerCase();
+    default:
+      throw new Error(`Unsupported platform: ${process.platform}`);
+  }
+}
+
+export function machineIdSync(original: boolean): string {
+  const id: string = expose(execSync(guid[platform]).toString());
+  return original ? id : hash(id);
+}
+
+export function machineId(original: boolean): Promise<string> {
+  return new Promise((resolve, reject) => {
+    return exec(guid[platform], {}, (err: any, stdout: any, stderr: any) => {
+      if (err) {
+        return reject(
+          new Error(`Error while obtaining machine id: ${err.stack}`)
+        );
+      }
+      const id: string = expose(stdout.toString());
+      return resolve(original ? id : hash(id));
+    });
+  });
+}

--- a/coc/tsconfig.json
+++ b/coc/tsconfig.json
@@ -11,7 +11,8 @@
     "composite": true,
     "declaration": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true
   },
-  "include": ["src"]
+  "include": ["package.json", "src"]
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:coverage": "yarn --cwd ./server run test:coverage",
     "test:codecov": "yarn --cwd ./server run test:codecov",
     "lint": "yarn prettier --check && yarn eslint && yarn --cwd ./client lint && yarn --cwd ./server lint && yarn --cwd ./coc lint && yarn --cwd ./test/protocol lint",
-    "lint:fix": "yarn prettier --write && yarn eslint --fix && yarn --cwd ./client lint:fix && yarn --cwd ./server lint:fix && yarn --cws ./coc lint:fix && yarn --cwd ./test/protocol lint:fix",
+    "lint:fix": "yarn prettier --write && yarn eslint --fix && yarn --cwd ./client lint:fix && yarn --cwd ./server lint:fix && yarn --cwd ./coc lint:fix && yarn --cwd ./test/protocol lint:fix",
     "prettier": "prettier *.md *.json \"{docs,syntaxes,.github,.vscode}/**/*.{md,yml,json}\" \"test/**/*.{ts,json}\"",
     "eslint": "eslint ./test/**/*.ts",
     "clean": "rimraf ./dist ./out && yarn --cwd ./client clean && yarn --cwd ./server clean",
@@ -109,7 +109,11 @@
         "solidity.telemetry": {
           "type": "boolean",
           "markdownDescription": "Allow **Solidity** to send extension telemetry. This helps us understand how the extension is used and how it is performing. Read more in our [privacy policy](https://hardhat.org/privacy-policy.html).\n\n&nbsp;\n\n*__Note:__ **Solidity** respects the global **Telemetry Level** setting, and will only send telemetry if enabled at both global and extension level.*",
-          "default": false
+          "default": false,
+          "tags": [
+            "usesOnlineServices",
+            "telemetry"
+          ]
         },
         "solidity.formatter": {
           "type": "string",

--- a/server/src/analytics/GoogleAnalytics.ts
+++ b/server/src/analytics/GoogleAnalytics.ts
@@ -18,6 +18,7 @@ export class GoogleAnalytics implements Analytics {
   private serverState: ServerState | null;
   private machineId: string | undefined;
   private extensionVersion: string | undefined;
+  private clientName: string | undefined;
 
   constructor(googleTrackingId: string) {
     this.googleTrackingId = googleTrackingId;
@@ -30,11 +31,13 @@ export class GoogleAnalytics implements Analytics {
   public init(
     machineId: string | undefined,
     extensionVersion: string | undefined,
-    serverState: ServerState
+    serverState: ServerState,
+    clientName: string | undefined
   ): void {
     this.machineId = machineId;
     this.extensionVersion = extensionVersion;
     this.serverState = serverState;
+    this.clientName = clientName;
   }
 
   public async sendPageView(
@@ -89,6 +92,9 @@ export class GoogleAnalytics implements Analytics {
       // Custom dimension 1: extension version
       //	 Example: 'v1.0.0'.
       cd1: `v${this.extensionVersion}`,
+
+      // Data source -> vs code or coc
+      ds: this.clientName,
     };
 
     return { ...defaultAnalytics, ...(more || {}) };

--- a/server/src/analytics/types.ts
+++ b/server/src/analytics/types.ts
@@ -18,6 +18,7 @@ export interface DefaultRawAnalyticsPayload {
   t: string;
   dp: string;
   cd1: string;
+  ds?: string;
 }
 
 export interface RawAnalyticsPayload {
@@ -33,7 +34,8 @@ export interface Analytics {
   init(
     trackingId: string | undefined,
     extensionVersion: string | undefined,
-    serverState: ServerState
+    serverState: ServerState,
+    clientName: string | undefined
   ): void;
 
   sendPageView(taskName: string, more?: RawAnalyticsPayload): Promise<void>;

--- a/server/src/services/initialization/onInitialize.ts
+++ b/server/src/services/initialization/onInitialize.ts
@@ -16,8 +16,13 @@ export const onInitialize = (serverState: ServerState) => {
     logger.trace("onInitialize");
     logger.info("Language server starting");
 
-    const { machineId, extensionName, extensionVersion, workspaceFolders } =
-      getSessionInfo(params);
+    const {
+      machineId,
+      extensionName,
+      extensionVersion,
+      workspaceFolders,
+      clientName,
+    } = getSessionInfo(params);
 
     updateServerStateFromParams(serverState, params);
 
@@ -25,7 +30,8 @@ export const onInitialize = (serverState: ServerState) => {
       machineId,
       extensionName,
       extensionVersion,
-      serverState
+      serverState,
+      clientName
     );
 
     logInitializationInfo(serverState, {
@@ -104,7 +110,15 @@ function getSessionInfo(params: InitializeParams) {
 
   const workspaceFolders = params.workspaceFolders || [];
 
-  return { machineId, extensionName, extensionVersion, workspaceFolders };
+  const clientName = params.clientInfo?.name;
+
+  return {
+    machineId,
+    extensionName,
+    extensionVersion,
+    workspaceFolders,
+    clientName,
+  };
 }
 
 function updateServerStateFromParams(

--- a/server/src/telemetry/SentryServerTelemetry.ts
+++ b/server/src/telemetry/SentryServerTelemetry.ts
@@ -32,7 +32,8 @@ export class SentryServerTelemetry implements Telemetry {
     machineId: string | undefined,
     extensionName: string | undefined,
     extensionVersion: string | undefined,
-    serverState: ServerState
+    serverState: ServerState,
+    clientName: string | undefined
   ) {
     this.serverState = serverState;
 
@@ -53,12 +54,13 @@ export class SentryServerTelemetry implements Telemetry {
         user: { id: machineId },
         tags: {
           component: "lsp",
+          client: clientName,
         },
       },
       beforeSend: (event) => (isTelemetryEnabled(serverState) ? event : null),
     });
 
-    this.analytics.init(machineId, extensionVersion, serverState);
+    this.analytics.init(machineId, extensionVersion, serverState, clientName);
 
     this.enableHeartbeat();
   }

--- a/server/src/telemetry/types.ts
+++ b/server/src/telemetry/types.ts
@@ -12,7 +12,8 @@ export interface Telemetry {
     machineId: string | undefined,
     extensionName: string | undefined,
     extensionVersion: string | undefined,
-    serverState: ServerState
+    serverState: ServerState,
+    clientName: string | undefined
   ): void;
   captureException(err: unknown): void;
   trackTiming<T>(


### PR DESCRIPTION
- Send `Data Source` to google analytics, using the language client's name (`coc.nvim` vs `Visual Studio Code`)
- Send the same value to a new sentry tag `client`
- Send extension version from coc's client (reading it from package.json)
- Generate and send a machineId from coc's client

Coc extension and lsp versions have to be bumped and published.

Closes #320 