### PR TITLE
feat: auto-import console.sol

### DIFF
--- a/server/src/frameworks/Hardhat/HardhatProject.ts
+++ b/server/src/frameworks/Hardhat/HardhatProject.ts
@@ -5,10 +5,13 @@ import { ChildProcess, fork } from "child_process";
 import _ from "lodash";
 import path from "path";
 import {
+  CodeAction,
   CompletionItem,
+  Diagnostic,
   DidChangeWatchedFilesParams,
   Position,
 } from "vscode-languageserver-protocol";
+import { TextDocument } from "vscode-languageserver-textdocument";
 import { OpenDocuments, ServerState } from "../../types";
 import { directoryContains } from "../../utils/directoryContains";
 import { Logger } from "../../utils/Logger";
@@ -16,6 +19,7 @@ import { CompilationDetails } from "../base/CompilationDetails";
 import { InitializationFailedError } from "../base/Errors";
 import { FileBelongsResult, Project } from "../base/Project";
 import { getImportCompletions } from "./getImportCompletions";
+import { resolveActionsFor } from "./resolveActionsFor";
 import { LogLevel } from "./worker/WorkerLogger";
 import {
   BuildCompilationRequest,
@@ -239,6 +243,14 @@ export class HardhatProject extends Project {
       position,
       currentImport
     );
+  }
+
+  public resolveActionsFor(
+    diagnostic: Diagnostic,
+    document: TextDocument,
+    uri: string
+  ): CodeAction[] {
+    return resolveActionsFor(this.serverState, diagnostic, document, uri);
   }
 
   private _requestTimeout(label: string) {

--- a/server/src/frameworks/Hardhat/resolveActionsFor.ts
+++ b/server/src/frameworks/Hardhat/resolveActionsFor.ts
@@ -1,0 +1,70 @@
+import { visit } from "@solidity-parser/parser";
+import {
+  ASTNode,
+  ContractDefinition,
+} from "@solidity-parser/parser/dist/src/ast-types";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import {
+  CodeAction,
+  Diagnostic,
+  Position,
+  TextEdit,
+} from "vscode-languageserver-types";
+import { normalizeParserPosition } from "../../parser/utils";
+import { ServerState } from "../../types";
+import { decodeUriAndRemoveFilePrefix } from "../../utils";
+
+export function resolveActionsFor(
+  serverState: ServerState,
+  diagnostic: Diagnostic,
+  document: TextDocument,
+  uri: string
+): CodeAction[] {
+  const codeActions: CodeAction[] = [];
+  const errorText = document.getText(diagnostic.range);
+
+  if (diagnostic.code === "7576" && errorText === "console") {
+    const filePath = decodeUriAndRemoveFilePrefix(uri);
+    const solFileEntry = serverState.solFileIndex[filePath];
+    const ast = solFileEntry?.ast;
+
+    if (ast !== undefined) {
+      const insertPosition = getImportInsertPosition(ast);
+      codeActions.push({
+        title: "Add import from 'hardhat'",
+        kind: "quickfix",
+        isPreferred: true,
+        edit: {
+          changes: {
+            [uri]: [
+              TextEdit.insert(
+                insertPosition,
+                'import "hardhat/console.sol";\n\n'
+              ),
+            ],
+          },
+        },
+      });
+    }
+  }
+
+  return codeActions;
+}
+
+function getImportInsertPosition(ast: ASTNode): Position {
+  let firstContractDefinition!: ContractDefinition;
+
+  visit(ast, {
+    ContractDefinition: (node) => {
+      firstContractDefinition = firstContractDefinition ?? node;
+    },
+  });
+
+  const loc = firstContractDefinition?.loc;
+
+  if (loc !== undefined) {
+    return normalizeParserPosition(loc.start);
+  } else {
+    return { character: 0, line: 0 };
+  }
+}

--- a/server/src/frameworks/base/Project.ts
+++ b/server/src/frameworks/base/Project.ts
@@ -1,5 +1,11 @@
 import { DidChangeWatchedFilesParams } from "vscode-languageserver-protocol";
-import { CompletionItem, Position } from "vscode-languageserver-types";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import {
+  CodeAction,
+  CompletionItem,
+  Diagnostic,
+  Position,
+} from "vscode-languageserver-types";
 import { OpenDocuments, ServerState } from "../../types";
 import { CompilationDetails } from "./CompilationDetails";
 
@@ -52,6 +58,14 @@ export abstract class Project {
     _position: Position,
     _currentImport: string
   ): CompletionItem[] {
+    return [];
+  }
+
+  public resolveActionsFor(
+    _diagnostic: Diagnostic,
+    _document: TextDocument,
+    _uri: string
+  ): CodeAction[] {
     return [];
   }
 }

--- a/server/src/parser/utils.ts
+++ b/server/src/parser/utils.ts
@@ -1,0 +1,11 @@
+import { Position } from "vscode-languageserver-types";
+
+export function normalizeParserPosition(position: {
+  line: number;
+  column: number;
+}): Position {
+  return {
+    character: position.column,
+    line: position.line - 1,
+  };
+}

--- a/test/protocol/projects/hardhat/contracts/codeAction/ImportConsole.sol
+++ b/test/protocol/projects/hardhat/contracts/codeAction/ImportConsole.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.8;
+
+contract ImportConsole {
+  constructor() {
+    console.log(123);
+  }
+}

--- a/test/protocol/test/textDocument/codeAction/hardhat/codeAction.test.ts
+++ b/test/protocol/test/textDocument/codeAction/hardhat/codeAction.test.ts
@@ -1028,4 +1028,46 @@ describe('[hardhat][codeAction]', () => {
 
     expect(codeActions).to.have.deep.members(expected)
   })
+
+  test('auto import console.sol', async () => {
+    const documentPath = getProjectPath('hardhat/contracts/codeAction/ImportConsole.sol')
+    const documentUri = toUri(documentPath)
+
+    await client.openDocument(documentPath)
+
+    const diagnostic = await client.getDiagnostic(documentPath, {
+      range: makeRange(5, 4, 5, 11),
+    })
+
+    const codeActions = await client.getCodeActions(documentUri, diagnostic)
+
+    const expected = [
+      {
+        title: "Add import from 'hardhat'",
+        kind: 'quickfix',
+        isPreferred: true,
+        edit: {
+          changes: {
+            [toUri(documentPath)]: [
+              {
+                range: {
+                  start: {
+                    character: 0,
+                    line: 3,
+                  },
+                  end: {
+                    character: 0,
+                    line: 3,
+                  },
+                },
+                newText: 'import "hardhat/console.sol";\n\n',
+              },
+            ],
+          },
+        },
+      },
+    ]
+
+    expect(codeActions).to.have.deep.members(expected)
+  })
 })


### PR DESCRIPTION
Besides the specific console.sol implementation, a small abstraction was put in place to allow framework adapters to provide quick fixes. Existing quickfixes remain with their current design

Closes #244 