### PR TITLE
chore: bump version to v0.6.14

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.6.14 - 2023-03-20
+
+### Fixed
+
+- `Missing content-length header` error on vim-coc extension.
+
 ## 0.6.13 - 2023-03-16
 
 ### Added

--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
   "displayName": "Solidity",
   "description": "Solidity and Hardhat support by the Hardhat team",
   "license": "MIT",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "private": true,
   "main": "./out/extension.js",
   "module": "./out/extension.js",
@@ -61,7 +61,7 @@
     "rimraf": "3.0.2"
   },
   "dependencies": {
-    "@ignored/solidity-language-server": "0.6.13",
+    "@ignored/solidity-language-server": "0.6.14",
     "@sentry/node": "6.19.1",
     "prettier": "2.5.1",
     "prettier-plugin-solidity": "1.1.2",

--- a/coc/package.json
+++ b/coc/package.json
@@ -2,7 +2,7 @@
   "name": "@ignored/coc-solidity",
   "description": "Solidity and Hardhat support for coc.nvim",
   "license": "MIT",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "author": "Nomic Foundation",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     "clean": "rimraf out .nyc_output coverage *.tsbuildinfo *.log"
   },
   "dependencies": {
-    "@ignored/solidity-language-server": "0.6.13"
+    "@ignored/solidity-language-server": "0.6.14"
   },
   "devDependencies": {
     "coc.nvim": "^0.0.80",

--- a/coc/src/index.ts
+++ b/coc/src/index.ts
@@ -16,6 +16,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     "Solidity Language Server",
     {
       module: require.resolve("@ignored/solidity-language-server"),
+      transport: coc.TransportKind.ipc,
     },
     {
       documentSelector: ["solidity"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,10 +39,10 @@
     },
     "client": {
       "name": "hardhat-solidity",
-      "version": "0.6.12",
+      "version": "0.6.13",
       "license": "MIT",
       "dependencies": {
-        "@ignored/solidity-language-server": "0.6.9",
+        "@ignored/solidity-language-server": "0.6.13",
         "@sentry/node": "6.19.1",
         "prettier": "2.5.1",
         "prettier-plugin-solidity": "1.1.2",
@@ -58,81 +58,6 @@
       "engines": {
         "vscode": "^1.70.2"
       }
-    },
-    "client/node_modules/@ignored/solidity-language-server": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/@ignored/solidity-language-server/-/solidity-language-server-0.6.9.tgz",
-      "integrity": "sha512-5x7pRJXCk2sfuMOU6CBjIXMzX0Bo5LzygxSRdmdZs/RHgt77kkpUDrZYsYxNNDjlejGpoifsEg7YTI4Z+ncsIg==",
-      "dependencies": {
-        "@nomicfoundation/solidity-analyzer": "0.1.0",
-        "@sentry/node": "6.19.1",
-        "@sentry/tracing": "6.19.1",
-        "@solidity-parser/parser": "^0.14.5",
-        "c3-linearization": "0.3.0",
-        "fast-glob": "3.2.11",
-        "fs-extra": "^10.0.0",
-        "got": "^11.8.2",
-        "hardhat": "^2.12.4",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "module-alias": "^2.2.2",
-        "prettier": "2.5.1",
-        "prettier-plugin-solidity": "1.0.0",
-        "qs": "^6.10.1",
-        "semver": "^7.3.7",
-        "serialize-error": "8.1.0",
-        "uuid": "^8.3.2",
-        "vscode-languageserver": "^7.0.0",
-        "vscode-languageserver-protocol": "3.16.0",
-        "vscode-languageserver-textdocument": "^1.0.1",
-        "vscode-languageserver-types": "^3.16.0",
-        "vscode-uri": "^3.0.6"
-      },
-      "bin": {
-        "nomicfoundation-solidity-language-server": "out/index.js"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "client/node_modules/@ignored/solidity-language-server/node_modules/prettier-plugin-solidity": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0.tgz",
-      "integrity": "sha512-gRJCeZ7imbWtNYN2SudjJoPmka5r6jcd2cSTV6FC3pVCtY6LFZbeQQjpKufUEp88hXBAAnkOTOh7TA5xwj9M3A==",
-      "dependencies": {
-        "@solidity-parser/parser": "^0.14.5",
-        "emoji-regex": "^10.2.1",
-        "escape-string-regexp": "^4.0.0",
-        "semver": "^7.3.8",
-        "solidity-comments-extractor": "^0.0.7",
-        "string-width": "^4.2.3"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "prettier": "^2.3.0"
-      }
-    },
-    "client/node_modules/@sentry/tracing": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.19.1.tgz",
-      "integrity": "sha512-o34+h0j70dszcIwpCIbmO4UauPurpqLvcPO3JsFhRdxQhwQaQgMwhFklbAt7al9oEDYkjlS0gzhhlOCz4IS9kA==",
-      "dependencies": {
-        "@sentry/hub": "6.19.1",
-        "@sentry/minimal": "6.19.1",
-        "@sentry/types": "6.19.1",
-        "@sentry/utils": "6.19.1",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "client/node_modules/emoji-regex": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.2.1.tgz",
-      "integrity": "sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA=="
     },
     "client/node_modules/eslint": {
       "version": "7.32.0",
@@ -206,10 +131,10 @@
     },
     "coc": {
       "name": "@ignored/coc-solidity",
-      "version": "0.6.12",
+      "version": "0.6.13",
       "license": "MIT",
       "dependencies": {
-        "@ignored/solidity-language-server": "0.6.12"
+        "@ignored/solidity-language-server": "0.6.13"
       },
       "devDependencies": {
         "coc.nvim": "^0.0.80",
@@ -3612,14 +3537,6 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
-    },
-    "node_modules/@solidity-parser/parser": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.5.tgz",
-      "integrity": "sha512-6dKnHZn7fg/iQATVEzqyUOyEidbn05q7YA2mQ9hC0MMXhhV3/JrsxmFSYZAcr7j1yUP700LLhTruvJ3MiQmjJg==",
-      "dependencies": {
-        "antlr4ts": "^0.5.0-alpha.4"
-      }
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -12790,17 +12707,6 @@
         "vscode": "^1.52.0"
       }
     },
-    "node_modules/vscode-languageserver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
-      "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
-      "dependencies": {
-        "vscode-languageserver-protocol": "3.16.0"
-      },
-      "bin": {
-        "installServerIntoExtension": "bin/installServerIntoExtension"
-      }
-    },
     "node_modules/vscode-languageserver-protocol": {
       "version": "3.16.0",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
@@ -13401,7 +13307,7 @@
     },
     "server": {
       "name": "@ignored/solidity-language-server",
-      "version": "0.6.12",
+      "version": "0.6.13",
       "license": "MIT",
       "dependencies": {
         "@nomicfoundation/solidity-analyzer": "0.1.1"

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "name": "@ignored/solidity-language-server",
   "description": "Solidity language server by Nomic Foundation",
   "license": "MIT",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "author": "Nomic Foundation",
   "repository": {
     "type": "git",

--- a/server/scripts/bundle.js
+++ b/server/scripts/bundle.js
@@ -5,7 +5,8 @@ const fs = require("fs");
 const path = require("path");
 const esbuild = require("esbuild");
 
-const ANTLR_MODULE_PATH = "../node_modules/@solidity-parser/parser/dist/antlr";
+const ANTLR_MODULE_PATH =
+  "../server/node_modules/@solidity-parser/parser/dist/antlr";
 
 const SOLIDITY_TOKENS = "Solidity.tokens";
 const SOLIDITY_LEXER_TOKENS = "SolidityLexer.tokens";


### PR DESCRIPTION
## 0.6.14 - 2023-03-20

### Fixed

- `Missing content-length header` error on vim-coc extension.