### PR TITLE
chore: fix  failing tests on mac CI build

### DIFF
--- a/test/protocol/src/helpers.ts
+++ b/test/protocol/src/helpers.ts
@@ -1,4 +1,6 @@
+import { existsSync } from 'fs'
 import { URI } from 'vscode-uri'
+import os from 'os'
 
 export function toUri(path: string) {
   return URI.file(path).toString()
@@ -10,4 +12,18 @@ export function timeoutPromise(timeout: number, reason: string) {
       reject(`Timeout: ${reason}`)
     }, timeout)
   })
+}
+
+let forgeInstalled: boolean | undefined
+
+export function isForgeInstalled() {
+  if (forgeInstalled === undefined) {
+    forgeInstalled = existsSync(`${process.env.HOME}/.foundry/bin/forge`)
+  }
+
+  return forgeInstalled
+}
+
+export function shouldSkipFoundryTests() {
+  return os.platform() !== 'linux' && !isForgeInstalled()
 }

--- a/test/protocol/test/helpers.ts
+++ b/test/protocol/test/helpers.ts
@@ -1,6 +1,5 @@
 import path from 'path'
 import { Position, Range } from 'vscode-languageserver-protocol'
-import os from 'os'
 
 export function getProjectPath(partialPath: string) {
   return path.join(__dirname, '..', 'projects', partialPath)
@@ -28,8 +27,4 @@ export function makeRange(startLine: number, startChar: number, endLine: number,
 
 export async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
-}
-
-export function runningOnWindows() {
-  return os.platform() === 'win32'
 }

--- a/test/protocol/test/misc/formatting.test.ts
+++ b/test/protocol/test/misc/formatting.test.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai'
-import { toUri } from '../../src/helpers'
+import { shouldSkipFoundryTests, toUri } from '../../src/helpers'
 import { TestLanguageClient } from '../../src/TestLanguageClient'
 import { getInitializedClient } from '../client'
-import { getProjectPath, runningOnWindows } from '../helpers'
+import { getProjectPath } from '../helpers'
 
 let client!: TestLanguageClient
 
@@ -32,7 +32,7 @@ describe('[misc] server document formatting', () => {
   })
 
   it('can use forge as formatter', async () => {
-    if (runningOnWindows()) {
+    if (shouldSkipFoundryTests()) {
       return
     }
 

--- a/test/protocol/test/textDocument/codeAction/foundry/codeAction.test.ts
+++ b/test/protocol/test/textDocument/codeAction/foundry/codeAction.test.ts
@@ -2,14 +2,14 @@ import { test } from 'mocha'
 import { expect } from 'chai'
 import { TestLanguageClient } from '../../../../src/TestLanguageClient'
 import { getInitializedClient } from '../../../client'
-import { getProjectPath, runningOnWindows } from '../../../helpers'
-import { toUri } from '../../../../src/helpers'
+import { getProjectPath } from '../../../helpers'
+import { shouldSkipFoundryTests, toUri } from '../../../../src/helpers'
 
 let client!: TestLanguageClient
 
 describe('[foundry][codeAction]', () => {
-  if (runningOnWindows()) {
-    return // skip foundry on windows
+  if (shouldSkipFoundryTests()) {
+    return
   }
   beforeEach(async () => {
     client = await getInitializedClient()

--- a/test/protocol/test/textDocument/completion/foundry/completion.test.ts
+++ b/test/protocol/test/textDocument/completion/foundry/completion.test.ts
@@ -1,15 +1,15 @@
 import { expect } from 'chai'
 import { test } from 'mocha'
-import { toUri } from '../../../../src/helpers'
+import { shouldSkipFoundryTests, toUri } from '../../../../src/helpers'
 import { TestLanguageClient } from '../../../../src/TestLanguageClient'
 import { getInitializedClient } from '../../../client'
-import { getProjectPath, runningOnWindows } from '../../../helpers'
+import { getProjectPath } from '../../../helpers'
 
 let client!: TestLanguageClient
 
 describe('[foundry][completion]', () => {
-  if (runningOnWindows()) {
-    return // skip foundry on windows
+  if (shouldSkipFoundryTests()) {
+    return
   }
 
   beforeEach(async () => {
@@ -54,8 +54,8 @@ describe('[foundry][completion]', () => {
     })
 
     test('lib contract import through remappings on partial specification', async () => {
-      if (runningOnWindows()) {
-        return // skip foundry on windows
+      if (shouldSkipFoundryTests()) {
+        return
       }
 
       const documentPath = getProjectPath('foundry/src/completion/Imports.sol')

--- a/test/protocol/test/textDocument/definition/foundry/definition.test.ts
+++ b/test/protocol/test/textDocument/definition/foundry/definition.test.ts
@@ -1,15 +1,15 @@
 import { expect } from 'chai'
 import { test } from 'mocha'
-import { toUri } from '../../../../src/helpers'
+import { shouldSkipFoundryTests, toUri } from '../../../../src/helpers'
 import { TestLanguageClient } from '../../../../src/TestLanguageClient'
 import { getInitializedClient } from '../../../client'
-import { getProjectPath, makePosition, makeRange, runningOnWindows } from '../../../helpers'
+import { getProjectPath, makePosition, makeRange } from '../../../helpers'
 
 let client!: TestLanguageClient
 
 describe('[foundry] definition', () => {
-  if (runningOnWindows()) {
-    return // skip foundry on windows
+  if (shouldSkipFoundryTests()) {
+    return
   }
 
   let testPath: string

--- a/test/protocol/test/textDocument/implementation/foundry/implementation.test.ts
+++ b/test/protocol/test/textDocument/implementation/foundry/implementation.test.ts
@@ -1,14 +1,14 @@
 import { expect } from 'chai'
-import { toUri } from '../../../../src/helpers'
+import { shouldSkipFoundryTests, toUri } from '../../../../src/helpers'
 import { TestLanguageClient } from '../../../../src/TestLanguageClient'
 import { getInitializedClient } from '../../../client'
-import { getProjectPath, makePosition, makeRange, runningOnWindows } from '../../../helpers'
+import { getProjectPath, makePosition, makeRange } from '../../../helpers'
 
 let client!: TestLanguageClient
 
 describe('[foundry] implementation', () => {
-  if (runningOnWindows()) {
-    return // skip foundry on windows
+  if (shouldSkipFoundryTests()) {
+    return
   }
 
   beforeEach(async () => {

--- a/test/protocol/test/textDocument/publishDiagnostics/foundry/publishDiagnostics.test.ts
+++ b/test/protocol/test/textDocument/publishDiagnostics/foundry/publishDiagnostics.test.ts
@@ -1,13 +1,14 @@
 import { DiagnosticSeverity } from 'vscode-languageserver-protocol'
 import { TestLanguageClient } from '../../../../src/TestLanguageClient'
 import { getInitializedClient } from '../../../client'
-import { getProjectPath, runningOnWindows } from '../../../helpers'
+import { getProjectPath } from '../../../helpers'
+import { shouldSkipFoundryTests } from '../../../../src/helpers'
 
 let client!: TestLanguageClient
 
 describe('[foundry] publishDiagnostics', () => {
-  if (runningOnWindows()) {
-    return // skip foundry on windows
+  if (shouldSkipFoundryTests()) {
+    return
   }
 
   beforeEach(async () => {

--- a/test/protocol/test/textDocument/references/foundry/references.test.ts
+++ b/test/protocol/test/textDocument/references/foundry/references.test.ts
@@ -1,14 +1,14 @@
 import { expect } from 'chai'
-import { toUri } from '../../../../src/helpers'
+import { shouldSkipFoundryTests, toUri } from '../../../../src/helpers'
 import { TestLanguageClient } from '../../../../src/TestLanguageClient'
 import { getInitializedClient } from '../../../client'
-import { getProjectPath, makePosition, makeRange, runningOnWindows } from '../../../helpers'
+import { getProjectPath, makePosition, makeRange } from '../../../helpers'
 
 let client!: TestLanguageClient
 
 describe('[foundry] references', () => {
-  if (runningOnWindows()) {
-    return // skip foundry on windows
+  if (shouldSkipFoundryTests()) {
+    return
   }
 
   beforeEach(async () => {

--- a/test/protocol/test/textDocument/rename/foundry/rename.test.ts
+++ b/test/protocol/test/textDocument/rename/foundry/rename.test.ts
@@ -1,14 +1,14 @@
 import { expect } from 'chai'
-import { toUri } from '../../../../src/helpers'
+import { shouldSkipFoundryTests, toUri } from '../../../../src/helpers'
 import { TestLanguageClient } from '../../../../src/TestLanguageClient'
 import { getInitializedClient } from '../../../client'
-import { getProjectPath, makePosition, makeRange, runningOnWindows } from '../../../helpers'
+import { getProjectPath, makePosition, makeRange } from '../../../helpers'
 
 let client!: TestLanguageClient
 
 describe('[foundry] rename', () => {
-  if (runningOnWindows()) {
-    return // skip foundry on windows
+  if (shouldSkipFoundryTests()) {
+    return
   }
 
   beforeEach(async () => {

--- a/test/protocol/test/textDocument/typeDefinition/foundry/typeDefinition.test.ts
+++ b/test/protocol/test/textDocument/typeDefinition/foundry/typeDefinition.test.ts
@@ -1,14 +1,14 @@
 import { expect } from 'chai'
-import { toUri } from '../../../../src/helpers'
+import { shouldSkipFoundryTests, toUri } from '../../../../src/helpers'
 import { TestLanguageClient } from '../../../../src/TestLanguageClient'
 import { getInitializedClient } from '../../../client'
-import { getProjectPath, makePosition, makeRange, runningOnWindows } from '../../../helpers'
+import { getProjectPath, makePosition, makeRange } from '../../../helpers'
 
 let client!: TestLanguageClient
 
 describe('[foundry] type definition', () => {
-  if (runningOnWindows()) {
-    return // skip foundry on windows
+  if (shouldSkipFoundryTests()) {
+    return
   }
 
   beforeEach(async () => {

--- a/test/protocol/test/window/showMessage/foundry/testInitializeError.test.ts
+++ b/test/protocol/test/window/showMessage/foundry/testInitializeError.test.ts
@@ -3,13 +3,14 @@ import { test } from 'mocha'
 import { MessageType } from 'vscode-languageserver-protocol'
 import { TestLanguageClient } from '../../../../src/TestLanguageClient'
 import { getInitializedClient } from '../../../client'
-import { getProjectPath, runningOnWindows } from '../../../helpers'
+import { getProjectPath } from '../../../helpers'
+import { shouldSkipFoundryTests } from '../../../../src/helpers'
 
 let client!: TestLanguageClient
 
 describe('[foundry] show notification', () => {
-  if (runningOnWindows()) {
-    return // skip foundry on windows
+  if (shouldSkipFoundryTests()) {
+    return
   }
 
   beforeEach(async () => {


### PR DESCRIPTION
This change involves checking whether foundry is installed when attempting to run protocol tests that involve forge. On mac and windows, if forge is not available, tests will be skipped. On linux they will always be run.

Closes #459 