### PR TITLE
docs: add Project sections to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Join our [Hardhat Support Discord server](https://hardhat.org/discord) to stay u
 
 Please refer to one of these packages to find detailed documentation relevant to your use case:
 
+- [Solidity language server](./server/README.md)
 - [VSCode extension](./client/README.md)
 - [coc.nvim extension](./coc/README.md)
-- [Solidity language server](./server/README.md)
 
 ## Contributing
 

--- a/client/README.md
+++ b/client/README.md
@@ -1,6 +1,6 @@
 # Solidity by Nomic Foundation
 
-This extension adds language support for [Solidity](https://soliditylang.org/) to Visual Studio Code, and provides editor integration for [Hardhat projects](https://hardhat.org/). Integrations for other tools are coming in the near future. It supports:
+This extension adds language support for [Solidity](https://soliditylang.org/) to Visual Studio Code, and provides editor integration for [Hardhat](https://hardhat.org/) projects, and experimental support for [Foundry](https://getfoundry.sh/), [Truffle](https://trufflesuite.com/) and [Ape](https://www.apeworx.io/) projects. It supports:
 
 - [Code completion](#code-completions)
 - [Go to definition, type definition and references](#navigation)
@@ -23,9 +23,12 @@ Built by the [Nomic Foundation](https://nomic.foundation/). [We’re hiring](htt
 
 - [Installation](#installation)
 - [Features](#features)
-- [Setup](#setup)
-- [Hardhat Projects](#hardhat-projects)
-  - [Monorepo Support](#monorepo-support)
+- [Project support](#project-support)
+  - [Hardhat](#hardhat)
+  - [Foundry](#foundry-experimental)
+  - [Truffle](#truffle-experimental)
+  - [Ape](#ape-experimental)
+- [Monorepo Support](#monorepo-support)
 - [Formatting](#formatting)
   - [Formatting Configuration](#formatting-configuration)
 - [Feedback, help and news](#feedback-help-and-news)
@@ -37,10 +40,6 @@ Built by the [Nomic Foundation](https://nomic.foundation/). [We’re hiring](htt
 **Solidity by Nomic Foundation** can be installed by [using the Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=NomicFoundation.hardhat-solidity).
 
 Some features (e.g. inline validation, quick fixes) are still experimental and are only enabled within a [Hardhat](https://hardhat.org/) project, this is a limitation that will be lifted with future releases.
-
-## Setup
-
-This extension should work without any configuration. If formatting functionality isn't working, or you have previously configured another **Solidity** formatter, please see the [formatting section](#formatting).
 
 ## Features
 
@@ -92,9 +91,7 @@ Rename the identifier under the cursor and all of its references:
 
 ### Format document
 
-Apply solidity formatting to the current document.
-
-The formatting configuration can be overridden through a `.prettierrc` file, see [Formatting Configuration](#formatting-configuration).
+Apply Solidity formatting to the current document, for all the configuration options see [Formatting Configuration](#formatting-configuration).
 
 ![Reformat](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/format.gif "Reformat")
 
@@ -110,9 +107,7 @@ Hovering the cursor over variables, function calls, errors and events will displ
 
 ### Inline code validation (Diagnostics)
 
-As code is edited, **Solidity by Nomic Foundation** runs the [solc](https://docs.soliditylang.org/en/latest/using-the-compiler.html) compiler over the changes and displays any warnings or errors it finds.
-
-This feature is only available in solidity files that are part of a **Hardhat** project, as **Hardhat** is used for import resolution, see [Hardhat Projects](#hardhat-projects) for details.
+As code is edited, the [solc](https://docs.soliditylang.org/en/latest/using-the-compiler.html) compiler is run over the changes and any warnings or errors are displayed.
 
 ![Diagnostic](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/diagnostic.gif "Diagnostic")
 
@@ -184,19 +179,47 @@ Hardhat's `console.sol` can be imported with this quickfix. Please note that thi
 
 ---
 
-## Hardhat Projects
+## Project support
 
-**Solidity by Nomic Foundation** provides enhanced functionality for Solidity files within a **Hardhat** project, including inline validation and quick fixes.
+Some features are only fully enabled, if the Solidity file being worked on is part of a supported project (e.g. [inline code validation](#inline-code-validation-diagnostics)).
 
-To take advantage of these features, use the `File` menu to `Open Folder`, and select the folder containing the `hardhat.config.{js,ts}` file.
+We provide support for [Hardhat](https://hardhat.org/) projects and experimental support for [Foundry](https://getfoundry.sh/), [Truffle](https://trufflesuite.com/) and [Ape](https://www.apeworx.io/) projects.
+
+Project support is needed as Solidity delegates to the project framework to determine _Solidity import resolution_. The current project and its configuration needs to be understood to replicate this logic and provide language features based upon it.
+
+If the Solidity file is not part of a project or the project cannot be determined, a best effort is made to resolve imports based only on [relative imports](https://docs.soliditylang.org/en/v0.8.19/path-resolution.html#relative-imports).
+
+### Hardhat
+
+Hardhat projects are detected by looking for a `hardhat.config.{js,ts}` file.
 
 Inline validation (the display of compiler errors and warnings against the code) is based on your Hardhat configuration file. The version of the `solc` solidity compiler used for validation is set within this file, see the [Hardhat documentation](https://hardhat.org/config/#solidity-configuration) for more details.
 
-### Monorepo Support
+### Foundry (experimental)
 
-**Solidity by Nomic Foundation** will detect Hardhat projects (folders containing a `hardhat.config.{js,ts}` file) within a monorepo, when the root of the monorepo is opened as a workspace folder.
+[Foundry](https://getfoundry.sh/) projects are detected by looking for a `foundry.toml` file.
 
-The **Hardhat config file** that is used when validating a Solidity file is shown in the Solidity section on the _Status Bar_:
+The version of the `solc` solidity compiler used for validation is set within the `foundry.toml`, see the [Foundry documentation](https://book.getfoundry.sh/reference/config/solidity-compiler) for more details.
+
+Remappings are supported either from a `remappings.txt` file or as part of the `foundry.toml`.
+
+### Truffle (experimental)
+
+[Truffle](https://trufflesuite.com/) projects are detected by the presence of a `truffle.js` or `truffle-config.js` file.
+
+Solidity import resolution for Truffle supports relative paths, direct imports from the `node_modules` folder and Truffle direct imports (e.g. `truffle/Assert.sol`).
+
+### Ape (experimental)
+
+[Ape](https://www.apeworx.io/) projects are detected by the presence of an `ape-config.yaml` file.
+
+Remappings are supported when set within the `ape-config.yaml` file.
+
+## Monorepo Support
+
+Monorepos are supported and can be opened as workspace folders. On opening a monorepo, it will be scanned to find all supported projects (i.e. Hardhat, Foundry, Truffle and Ape).
+
+The _project type_ and _project config file_ that are being used when validating a Solidity file are shown in the Solidity section of the _Status Bar_:
 
 ![Open Config](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/open-config.gif "Open Config")
 
@@ -205,7 +228,7 @@ The **Hardhat config file** that is used when validating a Solidity file is show
 
 #### Compile project
 
-When working on a hardhat project, the command `Hardhat: Compile project` is available on the command palette. This will trigger a `hardhat compile` run.
+When working on a Hardhat project, the command `Hardhat: Compile project` is available on the command palette. This will trigger a `hardhat compile` run.
 
 ![Compile command](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/command-compile.gif "Compile command")
 
@@ -223,7 +246,7 @@ When working on a solidity file inside a hardhat project, the command `Hardhat: 
 
 ### Task provider
 
-The extension is registered as a task provider for hardhat projects, in which the `build` task is provided, running `hardhat compile`, and the `test` task, which runs `hardhat test`.
+The extension is registered as a task provider for Hardhat projects, in which the `build` task is provided, running `hardhat compile`, and the `test` task, which runs `hardhat test`.
 
 ## Formatting
 
@@ -246,6 +269,10 @@ To set **Solidity by Nomic Foundation** as your default formatter for solidity f
 ![Format Document With](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/images/select_solidity_plus_hardhat.png "Confiure default formatter")
 
 ### Formatting Configuration
+
+Formatting can be configured to be provided by either `prettier` (the default) or `forge`.
+
+#### Prettier
 
 The default formatting rules that will be applied are taken from [prettier-plugin-solidity](https://github.com/prettier-solidity/prettier-plugin-solidity#configuration-file), with the exception that `explicitTypes` are preserved (rather than forced).
 
@@ -270,9 +297,15 @@ To override the settings, add a `prettierrc` configuration file at the root of y
 }
 ```
 
+#### Forge
+
+If `forge` is selected as the formatter under the configuration, then the `forge fmt` command is run on the open editor file to provide formatting. The `forge fmt` command determines the configuration based on the project's `foundry.toml` file.
+
+The configuration options for `forge fmt` are [available here](https://book.getfoundry.sh/reference/config/formatter).
+
 ## Alternative editors
 
-We currently distribute a [vim.coc](https://www.npmjs.com/package/@nomicfoundation/coc-solidity) extension and a [standalone language server](https://www.npmjs.com/package/@nomicfoundation/solidity-language-server) that you can integrate with your editor of choice to have full solidity language support.
+We currently distribute a [vim.coc](https://www.npmjs.com/package/@nomicfoundation/coc-solidity) extension and a [standalone language server](https://www.npmjs.com/package/@nomicfoundation/solidity-language-server) that you can integrate with your editor of choice to have full Solidity language support.
 
 ## Feedback, help and news
 

--- a/client/README.template.md
+++ b/client/README.template.md
@@ -1,6 +1,6 @@
 # Solidity by Nomic Foundation
 
-This extension adds language support for [Solidity](https://soliditylang.org/) to Visual Studio Code, and provides editor integration for [Hardhat projects](https://hardhat.org/). Integrations for other tools are coming in the near future. It supports:
+This extension adds language support for [Solidity](https://soliditylang.org/) to Visual Studio Code, and provides editor integration for [Hardhat](https://hardhat.org/) projects, and experimental support for [Foundry](https://getfoundry.sh/), [Truffle](https://trufflesuite.com/) and [Ape](https://www.apeworx.io/) projects. It supports:
 
 - [Code completion](#code-completions)
 - [Go to definition, type definition and references](#navigation)
@@ -23,9 +23,12 @@ Built by the [Nomic Foundation](https://nomic.foundation/). [We’re hiring](htt
 
 - [Installation](#installation)
 - [Features](#features)
-- [Setup](#setup)
-- [Hardhat Projects](#hardhat-projects)
-  - [Monorepo Support](#monorepo-support)
+- [Project support](#project-support)
+  - [Hardhat](#hardhat)
+  - [Foundry](#foundry-experimental)
+  - [Truffle](#truffle-experimental)
+  - [Ape](#ape-experimental)
+- [Monorepo Support](#monorepo-support)
 - [Formatting](#formatting)
   - [Formatting Configuration](#formatting-configuration)
 - [Feedback, help and news](#feedback-help-and-news)
@@ -38,17 +41,13 @@ Built by the [Nomic Foundation](https://nomic.foundation/). [We’re hiring](htt
 
 Some features (e.g. inline validation, quick fixes) are still experimental and are only enabled within a [Hardhat](https://hardhat.org/) project, this is a limitation that will be lifted with future releases.
 
-## Setup
-
-This extension should work without any configuration. If formatting functionality isn't working, or you have previously configured another **Solidity** formatter, please see the [formatting section](#formatting).
-
 [include '../docs/features.md']
 
 ### Commands
 
 #### Compile project
 
-When working on a hardhat project, the command `Hardhat: Compile project` is available on the command palette. This will trigger a `hardhat compile` run.
+When working on a Hardhat project, the command `Hardhat: Compile project` is available on the command palette. This will trigger a `hardhat compile` run.
 
 ![Compile command](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/command-compile.gif "Compile command")
 
@@ -66,7 +65,7 @@ When working on a solidity file inside a hardhat project, the command `Hardhat: 
 
 ### Task provider
 
-The extension is registered as a task provider for hardhat projects, in which the `build` task is provided, running `hardhat compile`, and the `test` task, which runs `hardhat test`.
+The extension is registered as a task provider for Hardhat projects, in which the `build` task is provided, running `hardhat compile`, and the `test` task, which runs `hardhat test`.
 
 ## Formatting
 
@@ -89,6 +88,10 @@ To set **Solidity by Nomic Foundation** as your default formatter for solidity f
 ![Format Document With](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/images/select_solidity_plus_hardhat.png "Confiure default formatter")
 
 ### Formatting Configuration
+
+Formatting can be configured to be provided by either `prettier` (the default) or `forge`.
+
+#### Prettier
 
 The default formatting rules that will be applied are taken from [prettier-plugin-solidity](https://github.com/prettier-solidity/prettier-plugin-solidity#configuration-file), with the exception that `explicitTypes` are preserved (rather than forced).
 
@@ -113,9 +116,15 @@ To override the settings, add a `prettierrc` configuration file at the root of y
 }
 ```
 
+#### Forge
+
+If `forge` is selected as the formatter under the configuration, then the `forge fmt` command is run on the open editor file to provide formatting. The `forge fmt` command determines the configuration based on the project's `foundry.toml` file.
+
+The configuration options for `forge fmt` are [available here](https://book.getfoundry.sh/reference/config/formatter).
+
 ## Alternative editors
 
-We currently distribute a [vim.coc](https://www.npmjs.com/package/@nomicfoundation/coc-solidity) extension and a [standalone language server](https://www.npmjs.com/package/@nomicfoundation/solidity-language-server) that you can integrate with your editor of choice to have full solidity language support.
+We currently distribute a [vim.coc](https://www.npmjs.com/package/@nomicfoundation/coc-solidity) extension and a [standalone language server](https://www.npmjs.com/package/@nomicfoundation/solidity-language-server) that you can integrate with your editor of choice to have full Solidity language support.
 
 ## Feedback, help and news
 

--- a/coc/README.md
+++ b/coc/README.md
@@ -71,9 +71,7 @@ Rename the identifier under the cursor and all of its references:
 
 ### Format document
 
-Apply solidity formatting to the current document.
-
-The formatting configuration can be overridden through a `.prettierrc` file, see [Formatting Configuration](#formatting-configuration).
+Apply Solidity formatting to the current document, for all the configuration options see [Formatting Configuration](#formatting-configuration).
 
 ![Reformat](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/format.gif "Reformat")
 
@@ -89,9 +87,7 @@ Hovering the cursor over variables, function calls, errors and events will displ
 
 ### Inline code validation (Diagnostics)
 
-As code is edited, **Solidity by Nomic Foundation** runs the [solc](https://docs.soliditylang.org/en/latest/using-the-compiler.html) compiler over the changes and displays any warnings or errors it finds.
-
-This feature is only available in solidity files that are part of a **Hardhat** project, as **Hardhat** is used for import resolution, see [Hardhat Projects](#hardhat-projects) for details.
+As code is edited, the [solc](https://docs.soliditylang.org/en/latest/using-the-compiler.html) compiler is run over the changes and any warnings or errors are displayed.
 
 ![Diagnostic](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/diagnostic.gif "Diagnostic")
 
@@ -163,19 +159,47 @@ Hardhat's `console.sol` can be imported with this quickfix. Please note that thi
 
 ---
 
-## Hardhat Projects
+## Project support
 
-**Solidity by Nomic Foundation** provides enhanced functionality for Solidity files within a **Hardhat** project, including inline validation and quick fixes.
+Some features are only fully enabled, if the Solidity file being worked on is part of a supported project (e.g. [inline code validation](#inline-code-validation-diagnostics)).
 
-To take advantage of these features, use the `File` menu to `Open Folder`, and select the folder containing the `hardhat.config.{js,ts}` file.
+We provide support for [Hardhat](https://hardhat.org/) projects and experimental support for [Foundry](https://getfoundry.sh/), [Truffle](https://trufflesuite.com/) and [Ape](https://www.apeworx.io/) projects.
+
+Project support is needed as Solidity delegates to the project framework to determine _Solidity import resolution_. The current project and its configuration needs to be understood to replicate this logic and provide language features based upon it.
+
+If the Solidity file is not part of a project or the project cannot be determined, a best effort is made to resolve imports based only on [relative imports](https://docs.soliditylang.org/en/v0.8.19/path-resolution.html#relative-imports).
+
+### Hardhat
+
+Hardhat projects are detected by looking for a `hardhat.config.{js,ts}` file.
 
 Inline validation (the display of compiler errors and warnings against the code) is based on your Hardhat configuration file. The version of the `solc` solidity compiler used for validation is set within this file, see the [Hardhat documentation](https://hardhat.org/config/#solidity-configuration) for more details.
 
-### Monorepo Support
+### Foundry (experimental)
 
-**Solidity by Nomic Foundation** will detect Hardhat projects (folders containing a `hardhat.config.{js,ts}` file) within a monorepo, when the root of the monorepo is opened as a workspace folder.
+[Foundry](https://getfoundry.sh/) projects are detected by looking for a `foundry.toml` file.
 
-The **Hardhat config file** that is used when validating a Solidity file is shown in the Solidity section on the _Status Bar_:
+The version of the `solc` solidity compiler used for validation is set within the `foundry.toml`, see the [Foundry documentation](https://book.getfoundry.sh/reference/config/solidity-compiler) for more details.
+
+Remappings are supported either from a `remappings.txt` file or as part of the `foundry.toml`.
+
+### Truffle (experimental)
+
+[Truffle](https://trufflesuite.com/) projects are detected by the presence of a `truffle.js` or `truffle-config.js` file.
+
+Solidity import resolution for Truffle supports relative paths, direct imports from the `node_modules` folder and Truffle direct imports (e.g. `truffle/Assert.sol`).
+
+### Ape (experimental)
+
+[Ape](https://www.apeworx.io/) projects are detected by the presence of an `ape-config.yaml` file.
+
+Remappings are supported when set within the `ape-config.yaml` file.
+
+## Monorepo Support
+
+Monorepos are supported and can be opened as workspace folders. On opening a monorepo, it will be scanned to find all supported projects (i.e. Hardhat, Foundry, Truffle and Ape).
+
+The _project type_ and _project config file_ that are being used when validating a Solidity file are shown in the Solidity section of the _Status Bar_:
 
 ![Open Config](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/open-config.gif "Open Config")
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -48,9 +48,7 @@ Rename the identifier under the cursor and all of its references:
 
 ### Format document
 
-Apply solidity formatting to the current document.
-
-The formatting configuration can be overridden through a `.prettierrc` file, see [Formatting Configuration](#formatting-configuration).
+Apply Solidity formatting to the current document, for all the configuration options see [Formatting Configuration](#formatting-configuration).
 
 ![Reformat](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/format.gif "Reformat")
 
@@ -66,9 +64,7 @@ Hovering the cursor over variables, function calls, errors and events will displ
 
 ### Inline code validation (Diagnostics)
 
-As code is edited, **Solidity by Nomic Foundation** runs the [solc](https://docs.soliditylang.org/en/latest/using-the-compiler.html) compiler over the changes and displays any warnings or errors it finds.
-
-This feature is only available in solidity files that are part of a **Hardhat** project, as **Hardhat** is used for import resolution, see [Hardhat Projects](#hardhat-projects) for details.
+As code is edited, the [solc](https://docs.soliditylang.org/en/latest/using-the-compiler.html) compiler is run over the changes and any warnings or errors are displayed.
 
 ![Diagnostic](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/diagnostic.gif "Diagnostic")
 
@@ -140,18 +136,46 @@ Hardhat's `console.sol` can be imported with this quickfix. Please note that thi
 
 ---
 
-## Hardhat Projects
+## Project support
 
-**Solidity by Nomic Foundation** provides enhanced functionality for Solidity files within a **Hardhat** project, including inline validation and quick fixes.
+Some features are only fully enabled, if the Solidity file being worked on is part of a supported project (e.g. [inline code validation](#inline-code-validation-diagnostics)).
 
-To take advantage of these features, use the `File` menu to `Open Folder`, and select the folder containing the `hardhat.config.{js,ts}` file.
+We provide support for [Hardhat](https://hardhat.org/) projects and experimental support for [Foundry](https://getfoundry.sh/), [Truffle](https://trufflesuite.com/) and [Ape](https://www.apeworx.io/) projects.
+
+Project support is needed as Solidity delegates to the project framework to determine _Solidity import resolution_. The current project and its configuration needs to be understood to replicate this logic and provide language features based upon it.
+
+If the Solidity file is not part of a project or the project cannot be determined, a best effort is made to resolve imports based only on [relative imports](https://docs.soliditylang.org/en/v0.8.19/path-resolution.html#relative-imports).
+
+### Hardhat
+
+Hardhat projects are detected by looking for a `hardhat.config.{js,ts}` file.
 
 Inline validation (the display of compiler errors and warnings against the code) is based on your Hardhat configuration file. The version of the `solc` solidity compiler used for validation is set within this file, see the [Hardhat documentation](https://hardhat.org/config/#solidity-configuration) for more details.
 
-### Monorepo Support
+### Foundry (experimental)
 
-**Solidity by Nomic Foundation** will detect Hardhat projects (folders containing a `hardhat.config.{js,ts}` file) within a monorepo, when the root of the monorepo is opened as a workspace folder.
+[Foundry](https://getfoundry.sh/) projects are detected by looking for a `foundry.toml` file.
 
-The **Hardhat config file** that is used when validating a Solidity file is shown in the Solidity section on the _Status Bar_:
+The version of the `solc` solidity compiler used for validation is set within the `foundry.toml`, see the [Foundry documentation](https://book.getfoundry.sh/reference/config/solidity-compiler) for more details.
+
+Remappings are supported either from a `remappings.txt` file or as part of the `foundry.toml`.
+
+### Truffle (experimental)
+
+[Truffle](https://trufflesuite.com/) projects are detected by the presence of a `truffle.js` or `truffle-config.js` file.
+
+Solidity import resolution for Truffle supports relative paths, direct imports from the `node_modules` folder and Truffle direct imports (e.g. `truffle/Assert.sol`).
+
+### Ape (experimental)
+
+[Ape](https://www.apeworx.io/) projects are detected by the presence of an `ape-config.yaml` file.
+
+Remappings are supported when set within the `ape-config.yaml` file.
+
+## Monorepo Support
+
+Monorepos are supported and can be opened as workspace folders. On opening a monorepo, it will be scanned to find all supported projects (i.e. Hardhat, Foundry, Truffle and Ape).
+
+The _project type_ and _project config file_ that are being used when validating a Solidity file are shown in the Solidity section of the _Status Bar_:
 
 ![Open Config](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/open-config.gif "Open Config")

--- a/server/README.md
+++ b/server/README.md
@@ -99,9 +99,7 @@ Rename the identifier under the cursor and all of its references:
 
 ### Format document
 
-Apply solidity formatting to the current document.
-
-The formatting configuration can be overridden through a `.prettierrc` file, see [Formatting Configuration](#formatting-configuration).
+Apply Solidity formatting to the current document, for all the configuration options see [Formatting Configuration](#formatting-configuration).
 
 ![Reformat](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/format.gif "Reformat")
 
@@ -117,9 +115,7 @@ Hovering the cursor over variables, function calls, errors and events will displ
 
 ### Inline code validation (Diagnostics)
 
-As code is edited, **Solidity by Nomic Foundation** runs the [solc](https://docs.soliditylang.org/en/latest/using-the-compiler.html) compiler over the changes and displays any warnings or errors it finds.
-
-This feature is only available in solidity files that are part of a **Hardhat** project, as **Hardhat** is used for import resolution, see [Hardhat Projects](#hardhat-projects) for details.
+As code is edited, the [solc](https://docs.soliditylang.org/en/latest/using-the-compiler.html) compiler is run over the changes and any warnings or errors are displayed.
 
 ![Diagnostic](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/diagnostic.gif "Diagnostic")
 
@@ -191,19 +187,47 @@ Hardhat's `console.sol` can be imported with this quickfix. Please note that thi
 
 ---
 
-## Hardhat Projects
+## Project support
 
-**Solidity by Nomic Foundation** provides enhanced functionality for Solidity files within a **Hardhat** project, including inline validation and quick fixes.
+Some features are only fully enabled, if the Solidity file being worked on is part of a supported project (e.g. [inline code validation](#inline-code-validation-diagnostics)).
 
-To take advantage of these features, use the `File` menu to `Open Folder`, and select the folder containing the `hardhat.config.{js,ts}` file.
+We provide support for [Hardhat](https://hardhat.org/) projects and experimental support for [Foundry](https://getfoundry.sh/), [Truffle](https://trufflesuite.com/) and [Ape](https://www.apeworx.io/) projects.
+
+Project support is needed as Solidity delegates to the project framework to determine _Solidity import resolution_. The current project and its configuration needs to be understood to replicate this logic and provide language features based upon it.
+
+If the Solidity file is not part of a project or the project cannot be determined, a best effort is made to resolve imports based only on [relative imports](https://docs.soliditylang.org/en/v0.8.19/path-resolution.html#relative-imports).
+
+### Hardhat
+
+Hardhat projects are detected by looking for a `hardhat.config.{js,ts}` file.
 
 Inline validation (the display of compiler errors and warnings against the code) is based on your Hardhat configuration file. The version of the `solc` solidity compiler used for validation is set within this file, see the [Hardhat documentation](https://hardhat.org/config/#solidity-configuration) for more details.
 
-### Monorepo Support
+### Foundry (experimental)
 
-**Solidity by Nomic Foundation** will detect Hardhat projects (folders containing a `hardhat.config.{js,ts}` file) within a monorepo, when the root of the monorepo is opened as a workspace folder.
+[Foundry](https://getfoundry.sh/) projects are detected by looking for a `foundry.toml` file.
 
-The **Hardhat config file** that is used when validating a Solidity file is shown in the Solidity section on the _Status Bar_:
+The version of the `solc` solidity compiler used for validation is set within the `foundry.toml`, see the [Foundry documentation](https://book.getfoundry.sh/reference/config/solidity-compiler) for more details.
+
+Remappings are supported either from a `remappings.txt` file or as part of the `foundry.toml`.
+
+### Truffle (experimental)
+
+[Truffle](https://trufflesuite.com/) projects are detected by the presence of a `truffle.js` or `truffle-config.js` file.
+
+Solidity import resolution for Truffle supports relative paths, direct imports from the `node_modules` folder and Truffle direct imports (e.g. `truffle/Assert.sol`).
+
+### Ape (experimental)
+
+[Ape](https://www.apeworx.io/) projects are detected by the presence of an `ape-config.yaml` file.
+
+Remappings are supported when set within the `ape-config.yaml` file.
+
+## Monorepo Support
+
+Monorepos are supported and can be opened as workspace folders. On opening a monorepo, it will be scanned to find all supported projects (i.e. Hardhat, Foundry, Truffle and Ape).
+
+The _project type_ and _project config file_ that are being used when validating a Solidity file are shown in the Solidity section of the _Status Bar_:
 
 ![Open Config](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/gifs/open-config.gif "Open Config")
 


### PR DESCRIPTION
Document the support experimental projects: Foundry, Truffle and Ape.

Update our formatting section to include `forge fmt`.
