### PR TITLE
fix: correctly assign project, analyze and validate on new/renamed file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
     },
     "client": {
       "name": "hardhat-solidity",
-      "version": "0.6.11",
+      "version": "0.6.12",
       "license": "MIT",
       "dependencies": {
         "@ignored/solidity-language-server": "0.6.9",
@@ -206,10 +206,10 @@
     },
     "coc": {
       "name": "@ignored/coc-solidity",
-      "version": "0.6.11",
+      "version": "0.6.12",
       "license": "MIT",
       "dependencies": {
-        "@ignored/solidity-language-server": "0.6.11"
+        "@ignored/solidity-language-server": "0.6.12"
       },
       "devDependencies": {
         "coc.nvim": "^0.0.80",
@@ -13401,7 +13401,7 @@
     },
     "server": {
       "name": "@ignored/solidity-language-server",
-      "version": "0.6.11",
+      "version": "0.6.12",
       "license": "MIT",
       "dependencies": {
         "@nomicfoundation/solidity-analyzer": "0.1.1"

--- a/server/src/services/documents/onDidChangeWatchedFiles.ts
+++ b/server/src/services/documents/onDidChangeWatchedFiles.ts
@@ -4,7 +4,7 @@ import {
 } from "vscode-languageserver";
 import { ServerState } from "../../types";
 import { decodeUriAndRemoveFilePrefix } from "../../utils";
-import { indexSolidityFiles } from "../initialization/indexWorkspaceFolders";
+import { clearDiagnostics } from "../validation/validate";
 
 export function onDidChangeWatchedFiles(serverState: ServerState) {
   return async (params: DidChangeWatchedFilesParams) => {
@@ -20,9 +20,10 @@ export function onDidChangeWatchedFiles(serverState: ServerState) {
     for (const change of normalizedParams.changes) {
       if (
         change.uri.endsWith(".sol") &&
-        change.type === FileChangeType.Created
+        change.type === FileChangeType.Deleted
       ) {
-        await indexSolidityFiles(serverState, [change.uri]);
+        delete serverState.solFileIndex[change.uri];
+        await clearDiagnostics(serverState, change.uri);
       }
     }
 

--- a/server/src/services/initialization/indexWorkspaceFolders.ts
+++ b/server/src/services/initialization/indexWorkspaceFolders.ts
@@ -154,24 +154,36 @@ export async function indexSolidityFiles(
   fileUris: string[]
 ) {
   for (const fileUri of fileUris) {
-    if (!(await serverState.workspaceFileRetriever.isFile(fileUri))) {
-      continue;
-    }
-
-    const { project, isLocal } = await findProjectForFile(serverState, fileUri);
-
-    serverState.logger.trace(
-      `Associating ${project.id()} to ${fileUri}. Local: ${isLocal}`
-    );
-
-    const docText = await serverState.workspaceFileRetriever.readFile(fileUri);
-    serverState.solFileIndex[fileUri] = SolFileEntry.createLoadedEntry(
-      fileUri,
-      project,
-      docText,
-      isLocal
-    );
+    await indexSolidityFile(serverState, fileUri);
   }
+}
+
+export async function indexSolidityFile(
+  serverState: ServerState,
+  fileUri: string
+) {
+  if (!(await serverState.workspaceFileRetriever.isFile(fileUri))) {
+    return;
+  }
+
+  const { project, isLocal } = await findProjectForFile(serverState, fileUri);
+
+  serverState.logger.trace(
+    `Associating ${project.id()} to ${fileUri}. Local: ${isLocal}`
+  );
+
+  const docText = await serverState.workspaceFileRetriever.readFile(fileUri);
+
+  const solFileEntry = SolFileEntry.createLoadedEntry(
+    fileUri,
+    project,
+    docText,
+    isLocal
+  );
+
+  serverState.solFileIndex[fileUri] = solFileEntry;
+
+  return solFileEntry;
 }
 
 async function analyzeSolFiles(

--- a/server/src/services/initialization/onInitialized.ts
+++ b/server/src/services/initialization/onInitialized.ts
@@ -1,4 +1,5 @@
 import { WorkspaceFileRetriever } from "@utils/WorkspaceFileRetriever";
+import { Project } from "../../frameworks/base/Project";
 import { ServerState } from "../../types";
 import { indexWorkspaceFolders } from "./indexWorkspaceFolders";
 import { removeWorkspaceFolders } from "./removeWorkspaceFolders";
@@ -33,13 +34,21 @@ export const onInitialized = (
     for (const [uri, solFileEntry] of Object.entries(
       serverState.solFileIndex
     )) {
-      await serverState.connection.sendNotification("custom/file-indexed", {
-        uri,
-        project: {
-          configPath: solFileEntry.project.configPath,
-          frameworkName: solFileEntry.project.frameworkName(),
-        },
-      });
+      await notifyFileIndexed(serverState, uri, solFileEntry.project);
     }
   };
 };
+
+export async function notifyFileIndexed(
+  serverState: ServerState,
+  uri: string,
+  project: Project
+) {
+  await serverState.connection.sendNotification("custom/file-indexed", {
+    uri,
+    project: {
+      configPath: project.configPath,
+      frameworkName: project.frameworkName(),
+    },
+  });
+}

--- a/server/src/services/validation/analyse.ts
+++ b/server/src/services/validation/analyse.ts
@@ -1,10 +1,10 @@
 import { TextDocumentChangeEvent } from "vscode-languageserver";
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { getOrInitialiseSolFileEntry } from "@utils/getOrInitialiseSolFileEntry";
 import { analyzeSolFile } from "@analyzer/analyzeSolFile";
 import { decodeUriAndRemoveFilePrefix, isTestMode } from "../../utils/index";
 import { ServerState } from "../../types";
 import { addFrameworkTag } from "../../telemetry/tags";
+import { indexSolidityFile } from "../initialization/indexWorkspaceFolders";
 
 export async function analyse(
   serverState: ServerState,
@@ -15,10 +15,18 @@ export async function analyse(
   return serverState.telemetry.trackTiming("analysis", async (transaction) => {
     try {
       const internalUri = decodeUriAndRemoveFilePrefix(changeDoc.uri);
-      const solFileEntry = getOrInitialiseSolFileEntry(
-        serverState,
-        internalUri
-      );
+
+      const solFileEntry =
+        serverState.solFileIndex[internalUri] ??
+        (await indexSolidityFile(serverState, internalUri));
+
+      if (solFileEntry === undefined) {
+        serverState.logger.error(
+          new Error(`Could not analyze, uri is not indexed: ${internalUri}`)
+        );
+
+        return { status: "failed_precondition", result: false };
+      }
 
       await analyzeSolFile(serverState, solFileEntry, changeDoc.getText());
 

--- a/test/protocol/projects/hardhat/contracts/misc/FileRename.sol
+++ b/test/protocol/projects/hardhat/contracts/misc/FileRename.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.8;
+
+import '@openzeppelin/contracts/access/Ownable.sol';
+
+contract FileRename is Ownable {}

--- a/test/protocol/test/misc/fileRename.test.ts
+++ b/test/protocol/test/misc/fileRename.test.ts
@@ -1,0 +1,54 @@
+import { expect } from 'chai'
+import { renameSync } from 'fs'
+import { FileChangeType } from 'vscode-languageserver-protocol'
+import { toUri } from '../../src/helpers'
+import { TestLanguageClient } from '../../src/TestLanguageClient'
+import { getInitializedClient } from '../client'
+import { getProjectPath } from '../helpers'
+
+let client!: TestLanguageClient
+
+describe('[misc] file rename', () => {
+  const originalPath = getProjectPath('hardhat/contracts/misc/FileRename.sol')
+  const renamedPath = getProjectPath('hardhat/contracts/misc/FileRename2.sol')
+
+  beforeEach(async () => {
+    client = await getInitializedClient()
+  })
+
+  afterEach(async () => {
+    client.closeAllDocuments()
+    try {
+      renameSync(renamedPath, originalPath)
+    } catch (error) {
+      //
+    }
+  })
+
+  it('should be correctly indexed and its project assigned', async () => {
+    const originalUri = toUri(originalPath)
+    const renamedUri = toUri(renamedPath)
+
+    // Open original file
+    await client.openDocument(originalPath)
+
+    // Emulate vscode rename: first send textDocument/didChange and then workspace/didChangeWatchedFiles
+    renameSync(originalPath, renamedPath)
+    await client.openDocument(renamedPath)
+
+    client.changeWatchedFiles({
+      changes: [
+        { type: FileChangeType.Deleted, uri: originalUri },
+        { type: FileChangeType.Created, uri: renamedUri },
+      ],
+    })
+
+    // Wait for renamed file to be analyzed
+    await client.documents[renamedUri].waitAnalyzed
+
+    // Assert there are no diagnostics (no import error, means project is assigned correctly)
+    const document = client.documents[renamedUri]
+
+    expect(document.diagnostics.length).to.eq(0)
+  })
+})


### PR DESCRIPTION
I noticed the `didChange` event is fired before the `didWatchedFilesChange`, so files were being analysed/validated without their project being correctly assigned. I moved this assigning to the validate/analysis actions inline, so they are always up to date. Works with new files and renames.

Also included the "clear diagnostics on file delete" task.

Closes #417 
Closes #416 
Closes #387
Closes #310 