### PR TITLE
feat: add support for region comments

### DIFF
--- a/client/language-configuration.json
+++ b/client/language-configuration.json
@@ -32,6 +32,12 @@
     ["[", "]"],
     ["(", ")"]
   ],
+  "folding": {
+		"markers": {
+			"start": "^\\s*//\\s*#?region\\b",
+			"end": "^\\s*//\\s*#?endregion\\b"
+		}
+	},
   "onEnterRules": [
     {
       // e.g. /** | */

--- a/docs/publish-extension.md
+++ b/docs/publish-extension.md
@@ -25,6 +25,9 @@ release.
 
 9. Push the release branch and open a pull request using the new changelog entry as the PR description
 10. Generate a release candidate vsix file with `npm run package`, the vsix file should appear in the `./client` folder with the new version number
+
+> NOTE: ensure .env file is populated with GA and Sentry secrets before packaging (see `./env.example`)
+
 11. Manually run smoke tests on the new features across:
 
 - mac os x


### PR DESCRIPTION
<!--
Thank you for using **Solidity for Visual Studio Code by Nomic Foundation** and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---
## Overview

This PR introduces support for region comments within Solidity `.sol` files previously mentioned in https://github.com/NomicFoundation/hardhat-vscode/issues/452, addressing the issue where developers were seeking the ability to organize code into collapsible sections for improved readability and navigation. 

## Changes

- Modified the Solidity language configuration file to recognize the `//#region` and `//#endregion` patterns.

## Implementation Details

Region comments are implemented by modifying the Solidity language grammar to include start and end region markers. The pattern follows the typical convention of `//#region` and `//#endregion` which is familiar to developers from other programming languages.

```solidity
//#region ExampleRegion

// Your Solidity code here

//#endregion ExampleRegion
```

The language configuration now includes logic to parse these markers and translate them into foldable regions within VS Code.

## Screenshots

_Included are screenshots demonstrating the collapsible regions in action within a Solidity file._

<img width="809" alt="image" src="https://github.com/NomicFoundation/hardhat-vscode/assets/4002635/208ff6f1-fd64-4538-bb9f-7246f9e00fc8">

\
<img width="862" alt="image" src="https://github.com/NomicFoundation/hardhat-vscode/assets/4002635/e00dfcea-fc38-4fd0-88dc-803a9a779e9e">

## How to test this feature

1. Check out this PR and follow the instructions in [CONTRIBUTING.md#running-locally](https://github.com/NomicFoundation/hardhat-vscode/blob/development/CONTRIBUTING.md#running-locally) to run it locally.
2. Open a `.sol` file in VS Code.
3. Insert `//#region` and `//#endregion` comments around the code you wish to collapse.
4. Verify that you can collapse and expand the region as expected.