### PR TITLE
fix: return `ok` when no diagnostics passed to onCodeAction

### DIFF
--- a/server/src/services/codeactions/onCodeAction.ts
+++ b/server/src/services/codeactions/onCodeAction.ts
@@ -12,7 +12,7 @@ export function onCodeAction(serverState: ServerState) {
       serverState.telemetry.trackTimingSync("onCodeAction", () => {
         const document = documents.get(params.textDocument.uri);
 
-        if (!document || params.context.diagnostics.length === 0) {
+        if (!document) {
           return { status: "failed_precondition", result: [] };
         }
 


### PR DESCRIPTION
Closes #488 