### PR TITLE
Add `foundryup` support for Windows

### DIFF
--- a/server/src/frameworks/Foundry/resolveForgeCommand.ts
+++ b/server/src/frameworks/Foundry/resolveForgeCommand.ts
@@ -15,6 +15,9 @@ export async function resolveForgeCommand() {
     potentialForgeCommands.push(
       `${process.env.USERPROFILE}\\.cargo\\bin\\forge`
     );
+    potentialForgeCommands.push(
+      `${process.env.USERPROFILE}\\.foundry\\bin\\forge`
+    );
   } else {
     potentialForgeCommands.push(
       `${process.env.XDG_CONFIG_HOME || process.env.HOME}/.foundry/bin/forge`


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

This PR adds support for `foundryup` on Windows, especially if `forge` is not available in `path` or conflicts with other globally installed packages.
