### PR TITLE
chore: add framework to telemetry and improve indexing telemetry

### DIFF
--- a/server/src/services/initialization/onInitialize.ts
+++ b/server/src/services/initialization/onInitialize.ts
@@ -47,11 +47,12 @@ export const onInitialize = (serverState: ServerState) => {
     logger.info("Language server ready");
 
     // Index and analysis
-    await serverState.telemetry.trackTiming("indexing", async () => {
+    await serverState.telemetry.trackTiming("indexing", async (transaction) => {
       await indexWorkspaceFolders(
         serverState,
         serverState.workspaceFileRetriever,
-        workspaceFolders
+        workspaceFolders,
+        transaction
       );
 
       return { status: "ok", result: null };

--- a/server/src/services/validation/analyse.ts
+++ b/server/src/services/validation/analyse.ts
@@ -4,6 +4,7 @@ import { getOrInitialiseSolFileEntry } from "@utils/getOrInitialiseSolFileEntry"
 import { analyzeSolFile } from "@analyzer/analyzeSolFile";
 import { decodeUriAndRemoveFilePrefix, isTestMode } from "../../utils/index";
 import { ServerState } from "../../types";
+import { addFrameworkTag } from "../../telemetry/tags";
 
 export async function analyse(
   serverState: ServerState,
@@ -11,7 +12,7 @@ export async function analyse(
 ) {
   serverState.logger.trace("analyse");
 
-  return serverState.telemetry.trackTiming("analysis", async () => {
+  return serverState.telemetry.trackTiming("analysis", async (transaction) => {
     try {
       const internalUri = decodeUriAndRemoveFilePrefix(changeDoc.uri);
       const solFileEntry = getOrInitialiseSolFileEntry(
@@ -28,6 +29,7 @@ export async function analyse(
         });
       }
 
+      addFrameworkTag(transaction, solFileEntry.project);
       return { status: "ok", result: true };
     } catch (err) {
       serverState.logger.error(err);

--- a/server/src/telemetry/SentryServerTelemetry.ts
+++ b/server/src/telemetry/SentryServerTelemetry.ts
@@ -1,6 +1,6 @@
 /* istanbul ignore file: external system */
 import * as Sentry from "@sentry/node";
-import type { Transaction } from "@sentry/types";
+import type { Primitive, Transaction } from "@sentry/types";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import * as tracing from "@sentry/tracing";
 import { isTelemetryEnabled } from "@utils/serverStateUtils";
@@ -71,9 +71,14 @@ export class SentryServerTelemetry implements Telemetry {
 
   public async trackTiming<T>(
     taskName: string,
-    action: (transaction: Transaction) => Promise<TrackingResult<T>>
+    action: (transaction: Transaction) => Promise<TrackingResult<T>>,
+    tags?: Record<string, Primitive>
   ): Promise<T | null> {
-    const transaction = this.startTransaction({ op: "task", name: taskName });
+    const transaction = this.startTransaction({
+      op: "task",
+      name: taskName,
+      tags,
+    });
     this.actionTaken = true;
 
     try {
@@ -93,9 +98,14 @@ export class SentryServerTelemetry implements Telemetry {
 
   public trackTimingSync<T>(
     taskName: string,
-    action: (transaction: Transaction) => TrackingResult<T>
+    action: (transaction: Transaction) => TrackingResult<T>,
+    tags?: Record<string, Primitive>
   ): T | null {
-    const transaction = this.startTransaction({ op: "task", name: taskName });
+    const transaction = this.startTransaction({
+      op: "task",
+      name: taskName,
+      tags,
+    });
     this.actionTaken = true;
 
     try {
@@ -116,13 +126,16 @@ export class SentryServerTelemetry implements Telemetry {
   public startTransaction({
     op,
     name,
+    tags,
   }: {
     op: string;
     name: string;
+    tags?: Record<string, Primitive>;
   }): Transaction {
     const transaction = Sentry.startTransaction({
       op,
       name,
+      tags,
     });
 
     Sentry.getCurrentHub().configureScope((scope) =>

--- a/server/src/telemetry/tags.ts
+++ b/server/src/telemetry/tags.ts
@@ -1,0 +1,13 @@
+import { Transaction } from "@sentry/types";
+import { Project } from "../frameworks/base/Project";
+
+export function addFrameworkTag(transaction: Transaction, project: Project) {
+  transaction.tags = {
+    ...(transaction.tags ?? {}),
+    ...frameworkTag(project),
+  };
+}
+
+export function frameworkTag(project: Project) {
+  return { framework: project.frameworkName() };
+}

--- a/server/src/telemetry/types.ts
+++ b/server/src/telemetry/types.ts
@@ -1,5 +1,5 @@
 import { SpanStatusType } from "@sentry/tracing";
-import type { Transaction } from "@sentry/types";
+import type { Primitive, Transaction } from "@sentry/types";
 import { ServerState } from "../types";
 
 export interface TrackingResult<T> {
@@ -18,11 +18,13 @@ export interface Telemetry {
   captureException(err: unknown): void;
   trackTiming<T>(
     taskName: string,
-    action: (transaction: Transaction) => Promise<TrackingResult<T>>
+    action: (transaction: Transaction) => Promise<TrackingResult<T>>,
+    tags?: Record<string, Primitive>
   ): Promise<T | null>;
   trackTimingSync<T>(
     taskName: string,
-    action: (transaction: Transaction) => TrackingResult<T>
+    action: (transaction: Transaction) => TrackingResult<T>,
+    tags?: Record<string, Primitive>
   ): T | null;
   startTransaction({ op, name }: { op: string; name: string }): Transaction;
   enableHeartbeat(): void;

--- a/server/src/utils/onCommand.ts
+++ b/server/src/utils/onCommand.ts
@@ -1,5 +1,6 @@
 import { ISolFileEntry } from "@common/types";
 import { TextDocument } from "vscode-languageserver-textdocument";
+import { addFrameworkTag } from "../telemetry/tags";
 import { ServerState } from "../types";
 import { lookupEntryForUri } from "./lookupEntryForUri";
 
@@ -13,7 +14,7 @@ export function onCommand<T>(
 
   logger.trace(commandName);
 
-  return telemetry.trackTimingSync(commandName, () => {
+  return telemetry.trackTimingSync(commandName, (transaction) => {
     const { found, errorMessage, documentAnalyzer, document } =
       lookupEntryForUri(serverState, uri);
 
@@ -24,6 +25,8 @@ export function onCommand<T>(
 
       return { status: "failed_precondition", result: null };
     }
+
+    addFrameworkTag(transaction, documentAnalyzer.project);
 
     return { status: "ok", result: action(documentAnalyzer, document) };
   });


### PR DESCRIPTION
All of the places where telemetry transactions are sent (validation, analysis, language server requests) now include a `framework` tag, if it's available for the file under work. Additionally, on the indexing process, extra spans have been added to benchmark with higher granularity, and the project initialization spans have their own framework tag as well (multiple projects can be indexed on a workspace). Tag values are `Hardhat`, `Foundry` and `None`, the last one being for projectless files.

Indexing process spans + framework tag on each:
![image](https://user-images.githubusercontent.com/2818438/210398416-91c2e416-662a-4f1a-8dc9-8757694f58fa.png)

Tag on requests:
![image](https://user-images.githubusercontent.com/2818438/210404990-046452c0-e509-4cb4-a208-5afc6d4f1f12.png)

Closes #338 
