### PR TITLE
fix: uri not indexed error

### DIFF
--- a/server/src/services/documents/onDidChangeWatchedFiles.ts
+++ b/server/src/services/documents/onDidChangeWatchedFiles.ts
@@ -16,7 +16,6 @@ export function onDidChangeWatchedFiles(serverState: ServerState) {
       ) {
         const unixStyleUri = toUnixStyle(change.uri);
 
-        delete serverState.solFileIndex[unixStyleUri];
         await clearDiagnostics(serverState, unixStyleUri);
       }
     }


### PR DESCRIPTION
Even though I couldn't reproduce the issue, I'm confident that the cause is a change introduced in 0.6.13 (when the issue first appeared), in which deleted files are removed from the sol file index. My guess is that after being removed, some debounced analyze/validate requests hit and the entry is not there anymore. The logic in place will try to index the file but since it was deleted it should be failing. 

This fix just stops removing the sol file entry on file deletion. That removal was in place just to free up some memory, but it's negligible.

Closes #487 