### PR TITLE
chore: add tracing to document formatting

### DIFF
--- a/server/src/services/formatting/forgeFormat.ts
+++ b/server/src/services/formatting/forgeFormat.ts
@@ -4,13 +4,21 @@ import { TextDocument } from "vscode-languageserver-textdocument";
 import { TextEdit } from "vscode-languageserver-types";
 import { URI } from "vscode-uri";
 import { resolveForgeCommand } from "../../frameworks/Foundry/resolveForgeCommand";
+import { Logger } from "../../utils/Logger";
 
-export async function forgeFormat(text: string, document: TextDocument) {
+export async function forgeFormat(
+  text: string,
+  document: TextDocument,
+  logger: Logger
+) {
   const forgeCommand = await resolveForgeCommand();
 
   const documentPath = URI.parse(document.uri).fsPath;
 
   const cwd = path.dirname(documentPath);
+
+  logger.trace(`Forge command: ${forgeCommand}`);
+  logger.trace(`CWD: ${cwd}`);
 
   const formattedText = cp
     .execSync(`${forgeCommand} fmt --raw -`, {

--- a/server/src/services/formatting/onDocumentFormatting.ts
+++ b/server/src/services/formatting/onDocumentFormatting.ts
@@ -36,7 +36,7 @@ export function onDocumentFormatting(serverState: ServerState) {
           return null;
       }
     } catch (error) {
-      logger.error(`Error formatting document ${uri} with ${formatter}`);
+      logger.info(`Error formatting document ${uri} with ${formatter}`);
       return null;
     }
   };

--- a/server/src/services/formatting/onDocumentFormatting.ts
+++ b/server/src/services/formatting/onDocumentFormatting.ts
@@ -8,22 +8,26 @@ export function onDocumentFormatting(serverState: ServerState) {
   return async (
     params: DocumentFormattingParams
   ): Promise<TextEdit[] | null> => {
+    const { logger } = serverState;
+
     const formatter = serverState.extensionConfig.formatter ?? "prettier";
     const uri = params.textDocument.uri;
     const document = serverState.documents.get(uri);
 
     if (document === undefined) {
-      serverState.logger.error(`Failed to format, uri ${uri} not indexed`);
+      logger.error(`Failed to format, uri ${uri} not indexed`);
 
       return null;
     }
+
+    logger.trace(`Formatter: ${formatter}`);
 
     const text = document.getText();
 
     try {
       switch (formatter) {
         case "forge":
-          return await forgeFormat(text, document);
+          return await forgeFormat(text, document, logger);
 
         case "prettier":
           return prettierFormat(text, document);
@@ -32,9 +36,7 @@ export function onDocumentFormatting(serverState: ServerState) {
           return null;
       }
     } catch (error) {
-      serverState.logger.error(
-        `Error formatting document ${uri} with ${formatter}`
-      );
+      logger.error(`Error formatting document ${uri} with ${formatter}`);
       return null;
     }
   };


### PR DESCRIPTION
This will help us troubleshoot issues with formatting. Setting the log level to 'verbose' right now gives us some information like the formatting input and the output, but we can't tell which formatter was invoked.

This change adds tracing to show what formatter is used, what binary in the case of forge, and in which directory it's invoked.

References #456 