### PR TITLE
fix: remappings structure as solc input

### DIFF
--- a/server/src/frameworks/Foundry/FoundryProject.ts
+++ b/server/src/frameworks/Foundry/FoundryProject.ts
@@ -102,8 +102,12 @@ export class FoundryProject extends Project {
     // Apply remappings to importPath if it's not a relative import
     if (!importPath.startsWith(".")) {
       for (const { from, to } of this.remappings) {
+        const toAbsolutePath = path.join(this.basePath, to);
         if (importPath.startsWith(from)) {
-          transformedPath = path.join(to, importPath.slice(from.length));
+          transformedPath = path.join(
+            toAbsolutePath,
+            importPath.slice(from.length)
+          );
         }
       }
     }
@@ -183,7 +187,7 @@ export class FoundryProject extends Project {
   ): CompletionItem[] {
     return getImportCompletions(
       {
-        remappings: this.remappings,
+        project: this,
         solFileIndex: this.serverState.solFileIndex,
       },
       position,
@@ -210,7 +214,10 @@ export class FoundryProject extends Project {
         token.endsWith("/") ? token : `${token}/`
       );
 
-      remappings.push({ from, to: path.join(this.basePath, to) });
+      remappings.push({
+        from,
+        to,
+      });
     }
 
     return remappings;

--- a/server/src/frameworks/Foundry/getImportCompletions.ts
+++ b/server/src/frameworks/Foundry/getImportCompletions.ts
@@ -1,13 +1,14 @@
+import path from "path";
 import {
   CompletionItem,
   CompletionItemKind,
   Position,
 } from "vscode-languageserver-types";
 import { SolFileIndexMap } from "../../parser/common/types";
-import { Remapping } from "./Remapping";
+import { FoundryProject } from "./FoundryProject";
 
 interface ImportCompletionContext {
-  remappings: Remapping[];
+  project: FoundryProject;
   solFileIndex: SolFileIndexMap;
 }
 
@@ -26,7 +27,7 @@ export function getImportCompletions(
 function _getRemappingKeyCompletions(
   ctx: ImportCompletionContext
 ): CompletionItem[] {
-  return ctx.remappings.map((r) => {
+  return ctx.project.remappings.map((r) => {
     const strippedKey = r.from.replace(/\/$/, ""); // Remove trailing slash
     return {
       label: strippedKey,
@@ -45,11 +46,12 @@ function _getRemappedContractCompletions(
 ): CompletionItem[] {
   let currentImportRemapped = currentImport;
 
-  for (const remapping of ctx.remappings) {
+  for (const remapping of ctx.project.remappings) {
     if (currentImportRemapped.startsWith(remapping.from)) {
+      const toAbsolutePath = path.join(ctx.project.basePath, remapping.to);
       currentImportRemapped = currentImportRemapped.replace(
         remapping.from,
-        remapping.to
+        toAbsolutePath
       );
       break;
     }


### PR DESCRIPTION
We are sending the remappings object to solc with absolute paths, e.g:
```
    "remappings": [
      "ds-test/=/home/.../projects/.../lib/forge-std/lib/ds-test/src/",
      "forge-std/=/home/.../projects/.../lib/forge-std/src/",
    ]
```

After this change, the remappings object is sent in the way they are declared, without transforming relative into absolute paths, e.g:
```
    "remappings": [
      "ds-test/=lib/forge-std/lib/ds-test/src/",
      "forge-std/=lib/forge-std/src/",
    ]
```

Closes #369 