### PR TITLE
chore: support node 14

### DIFF
--- a/server/scripts/bundle.js
+++ b/server/scripts/bundle.js
@@ -89,6 +89,7 @@ async function main() {
     platform: "node",
     outdir: ".",
     logLevel: "info",
+    target: "node14",
     define: definedConstants,
   });
 


### PR DESCRIPTION
Changed the target on esbuild to node14. By default it is `esnext`.

Manually ran protocol tests on node 14 and they are passing