### PR TITLE
chore: reduce server dependencies

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -63,10 +63,7 @@
     "rimraf": "3.0.2",
     "sinon": "12.0.1",
     "ts-node": "10.4.0",
-    "typescript": "4.5.4"
-  },
-  "dependencies": {
-    "@nomicfoundation/solidity-analyzer": "0.1.0",
+    "typescript": "4.5.4",
     "@sentry/node": "7.32.1",
     "@sentry/tracing": "7.32.1",
     "@solidity-parser/parser": "^0.14.5",
@@ -89,5 +86,8 @@
     "vscode-languageserver-textdocument": "^1.0.1",
     "vscode-languageserver-types": "^3.16.0",
     "vscode-uri": "^3.0.6"
+  },
+  "dependencies": {
+    "@nomicfoundation/solidity-analyzer": "0.1.0"
   }
 }


### PR DESCRIPTION
This moves all dependencies (except `solidity-analyzer`) to devDependencies on the server package. This drastically reduces the installation time of the coc extension and the size from ~180mb to ~20mb.

Closes #373