### PR TITLE
chore: bump version to v0.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.6.7 - 2023-01-05
+
+### Added
+
+- Quickfix for non checksummed addresses
+- Track timing on analysis
+- Add `encodeCall` completion to `abi`
+
+### Fixed
+
+- Status item links on windows
+- Foundry validation on windows
+
 ## 0.6.6 - 2022-12-22
 
 ### Changed

--- a/coc/package.json
+++ b/coc/package.json
@@ -2,7 +2,7 @@
   "name": "@ignored/coc-solidity",
   "description": "Solidity and Hardhat support for coc.nvim",
   "license": "MIT",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "author": "Nomic Foundation",
   "repository": {
     "type": "git",
@@ -28,7 +28,7 @@
     "clean": "rimraf out .nyc_output coverage *.tsbuildinfo *.log"
   },
   "dependencies": {
-    "@ignored/solidity-language-server": "0.6.6"
+    "@ignored/solidity-language-server": "0.6.7"
   },
   "devDependencies": {
     "@types/node": "^17.0.21",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Solidity",
   "description": "Solidity and Hardhat support by the Hardhat team",
   "license": "MIT",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "private": true,
   "main": "./client/out/extension.js",
   "module": "./client/out/extension.js",

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "name": "@ignored/solidity-language-server",
   "description": "Solidity language server by Nomic Foundation",
   "license": "MIT",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "author": "Nomic Foundation",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 0.6.7 - 2023-01-05

### Added

- Quickfix for non checksummed addresses
- Track timing on analysis
- Add `encodeCall` completion to `abi`

### Fixed

- Status item links on windows
- Foundry validation on windows