### PR TITLE
feat: function natspec completion

### DIFF
--- a/server/src/parser/common/types/index.ts
+++ b/server/src/parser/common/types/index.ts
@@ -248,8 +248,6 @@ export interface Searcher {
    * @param uri Path to the file. Uri needs to be decoded and without the "file://" prefix.
    * @param position Position in the file.
    * @param from From which Node do we start searching.
-   * @param returnDefinitionNode If it is true, we will return the definition Node of found Node,
-   * otherwise we will return found Node. Default is true.
    * @param searchInExpression If it is true, we will also look at the expressionNode for Node
    * otherwise, we won't. Default is false.
    * @returns Founded Node.

--- a/server/src/services/completion/onCompletion.ts
+++ b/server/src/services/completion/onCompletion.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {
   VSCodePosition,
   CompletionList,
@@ -15,8 +16,9 @@ import {
   TextDocument,
   MemberAccessNode,
 } from "@common/types";
+import * as parser from "@solidity-parser/parser";
+import { FunctionDefinition } from "@solidity-parser/parser/src/ast-types";
 import { getParserPositionFromVSCodePosition } from "@common/utils";
-import { Logger } from "@utils/Logger";
 import { isImportDirectiveNode } from "@analyzer/utils/typeGuards";
 import {
   CompletionContext,
@@ -67,7 +69,8 @@ export const onCompletion = (serverState: ServerState) => {
           params.position,
           params.context,
           projCtx,
-          logger
+          serverState,
+          document
         );
 
         return { status: "ok", result: completions };
@@ -107,9 +110,68 @@ export function doComplete(
   position: VSCodePosition,
   context: CompletionContext | undefined,
   projCtx: ProjectContext,
-  logger: Logger
+  { logger }: ServerState,
+  document: TextDocument
 ): CompletionList | null {
   const result: CompletionList = { isIncomplete: false, items: [] };
+
+  if (context?.triggerCharacter === "*") {
+    const searchString = "/** */";
+    const lineText = document.getText({
+      start: { line: position.line, character: 0 },
+      end: { line: position.line + 1, character: 0 },
+    });
+    const isJsDoc = lineText.includes(searchString);
+
+    if (!isJsDoc) {
+      return null;
+    }
+
+    const currentOffset = document.offsetAt(position);
+    let nextFunction: FunctionDefinition | undefined;
+
+    parser.visit(documentAnalyzer.analyzerTree.tree.astNode, {
+      FunctionDefinition(node) {
+        if (!node.range || node.range[0] < currentOffset) {
+          return;
+        }
+        if (
+          nextFunction === undefined ||
+          node.range[0] < nextFunction.range![0]
+        ) {
+          nextFunction = node;
+        }
+      },
+    });
+
+    if (nextFunction === undefined) {
+      return null;
+    }
+
+    const range = {
+      start: position,
+      end: position,
+    };
+
+    let text = `\n * @dev Function description\n`;
+
+    for (const param of nextFunction.parameters) {
+      text += ` * @param ${param.name} \n`;
+    }
+
+    for (const _param of nextFunction.returnParameters ?? []) {
+      text += ` * @return  \n`;
+    }
+
+    result.items.push({
+      label: "NatSpec documentation",
+      textEdit: {
+        range,
+        newText: text,
+      },
+    });
+    return result;
+  }
 
   let definitionNode = documentAnalyzer.searcher.findNodeByPosition(
     documentAnalyzer.uri,

--- a/server/src/services/initialization/onInitialize.ts
+++ b/server/src/services/initialization/onInitialize.ts
@@ -67,7 +67,7 @@ export const onInitialize = (serverState: ServerState) => {
         textDocumentSync: TextDocumentSyncKind.Incremental,
         // Tell the client that this server supports code completion.
         completionProvider: {
-          triggerCharacters: [".", "/", '"', "'"],
+          triggerCharacters: [".", "/", '"', "'", "*"],
         },
         signatureHelpProvider: {
           triggerCharacters: ["(", ","],

--- a/server/test/server.ts
+++ b/server/test/server.ts
@@ -42,7 +42,7 @@ describe("Solidity Language Server", () => {
       describe("completions", () => {
         it("advertises capability", () =>
           assert.deepStrictEqual(capabilities.completionProvider, {
-            triggerCharacters: [".", "/", '"', "'"],
+            triggerCharacters: [".", "/", '"', "'", "*"],
           }));
 
         it("registers onCompletion", () =>


### PR DESCRIPTION
Closes #296

When typing `/**`, which gets autocompleted to `/** */`, a Natspec completion item is shown to generate comments for the next found function declaration in the code.

![natspec-completion](https://user-images.githubusercontent.com/2818438/209675938-6dbc8e2b-3e04-45cf-836c-56294b64c43f.gif)
