### PR TITLE
fix: use IPC as transport for coc client-server

### DIFF
--- a/coc/src/index.ts
+++ b/coc/src/index.ts
@@ -16,6 +16,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     "Solidity Language Server",
     {
       module: require.resolve("@ignored/solidity-language-server"),
+      transport: coc.TransportKind.ipc,
     },
     {
       documentSelector: ["solidity"],


### PR DESCRIPTION
Prevents client crashes caused by potential `console.log` calls floating to the client and making it out of sync when using the default `stdio` transport.

Using `ipc` allows for stdout to float and even show on the server's output log

Closes #407 