### PR TITLE
chore: bump version to v0.0.10

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.6.10 - 2023-02-15
+
+### Changed
+
+- Optimize initial indexing by only analysing local files ([#302](https://github.com/NomicFoundation/hardhat-vscode/issues/302))
+- Reduced deps for coc-solidity ([#373](https://github.com/NomicFoundation/hardhat-vscode/issues/373))
+
+### Fixed
+
+- Mimic foundry solc input mapping ([#377](https://github.com/NomicFoundation/hardhat-vscode/pull/377))
+
 ## 0.6.9 - 2023-01-20
 
 ### Added

--- a/client/README.md
+++ b/client/README.md
@@ -48,13 +48,13 @@ Direct imports (those not starting with `./` or `../`) are completed based on su
 
 Relative imports pull their suggestions from the file system based on the current solidity file's location.
 
-![Import completions](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/import-completion.gif "Import completions")
+![Import completions](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/client/docs/gifs/import-completion.gif "Import completions")
 
 Natspec documentation completion is also supported
 
-![Natspec contract completions](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/natspec-contract.gif "Natspec contract completion")
+![Natspec contract completions](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/client/docs/gifs/natspec-contract.gif "Natspec contract completion")
 
-![Natspec function completions](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/natspec-function.gif "Natspec function completion")
+![Natspec function completions](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/client/docs/gifs/natspec-function.gif "Natspec function completion")
 
 ---
 
@@ -74,7 +74,7 @@ Navigates to the type of an identifier.
 
 Shows all references of the identifier under the cursor.
 
-![Navigation](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/navigation.gif "Navigation")
+![Navigation](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/client/docs/gifs/navigation.gif "Navigation")
 
 ---
 
@@ -82,7 +82,7 @@ Shows all references of the identifier under the cursor.
 
 Rename the identifier under the cursor and all of its references:
 
-![Rename](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/rename.gif "Rename")
+![Rename](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/client/docs/gifs/rename.gif "Rename")
 
 ---
 
@@ -92,7 +92,7 @@ Apply solidity formatting to the current document.
 
 The formatting configuration can be overriden through a `.prettierrc` file, see [Formatting Configuration](#formatting-configuration).
 
-![Reformat](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/format.gif "Reformat")
+![Reformat](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/client/docs/gifs/format.gif "Reformat")
 
 ---
 
@@ -100,7 +100,7 @@ The formatting configuration can be overriden through a `.prettierrc` file, see 
 
 Hovering the cursor over variables, function calls, errors and events will display a popup showing type and signature information:
 
-![Hover](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/on-hover.gif "Hover")
+![Hover](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/client/docs/gifs/on-hover.gif "Hover")
 
 ---
 
@@ -110,7 +110,7 @@ As code is edited, **Solidity by Nomic Foundation** runs the [solc](https://docs
 
 This feature is only available in solidity files that are part of a **Hardhat** project, as **Hardhat** is used for import resolution, see [Hardhat Projects](#hardhat-projects) for details.
 
-![Diagnostic](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/diagnostic.gif "Diagnostic")
+![Diagnostic](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/client/docs/gifs/diagnostic.gif "Diagnostic")
 
 ---
 
@@ -126,7 +126,7 @@ A contract that implements an interface, but is missing functions specified in t
 
 The matching code action _Add missing functions from interface_ will determine which functions need to be implemented to satisfy the interface and add them as stubs to the body of the contract.
 
-![Implement interface](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/implement-interface.gif "Implement interface")
+![Implement interface](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/client/docs/gifs/implement-interface.gif "Implement interface")
 
 #### Constrain mutability
 
@@ -134,7 +134,7 @@ A function without a mutability keyword but which does not update contract state
 
 The matching code action _Add view/pure modifier to function declaration_ resolves the warning by adding the keyword to the function signature.
 
-![Constrain Mutability](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/constrain-mutability.gif "Constrain Mutability")
+![Constrain Mutability](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/client/docs/gifs/constrain-mutability.gif "Constrain Mutability")
 
 #### Adding `virtual`/`override` on inherited function signature
 
@@ -142,7 +142,7 @@ A function in an inheriting contract, that has the same name and parameters as a
 
 The _Add virtual specifier to function definition_ and _Add override specifier to function definition_ code actions appear against functions with these errors.
 
-![Virtual and Override](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/virtual-override.gif "Virtual and Override")
+![Virtual and Override](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/client/docs/gifs/virtual-override.gif "Virtual and Override")
 
 #### Adding `public`/`private` to function signature
 
@@ -150,27 +150,27 @@ A function without an accessibility keyword will cause the `solidity(4937)` erro
 
 Two code actions will appear against a function with this error: _Add public visibility to declaration_ and _Add private visibility to declaration_.
 
-![Public Private](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/public-private.gif "Public Private")
+![Public Private](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/client/docs/gifs/public-private.gif "Public Private")
 
 #### Adding license identifier and `pragma solidity` version
 
 When no license is specified on a contract, the `solidity(1878)` warning is raised by the compiler. Similarly, when no compiler version is specified with a `pragma solidity` statement, the compiler shows the `solidity(3420)` warning. There are code actions available for quick fixes.
 
-![Add license specifier](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/add-license.gif "Add license specifier")
+![Add license specifier](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/client/docs/gifs/add-license.gif "Add license specifier")
 
-![Add pragma solidity](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/add-pragma.gif "Add pragma solidity")
+![Add pragma solidity](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/client/docs/gifs/add-pragma.gif "Add pragma solidity")
 
 #### Specifying data location for variables
 
 Some types require you to specify a data location (memory, storage, calldata), depending on where they are defined. The available code actions allow the user to add, change or remove data locations depending on the error being raised.
 
-![Data location quickfix](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/data-location.gif "Specify data location")
+![Data location quickfix](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/client/docs/gifs/data-location.gif "Specify data location")
 
 #### Fix addresses checksum
 
 The solidity compiler requires explicit addresses to be in the correct checksummed format. This quickfix transforms any address to the correct checksummed version.
 
-![Address checksum](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/checksum-address.gif "Fix address checksum")
+![Address checksum](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/client/docs/gifs/checksum-address.gif "Fix address checksum")
 
 ### Commands
 
@@ -178,19 +178,19 @@ The solidity compiler requires explicit addresses to be in the correct checksumm
 
 When working on a hardhat project, the command `Hardhat: Compile project` is available on the command palette. This will trigger a `hardhat compile` run.
 
-![Compile command](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/command-compile.gif "Compile command")
+![Compile command](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/client/docs/gifs/command-compile.gif "Compile command")
 
 #### Clean artifacts
 
 When working on a hardhat project, the command `Hardhat: Clear cache and artifacts` is present on the command palette. This will trigger a `hardhat clean` run.
 
-![Clean command](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/command-clean.gif "Clean command")
+![Clean command](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/client/docs/gifs/command-clean.gif "Clean command")
 
 #### Flatten contract
 
 When working on a solidity file inside a hardhat project, the command `Hardhat: Flatten this file and its dependencies` is present on the command palette and the context menu. This will trigger a `hardhat flatten $FILE` run, and will output the result in a new file tab.
 
-![Flatten command](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/command-flatten.gif "Flatten command")
+![Flatten command](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/client/docs/gifs/command-flatten.gif "Flatten command")
 
 ### Task provider
 
@@ -216,7 +216,7 @@ Inline validation (the display of compiler errors and warnings against the code)
 
 The **Hardhat config file** that is used when validating a Solidity file is shown in the Solidity section on the _Status Bar_:
 
-![Open Config](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/open-config.gif "Open Config")
+![Open Config](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/client/docs/gifs/open-config.gif "Open Config")
 
 ## Formatting
 
@@ -228,15 +228,15 @@ To set **Solidity by Nomic Foundation** as your default formatter for solidity f
 
 1. Within a Solidity file run the _Format Document With_ command, either through the **command palette**, or by right clicking and selecting through the context menu:
 
-![Format Document With](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/images/format_document_with.png "Format Document With")
+![Format Document With](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/client/docs/images/format_document_with.png "Format Document With")
 
 2. Select `Configure Default Formatter...`
 
-![Format Document With](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/images/configure_default_formatter.png "Configure default formatter")
+![Format Document With](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/client/docs/images/configure_default_formatter.png "Configure default formatter")
 
 3. Select `Solidity` as the default formatter for solidity files
 
-![Format Document With](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/images/select_solidity_plus_hardhat.png "Confiure default formatter")
+![Format Document With](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/client/docs/images/select_solidity_plus_hardhat.png "Confiure default formatter")
 
 ### Formatting Configuration
 

--- a/client/docs/publish-extension.md
+++ b/client/docs/publish-extension.md
@@ -9,7 +9,7 @@ To publish `hardhat-solidity` you need to do next steps:
 5. Branch into a release branch named for the current date: `git checkout -b release/yyyy-mm-dd`
 6. Update the version based on semver, ensure it is updated in:
 
-- the root `./package.json`
+- the client `./client/package.json`
 - the language server package.json `./server/package.json`
 - the coc extension package.json, both its version and its dep on the language server, at `./coc/package.json`
 

--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
   "displayName": "Solidity",
   "description": "Solidity and Hardhat support by the Hardhat team",
   "license": "MIT",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "private": true,
   "main": "./out/extension.js",
   "module": "./out/extension.js",

--- a/coc/package.json
+++ b/coc/package.json
@@ -2,7 +2,7 @@
   "name": "@ignored/coc-solidity",
   "description": "Solidity and Hardhat support for coc.nvim",
   "license": "MIT",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "author": "Nomic Foundation",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:coverage": "npm -w server run test:coverage",
     "test:codecov": "npm -w server run test:codecov",
     "lint": "npm run prettier -- --check && npm run eslint && npm -w client run lint && npm -w server run lint && npm -w coc run lint && npm -w test/protocol run lint",
-    "lint:fix": "npm run prettier -- --write && npm run eslint -- --fix && npm run -w client lint:fix && npm run -w server lint:fix && npm run -w coc lint:fix && npm -w test/protocol lint:fix",
+    "lint:fix": "npm run prettier -- --write && npm run eslint -- --fix && npm run -w client lint:fix && npm run -w server lint:fix && npm run -w coc lint:fix && npm run -w test/protocol lint:fix",
     "prettier": "prettier *.md *.json \"{docs,syntaxes,.github,.vscode}/**/*.{md,yml,json}\" \"test/**/*.{ts,json}\"",
     "eslint": "eslint ./test/**/*.ts",
     "clean": "rimraf ./dist ./out && npm -w client run clean && npm -w server run clean",

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "name": "@ignored/solidity-language-server",
   "description": "Solidity language server by Nomic Foundation",
   "license": "MIT",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "author": "Nomic Foundation",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 0.6.10 - 2023-02-15

### Changed

- Optimize initial indexing by only analysing local files ([#302](https://github.com/NomicFoundation/hardhat-vscode/issues/302))
- Reduced deps for coc-solidity ([#373](https://github.com/NomicFoundation/hardhat-vscode/issues/373))

### Fixed

- Mimic foundry solc input mapping ([#377](https://github.com/NomicFoundation/hardhat-vscode/pull/377))

