### PR TITLE
fix: suppress access errors while fast-globbing

### DIFF
--- a/server/src/utils/WorkspaceFileRetriever.ts
+++ b/server/src/utils/WorkspaceFileRetriever.ts
@@ -13,6 +13,7 @@ export class WorkspaceFileRetriever {
       cwd: baseUri,
       ignore,
       followSymbolicLinks: false,
+      suppressErrors: true,
     });
 
     return relativePaths.map((rp) =>


### PR DESCRIPTION
The error happened when there was a file or folder without access permissions while globbing for e.g. config files. It prevented any projects from being indexed at all.

Closes #448 