### PR TITLE
fix: support absolute path remappings on foundry projects

### DIFF
--- a/server/src/frameworks/Foundry/FoundryProject.ts
+++ b/server/src/frameworks/Foundry/FoundryProject.ts
@@ -108,7 +108,8 @@ export class FoundryProject extends Project {
     // Apply remappings to importPath if it's not a relative import
     if (!importPath.startsWith(".")) {
       for (const { from, to } of this.remappings) {
-        const toAbsolutePath = path.join(this.basePath, to);
+        const toAbsolutePath = path.resolve(this.basePath, to);
+
         if (importPath.startsWith(from)) {
           transformedPath = path.join(
             toAbsolutePath,
@@ -162,6 +163,10 @@ export class FoundryProject extends Project {
     // Modify source keys to be root-relative instead of absolute
     // i,e, '/home/user/myProject/src/Contract.sol' => 'src/Contract.sol'
     for (const [sourceKey, sourceValue] of Object.entries(sources)) {
+      if (!directoryContains(this.basePath, sourceKey)) {
+        continue;
+      }
+
       const transformedSourceKey = path.relative(this.basePath, sourceKey);
       sources[transformedSourceKey] = sourceValue;
       delete sources[sourceKey];

--- a/test/protocol/projects/foundry/remappings.txt
+++ b/test/protocol/projects/foundry/remappings.txt
@@ -1,2 +1,3 @@
 @lib/=lib
 @myLib/=lib/myLib
+@tmp=/tmp

--- a/test/protocol/projects/foundry/src/definition/Importer.sol
+++ b/test/protocol/projects/foundry/src/definition/Importer.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.7;
 
 import '@lib/myLib/Imported.sol';
 import '@myLib/OtherImported.sol';
+import '@tmp/AbsoluteImported.sol';
 
 contract Importer {
   Imported i1;

--- a/test/protocol/test/textDocument/completion/foundry/completion.test.ts
+++ b/test/protocol/test/textDocument/completion/foundry/completion.test.ts
@@ -44,6 +44,12 @@ describe('[foundry][completion]', () => {
             documentation: 'Imports the package',
           },
           {
+            label: '@tmp',
+            insertText: '@tmp',
+            kind: 9,
+            documentation: 'Imports the package',
+          },
+          {
             label: 'myLib',
             insertText: 'myLib',
             kind: 9,

--- a/test/protocol/test/textDocument/definition/foundry/definition.test.ts
+++ b/test/protocol/test/textDocument/definition/foundry/definition.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai'
 import { test } from 'mocha'
+import { writeFileSync } from 'fs'
 import { shouldSkipFoundryTests, toUri } from '../../../../src/helpers'
 import { TestLanguageClient } from '../../../../src/TestLanguageClient'
 import { getInitializedClient } from '../../../client'
@@ -60,7 +61,7 @@ describe('[foundry] definition', () => {
   })
 
   test('[multi-file][remappings] - go to Imported.sol via declaration line', async function () {
-    const location = await client.findDefinition(toUri(importerPath), makePosition(8, 5))
+    const location = await client.findDefinition(toUri(importerPath), makePosition(9, 5))
 
     expect(location).to.deep.equal({
       uri: toUri(importedPath),
@@ -69,11 +70,22 @@ describe('[foundry] definition', () => {
   })
 
   test('[multi-file][remappings] - go to OtherImported.sol via declaration line', async function () {
-    const location = await client.findDefinition(toUri(importerPath), makePosition(9, 5))
+    const location = await client.findDefinition(toUri(importerPath), makePosition(10, 5))
 
     expect(location).to.deep.equal({
       uri: toUri(otherImportedPath),
       range: makeRange(4, 9, 4, 22),
+    })
+  })
+
+  test('[multi-file][remappings] - go to absolute path imported file', async function () {
+    writeFileSync('/tmp/AbsoluteImported.sol', '')
+    await client.openDocument(importerPath) // reopen to reanalyze the file and the imports
+
+    const location = await client.findDefinition(toUri(importerPath), makePosition(6, 22))
+
+    expect(location).to.include({
+      uri: toUri('/tmp/AbsoluteImported.sol'),
     })
   })
 })


### PR DESCRIPTION
Replaced `path.join` with `path.resolve` when parsing remappings to allow for absolute path remappings.

Closes #476 