### PR TITLE
docs: add .env warning to publish instructions

### DIFF
--- a/docs/publish-extension.md
+++ b/docs/publish-extension.md
@@ -25,6 +25,9 @@ release.
 
 9. Push the release branch and open a pull request using the new changelog entry as the PR description
 10. Generate a release candidate vsix file with `npm run package`, the vsix file should appear in the `./client` folder with the new version number
+
+> NOTE: ensure .env file is populated with GA and Sentry secrets before packaging (see `./env.example`)
+
 11. Manually run smoke tests on the new features across:
 
 - mac os x


### PR DESCRIPTION
Our changes to the build to pull in telemetry secrets for ga and sentry clashed with our publish instructions (to `git clean` to test that there are no changes with an `npm install`).

A warning to check that a valid `.env` file has been added is included now in the publish doc.