### PR TITLE
Update README.md

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -34,11 +34,16 @@ For coc the extension for this language server (found [here](https://www.npmjs.c
 To run the language server directly through the neovim lsp (assuming [neovim/nvim-lspconfig](https://github.com/neovim/nvim-lspconfig))
 
 ```sh
-local lspconfig = require 'lspconfig'
+local on_attach = require("plugins.configs.lspconfig").on_attach
+local capabilities = require("plugins.configs.lspconfig").capabilities
+
+local lspconfig = require "lspconfig"
 local configs = require 'lspconfig.configs'
 
 configs.solidity = {
   default_config = {
+    on_attach = on_attach,
+    capabilities = capabilities,
     cmd = {'nomicfoundation-solidity-language-server', '--stdio'},
     filetypes = { 'solidity' },
     root_dir = lspconfig.util.find_git_ancestor,


### PR DESCRIPTION
Added additional on_attach and capabilities to nvim-lspconfig

<!--
Thank you for using **Solidity for Visual Studio Code by Nomic Foundation** and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

The Language server for hardhat works great with the config in the readme, but I found a couple of features missing:

- Error diagnostics were being shown in the editor, but the  keybinding to open the modal was not expanding the full error.
- Docstrings and signatures were not being loaded with <K>

Both of these are a bit of a pain to work without, so added the recommended additional lines to the LSP config for neovim.

Let me know what you think. 
