### PR TITLE
optimization: only analyze local files on initialization

### DIFF
--- a/server/src/frameworks/Foundry/FoundryProject.ts
+++ b/server/src/frameworks/Foundry/FoundryProject.ts
@@ -84,15 +84,18 @@ export class FoundryProject extends Project {
   public async fileBelongs(uri: string) {
     if (this.initializeError === undefined) {
       // Project was initialized correctly, then check contract is inside source or test folders
-      return [
+      const belongs = [
         this.sourcesPath,
         this.testsPath,
         this.libPath,
         this.scriptPath,
       ].some((dir) => directoryContains(dir, uri));
+      const isLocal = directoryContains(this.sourcesPath, uri);
+
+      return { belongs, isLocal };
     } else {
       // Project could not be initialized. Claim all files under base path to avoid them being incorrectly assigned to other projects
-      return directoryContains(this.basePath, uri);
+      return { belongs: directoryContains(this.basePath, uri), isLocal: true };
     }
   }
 

--- a/server/src/frameworks/Hardhat/worker/WorkerProcess.ts
+++ b/server/src/frameworks/Hardhat/worker/WorkerProcess.ts
@@ -148,11 +148,11 @@ export class WorkerProcess {
       this.hre.config.paths.root,
       "node_modules"
     );
-    const belongs =
-      directoryContains(sourcesPath, uri) ||
-      directoryContains(nodeModulesPath, uri);
+    const isLocal = directoryContains(sourcesPath, uri);
 
-    await this.send(new FileBelongsResponse(requestId, belongs));
+    const belongs = isLocal || directoryContains(nodeModulesPath, uri);
+
+    await this.send(new FileBelongsResponse(requestId, { belongs, isLocal }));
   }
 
   private async _handleResolveImport({

--- a/server/src/frameworks/Hardhat/worker/WorkerProtocol.ts
+++ b/server/src/frameworks/Hardhat/worker/WorkerProtocol.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { OpenDocuments } from "../../../types";
 import { CompilationDetails } from "../../base/CompilationDetails";
+import { FileBelongsResult } from "../../base/Project";
 import { LogLevel } from "./WorkerLogger";
 
 export enum MessageType {
@@ -63,7 +64,7 @@ export class FileBelongsRequest extends RequestMessage {
 
 export class FileBelongsResponse extends ResponseMessage {
   public type = MessageType.FILE_BELONGS_RESPONSE;
-  constructor(requestId: number, public belongs: boolean) {
+  constructor(requestId: number, public result: FileBelongsResult) {
     super(requestId);
   }
 }

--- a/server/src/frameworks/Projectless/ProjectlessProject.ts
+++ b/server/src/frameworks/Projectless/ProjectlessProject.ts
@@ -31,7 +31,7 @@ export class ProjectlessProject extends Project {
   }
 
   public async fileBelongs(_file: string) {
-    return true;
+    return { belongs: true, isLocal: true };
   }
 
   public async resolveImportPath(file: string, importPath: string) {

--- a/server/src/frameworks/base/Project.ts
+++ b/server/src/frameworks/base/Project.ts
@@ -3,6 +3,11 @@ import { CompletionItem, Position } from "vscode-languageserver-types";
 import { OpenDocuments, ServerState } from "../../types";
 import { CompilationDetails } from "./CompilationDetails";
 
+export interface FileBelongsResult {
+  belongs: boolean;
+  isLocal: boolean;
+}
+
 export abstract class Project {
   constructor(public serverState: ServerState, public basePath: string) {}
 
@@ -15,7 +20,7 @@ export abstract class Project {
   public abstract id(): string;
 
   // Check if a solidity file belongs to this project
-  public abstract fileBelongs(file: string): Promise<boolean>;
+  public abstract fileBelongs(file: string): Promise<FileBelongsResult>;
 
   // Resolve the full path of an import statement
   public abstract resolveImportPath(

--- a/server/src/parser/analyzer/SolFileEntry.ts
+++ b/server/src/parser/analyzer/SolFileEntry.ts
@@ -19,12 +19,14 @@ export class SolFileEntry implements ISolFileEntry {
   public analyzerTree: { tree: Node };
   public searcher: ISearcher;
   public orphanNodes: Node[] = [];
+  public isLocal: boolean;
 
   private constructor(uri: string, project: Project) {
     this.uri = uri;
     this.project = project;
     this.text = "";
     this.status = SolFileState.UNLOADED;
+    this.isLocal = true;
 
     this.analyzerTree = {
       tree: new EmptyNode(

--- a/server/src/parser/analyzer/SolFileEntry.ts
+++ b/server/src/parser/analyzer/SolFileEntry.ts
@@ -47,9 +47,11 @@ export class SolFileEntry implements ISolFileEntry {
   public static createLoadedEntry(
     uri: string,
     project: Project,
-    text: string
+    text: string,
+    isLocal: boolean
   ): ISolFileEntry {
     const unloaded = new SolFileEntry(uri, project);
+    unloaded.isLocal = isLocal;
 
     return unloaded.loadText(text);
   }

--- a/server/src/parser/common/types/index.ts
+++ b/server/src/parser/common/types/index.ts
@@ -398,6 +398,11 @@ export interface ISolFileEntry {
    * Has an analysis pass succeeded, allowing a user to operate on the ast.
    */
   isAnalyzed(): boolean;
+
+  /**
+   * Local means the file is part of the project's scope, and not external, dependency or library
+   */
+  isLocal: boolean;
 }
 
 /**

--- a/server/src/utils/getOrInitialiseSolFileEntry.ts
+++ b/server/src/utils/getOrInitialiseSolFileEntry.ts
@@ -22,7 +22,12 @@ export function getOrInitialiseSolFileEntry(
 
     if (fs.existsSync(uri)) {
       const docText = fs.readFileSync(uri).toString();
-      solFileEntry = SolFileEntry.createLoadedEntry(uri, project, docText);
+      solFileEntry = SolFileEntry.createLoadedEntry(
+        uri,
+        project,
+        docText,
+        false
+      );
     } else {
       // TODO: figure out what happens if we just don't do this
       // why bother with non-existant files? Maybe untitled but unsaved

--- a/server/test/frameworks/hardhat/HardhatProject.test.ts
+++ b/server/test/frameworks/hardhat/HardhatProject.test.ts
@@ -59,14 +59,18 @@ describe("HardhatProject", function () {
       });
 
       it("claims every contract under project basePath, to avoid it being assigned other project", async () => {
-        assert.isTrue(
+        assert.deepEqual(
           await project.fileBelongs(
             `/my_hardhat_project/any_folder/contract.sol`
-          )
+          ),
+          { belongs: true, isLocal: true }
         );
 
-        assert.isFalse(
-          await project.fileBelongs("/other_project/any_folder/contract.sol")
+        assert.include(
+          await project.fileBelongs("/other_project/any_folder/contract.sol"),
+          {
+            belongs: false,
+          }
         );
       });
     });


### PR DESCRIPTION
Mark which indexed files are local (i.e. inside configured sources folder), and only analyze those during the initialization step. This avoids e.g. indexing all of OZ contracts when a small project uses few of them.

Closes #302 