### PR TITLE
fix: compare ast ranges in isNodeEqual

### DIFF
--- a/server/src/compilerDiagnostics/diagnostics/common/ImplementInterface/utils/methodResolutionOrdersFor.ts
+++ b/server/src/compilerDiagnostics/diagnostics/common/ImplementInterface/utils/methodResolutionOrdersFor.ts
@@ -1,3 +1,4 @@
+// @ts-ignore
 import { linearize } from "c3-linearization";
 import { ContractDefinitionNode } from "@common/types";
 import {

--- a/server/src/parser/analyzer/analyzeSolFile.ts
+++ b/server/src/parser/analyzer/analyzeSolFile.ts
@@ -35,7 +35,7 @@ export async function analyzeSolFile(
       const oldDocumentsAnalyzerTree = solFileEntry.analyzerTree
         .tree as SourceUnitNode;
 
-      for (const importNode of oldDocumentsAnalyzerTree.getImportNodes()) {
+      for (const importNode of oldDocumentsAnalyzerTree.children) {
         importNode.getParent()?.removeChild(importNode);
         importNode.setParent(undefined);
       }

--- a/server/src/parser/common/types/index.ts
+++ b/server/src/parser/common/types/index.ts
@@ -921,8 +921,6 @@ function isNodeEqual(
     node1.nameLoc === node2.nameLoc &&
     node1.uri === node2.uri &&
     node1.astNode.range === node2.astNode.range;
-
-  
 }
 
 export type AstMutability = "pure" | "constant" | "payable" | "view" | null;

--- a/server/src/parser/common/types/index.ts
+++ b/server/src/parser/common/types/index.ts
@@ -902,7 +902,7 @@ export const expressionNodeTypes = [
 ];
 
 /**
- * Checks if 2 nodes have the same {@link Node.getName name}, {@link Node.nameLoc location name} and {@link Node.uri URI}.
+ * Checks if 2 nodes have the same {@link Node.getName name}, {@link Node.nameLoc location name}, {@link Node.astNode.range range} and {@link Node.uri URI}.
  * @returns true if the Nodes are equal, otherwise false.
  */
 function isNodeEqual(
@@ -917,15 +917,12 @@ function isNodeEqual(
     return true;
   }
 
-  if (
-    node1.getName() === node2.getName() &&
-    JSON.stringify(node1.nameLoc) === JSON.stringify(node2.nameLoc) &&
-    node1.uri === node2.uri
-  ) {
-    return true;
-  }
+  return node1.getName() === node2.getName() &&
+    node1.nameLoc === node2.nameLoc &&
+    node1.uri === node2.uri &&
+    node1.astNode.range === node2.astNode.range;
 
-  return false;
+  
 }
 
 export type AstMutability = "pure" | "constant" | "payable" | "view" | null;

--- a/server/src/utils/PrettyPrinter.ts
+++ b/server/src/utils/PrettyPrinter.ts
@@ -1,4 +1,5 @@
 import * as prettier from "prettier";
+// @ts-ignore
 import * as prettierPluginSolidity from "prettier-plugin-solidity";
 import { ASTNode, TextDocument } from "@common/types";
 import { URI } from "vscode-uri";

--- a/server/test/services/analyzer/analyzer.ts
+++ b/server/test/services/analyzer/analyzer.ts
@@ -1,0 +1,26 @@
+import {assert} from "chai";
+import * as path from "path";
+import {forceToUnixStyle} from "../../helpers/forceToUnixStyle";
+import {SolFileEntry} from "@analyzer/SolFileEntry";
+import {Project} from "../../../out/frameworks/base/Project";
+import {analyzeSolFile} from "@analyzer/analyzeSolFile";
+import fs from "fs";
+
+describe("Analyzer", () => {
+  const multipleUnnamedNodes = forceToUnixStyle(
+    path.join(__dirname, "testData", "MultipleUnnamedNodes.sol")
+  );
+
+  const emptyProject: Project = {
+    basePath: "",
+    priority: 0
+  } as Project;
+
+  it("Works with multiple unnamed nodes", async () => {
+    const file = SolFileEntry.createUnloadedEntry(multipleUnnamedNodes, emptyProject);
+    file.loadText(await fs.promises.readFile(file.uri, "utf-8"))
+    const node = await analyzeSolFile({solFileIndex: {}}, file);
+    
+    assert.equal(node?.children[0]?.children[0]?.children?.length, 2);
+  });
+});

--- a/server/test/services/analyzer/testData/MultipleUnnamedNodes.sol
+++ b/server/test/services/analyzer/testData/MultipleUnnamedNodes.sol
@@ -1,0 +1,7 @@
+contract Test {
+    function MultipleUnnamedNodes() public pure returns (uint256) {
+        if (true) {
+            uint256 item = 1234;
+        }
+    }
+}

--- a/server/test/services/completion/testData/MultipleUnnamedNodes.sol
+++ b/server/test/services/completion/testData/MultipleUnnamedNodes.sol
@@ -1,0 +1,8 @@
+contract Test {
+    function MultipleUnnamedNodes() public pure returns (uint256) {
+        if (true) {
+            uint256 item = 1234;
+            i;
+        }
+    }
+}


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.

There can be multiple nodes without names, and they can't be added via addChild/addTypeNode