### PR TITLE
fix: make forge fmt call async and set a timeout

### DIFF
--- a/server/src/services/formatting/forgeFormat.ts
+++ b/server/src/services/formatting/forgeFormat.ts
@@ -30,12 +30,14 @@ export async function forgeFormat(
   child.stdin?.end();
 
   // Set a time limit
-  setTimeout(() => {
+  const timeout = setTimeout(() => {
     child.kill("SIGKILL");
   }, 2000);
 
   // Wait for the formatted output
   const formattedText = (await execPromise).stdout;
+
+  clearTimeout(timeout);
 
   // Build and return a text edit with the entire file content
   const textEdit: TextEdit = {

--- a/server/src/services/formatting/onDocumentFormatting.ts
+++ b/server/src/services/formatting/onDocumentFormatting.ts
@@ -36,7 +36,10 @@ export function onDocumentFormatting(serverState: ServerState) {
           return null;
       }
     } catch (error) {
-      logger.info(`Error formatting document ${uri} with ${formatter}`);
+      serverState.logger.info(
+        `Error formatting document ${uri} with ${formatter}: ${error}`
+      );
+
       return null;
     }
   };


### PR DESCRIPTION
This changes how `forge fmt` is invoked from the server on a document formatting request. I replace the use of `execSync` with `exec`, so the server can continue handling other requests while forge is running, and I also added a 2 seconds timeout for the process. If it times out, an error will be logged on the output channel.

References #462 