### PR TITLE
chore: array syntax highlighting

### DIFF
--- a/client/syntaxes/solidity.json
+++ b/client/syntaxes/solidity.json
@@ -30,6 +30,9 @@
       "include": "#type-primitive"
     },
     {
+      "include": "#type-user"
+    },
+    {
       "include": "#type-modifier-extended-scope"
     },
     {
@@ -446,6 +449,37 @@
         }
       ]
     },
+    "type-user": {
+      "patterns": [
+        {
+          "begin": "\\b([A-Z]\\w*)\\b(?:\\[\\])(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.type"
+            }
+          },
+          "end": "(\\))",
+          "patterns": [
+            {
+              "include": "#primitive"
+            },
+            {
+              "include": "#punctuation"
+            },
+            {
+              "include": "#global"
+            },
+            {
+              "include": "#variable"
+            }
+          ]
+        },
+        {
+          "match": "\\b([A-Z]\\w*)\\b",
+          "name": "entity.name.type"
+        }
+      ]
+    },
     "global": {
       "patterns": [
         {
@@ -611,6 +645,9 @@
         },
         {
           "include": "#type-primitive"
+        },
+        {
+          "include": "#type-user"
         },
         {
           "include": "#type-modifier-access"
@@ -786,6 +823,9 @@
               "include": "#type-primitive"
             },
             {
+              "include": "#type-user"
+            },
+            {
               "include": "#variable"
             },
             {
@@ -814,6 +854,9 @@
           "patterns": [
             {
               "include": "#type-primitive"
+            },
+            {
+              "include": "#type-user"
             },
             {
               "match": "\\b(?:(indexed)\\s)?(\\w+)(?:,\\s*|)",
@@ -933,6 +976,9 @@
       "patterns": [
         {
           "include": "#type-primitive"
+        },
+        {
+          "include": "#type-user"
         },
         {
           "include": "#type-modifier-extended-scope"
@@ -1096,6 +1142,9 @@
             },
             {
               "include": "#type-primitive"
+            },
+            {
+              "include": "#type-user"
             },
             {
               "include": "#punctuation"


### PR DESCRIPTION
User type names like structs and contracts were not highlighted at all (not only on arrays). With this change, they are highlighted properly in both cases:

![image](https://user-images.githubusercontent.com/2818438/228585734-baa8d475-c7e3-470c-af12-fde37a96ee40.png)


Closes #385 