### PR TITLE
fix: check for workspace folder capability

### DIFF
--- a/server/src/services/initialization/onInitialize.ts
+++ b/server/src/services/initialization/onInitialize.ts
@@ -135,7 +135,7 @@ function updateServerStateFromParams(
 
   serverState.hasWorkspaceFolderCapability =
     params.capabilities.workspace !== undefined &&
-    params.capabilities.workspace.workspaceFolders !== undefined;
+    params.capabilities.workspace.workspaceFolders === true;
 }
 
 function logInitializationInfo(


### PR DESCRIPTION
Fix logic for checking `initializeParams.capabilities.workspace.workspaceFolders` to be `true` before requesting workspace capabilities. Noticed this when investigating #356, althought that behaviour won't change since neovim's client sends `true` anyways.