### PR TITLE
chore: stop capturing initialize errors

### DIFF
--- a/server/src/frameworks/Ape/ApeProject.ts
+++ b/server/src/frameworks/Ape/ApeProject.ts
@@ -82,7 +82,7 @@ export class ApeProject extends Project {
       }
     } catch (error) {
       this.initializeError = `${error}`;
-      this.serverState.logger.error(this.initializeError);
+      this.serverState.logger.info(this.initializeError);
     }
 
     return;

--- a/server/src/frameworks/Foundry/FoundryProject.ts
+++ b/server/src/frameworks/Foundry/FoundryProject.ts
@@ -66,8 +66,6 @@ export class FoundryProject extends Project {
       );
       this.remappings = parseRemappings(rawRemappings);
     } catch (error: any) {
-      this.serverState.logger.error(error.toString());
-
       switch (error.code) {
         case 134:
           this.initializeError =
@@ -79,6 +77,7 @@ export class FoundryProject extends Project {
         default:
           this.initializeError = `Unexpected error while running \`forge\`: ${error}`;
       }
+      this.serverState.logger.info(this.initializeError);
     }
 
     return;

--- a/server/src/frameworks/Truffle/TruffleProject.ts
+++ b/server/src/frameworks/Truffle/TruffleProject.ts
@@ -69,6 +69,7 @@ export class TruffleProject extends Project {
       const errorMessage = `Truffle module not found. Ensure it's installed globally or locally.`;
       this.status = Status.INITIALIZED_FAILURE;
       this.initializeError = errorMessage;
+      this.serverState.logger.info(this.initializeError);
     }
 
     try {
@@ -89,11 +90,13 @@ export class TruffleProject extends Project {
         this.serverState.solcVersions,
         configSolcVersion
       );
+
       if (resolvedSolcVersion === null) {
         throw new Error(
           `No version satisfies ${configSolcVersion}. Available versions are: ${this.serverState.solcVersions}`
         );
       }
+
       this.resolvedSolcVersion = resolvedSolcVersion;
 
       // Load contracts directory
@@ -112,7 +115,7 @@ export class TruffleProject extends Project {
       const errorMessage = `Error loading config file ${this.configPath}: ${error}`;
       this.status = Status.INITIALIZED_FAILURE;
       this.initializeError = errorMessage;
-      throw new Error(errorMessage);
+      this.serverState.logger.info(this.initializeError);
     }
   }
 

--- a/server/src/frameworks/Truffle/TruffleProject.ts
+++ b/server/src/frameworks/Truffle/TruffleProject.ts
@@ -69,7 +69,6 @@ export class TruffleProject extends Project {
       const errorMessage = `Truffle module not found. Ensure it's installed globally or locally.`;
       this.status = Status.INITIALIZED_FAILURE;
       this.initializeError = errorMessage;
-      throw new Error(errorMessage);
     }
 
     try {

--- a/server/src/services/initialization/indexWorkspaceFolders.ts
+++ b/server/src/services/initialization/indexWorkspaceFolders.ts
@@ -83,7 +83,7 @@ export async function indexWorkspaceFolders(
       try {
         await foundProject.initialize();
       } catch (error) {
-        logger.info(`Error initializing ${foundProject.basePath}: ${error}`);
+        logger.error(error);
       }
 
       span?.finish();

--- a/server/src/services/initialization/indexWorkspaceFolders.ts
+++ b/server/src/services/initialization/indexWorkspaceFolders.ts
@@ -83,7 +83,7 @@ export async function indexWorkspaceFolders(
       try {
         await foundProject.initialize();
       } catch (error) {
-        logger.error(`Error initializing ${foundProject.basePath}: ${error}`);
+        logger.info(`Error initializing ${foundProject.basePath}: ${error}`);
       }
 
       span?.finish();


### PR DESCRIPTION
This is to address the new errors appearing on sentry related to project initialization. I just realized that our logger creates error entries when we call the `.error` method. I replaced existing logging related to project initialization from `error` calls to `info`, to avoid this. 