### PR TITLE
update NodeJS version used in CI

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -10,7 +10,12 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.4.0
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+
+      - uses: actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/NomicFoundation/projects/5
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/add-label-to-new-issue.yml
+++ b/.github/workflows/add-label-to-new-issue.yml
@@ -13,7 +13,12 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/github-script@v6
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+
+      - uses: actions/github-script@v7
         with:
           script: |
             const issue = await github.rest.issues.get({

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: "14.x"
+          node-version: "18.x"
 
       - name: npm latest
         run: npm i -g npm@8 && npm i -g npm@latest
@@ -79,12 +79,9 @@ jobs:
           key: ${{ runner.os }}-vscode-1.70.2
 
       - name: Run E2E tests
-        uses: GabrielBB/xvfb-action@v1.0
+        uses: coactions/setup-xvfb@v1.0.1
         with:
           run: npm run test:e2e
-        env:
-          CODE_VERSION: ${{ matrix.version }}
-          VSCODEGO_BEFORE_RELEASE_TESTS: true
 
       - name: Package the extension
         run: npm run package

--- a/client/src/popups/showAnalyticsAllowPopup.ts
+++ b/client/src/popups/showAnalyticsAllowPopup.ts
@@ -3,6 +3,7 @@ import {
   window,
   ExtensionContext,
   ConfigurationTarget,
+  ExtensionMode,
 } from "vscode";
 
 const PREVIOUSLY_SHOWN_TELEMETRY_LABEL = "previouslyShownTelemetryMessage";
@@ -12,6 +13,12 @@ export async function showAnalyticsAllowPopup({
 }: {
   context: ExtensionContext;
 }): Promise<void> {
+  if (context.extensionMode === ExtensionMode.Test) {
+    // Dialog messages are prohibited in tests:
+    // https://github.com/microsoft/vscode/blob/36fefc828e4c496a7bbb64c63f3eb3052a650f8f/src/vs/workbench/services/dialogs/common/dialogService.ts#L56
+    return;
+  }
+
   // TODO: remove this once we are happy we have most people reconfirmed
   await context.globalState.update("shownTelemetryMessage", undefined);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@types/vscode": "^1.70",
         "@typescript-eslint/eslint-plugin": "5.8.0",
         "@typescript-eslint/parser": "5.8.0",
-        "@vscode/test-electron": "2.1.3",
+        "@vscode/test-electron": "2.3.8",
         "@vscode/vsce": "2.17.0",
         "concurrently": "7.1.0",
         "dotenv": "16.0.3",
@@ -3484,17 +3484,18 @@
       "license": "ISC"
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.1.3",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.8.tgz",
+      "integrity": "sha512-b4aZZsBKtMGdDljAsOPObnAi7+VWIaYl3ylCz1jTs+oV6BZ4TNHcVNC3xUn0azPeszBmwSBDQYfFESIaUQnrOg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "http-proxy-agent": "^4.0.1",
         "https-proxy-agent": "^5.0.0",
-        "rimraf": "^3.0.2",
-        "unzipper": "^0.10.11"
+        "jszip": "^3.10.1",
+        "semver": "^7.5.2"
       },
       "engines": {
-        "node": ">=8.9.3"
+        "node": ">=16"
       }
     },
     "node_modules/@vscode/vsce": {
@@ -3952,14 +3953,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/big-integer": {
-      "version": "1.6.51",
-      "dev": true,
-      "license": "Unlicense",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/bigint-crypto-utils": {
       "version": "3.1.8",
       "dev": true,
@@ -3977,15 +3970,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.4.0"
-      }
-    },
-    "node_modules/binary": {
-      "version": "0.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffers": "~0.1.1",
-        "chainsaw": "~0.1.0"
       }
     },
     "node_modules/binary-extensions": {
@@ -4033,11 +4017,6 @@
     },
     "node_modules/blakejs": {
       "version": "1.2.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/bluebird": {
-      "version": "3.4.7",
       "dev": true,
       "license": "MIT"
     },
@@ -4193,25 +4172,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/buffer-indexof-polyfill": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/buffers": {
-      "version": "0.1.1",
-      "dev": true,
-      "engines": {
-        "node": ">=0.2.0"
-      }
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -4363,14 +4327,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/chainsaw": {
-      "version": "0.1.0",
-      "dev": true,
-      "license": "MIT/X11",
-      "dependencies": {
-        "traverse": ">=0.3.0 <0.4"
       }
     },
     "node_modules/chalk": {
@@ -4659,8 +4615,9 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
@@ -5052,46 +5009,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/duplexer2": {
-      "version": "0.1.4",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "node_modules/duplexer2/node_modules/isarray": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/duplexer2/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/duplexer2/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/duplexer2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -6198,31 +6115,6 @@
       "version": "1.0.0",
       "license": "ISC"
     },
-    "node_modules/fstream": {
-      "version": "1.0.12",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      },
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/fstream/node_modules/rimraf": {
-      "version": "2.7.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "dev": true,
@@ -7323,6 +7215,12 @@
         "minimatch": "^3.0.4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true
+    },
     "node_modules/immutable": {
       "version": "4.2.4",
       "dev": true,
@@ -7949,6 +7847,54 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/just-extend": {
       "version": "4.2.1",
       "dev": true,
@@ -8064,6 +8010,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "dev": true,
@@ -8076,11 +8031,6 @@
       "dependencies": {
         "uc.micro": "^1.0.1"
       }
-    },
-    "node_modules/listenercount": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/load-yaml-file": {
       "version": "0.2.0",
@@ -8436,17 +8386,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -9160,6 +9099,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "license": "MIT",
@@ -9472,8 +9417,9 @@
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "node_modules/process-on-spawn": {
       "version": "1.0.0",
@@ -10000,8 +9946,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "license": "ISC",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -10836,11 +10783,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/traverse": {
-      "version": "0.3.9",
-      "dev": true,
-      "license": "MIT/X11"
-    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "dev": true,
@@ -11201,55 +11143,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/unzipper": {
-      "version": "0.10.11",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "big-integer": "^1.6.17",
-        "binary": "~0.3.0",
-        "bluebird": "~3.4.1",
-        "buffer-indexof-polyfill": "~1.0.0",
-        "duplexer2": "~0.1.4",
-        "fstream": "^1.0.12",
-        "graceful-fs": "^4.2.2",
-        "listenercount": "~1.0.1",
-        "readable-stream": "~2.3.6",
-        "setimmediate": "~1.0.4"
-      }
-    },
-    "node_modules/unzipper/node_modules/isarray": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/unzipper/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/unzipper/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/unzipper/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -15532,13 +15425,15 @@
       "dev": true
     },
     "@vscode/test-electron": {
-      "version": "2.1.3",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.8.tgz",
+      "integrity": "sha512-b4aZZsBKtMGdDljAsOPObnAi7+VWIaYl3ylCz1jTs+oV6BZ4TNHcVNC3xUn0azPeszBmwSBDQYfFESIaUQnrOg==",
       "dev": true,
       "requires": {
         "http-proxy-agent": "^4.0.1",
         "https-proxy-agent": "^5.0.0",
-        "rimraf": "^3.0.2",
-        "unzipper": "^0.10.11"
+        "jszip": "^3.10.1",
+        "semver": "^7.5.2"
       }
     },
     "@vscode/vsce": {
@@ -15821,10 +15716,6 @@
         "is-windows": "^1.0.0"
       }
     },
-    "big-integer": {
-      "version": "1.6.51",
-      "dev": true
-    },
     "bigint-crypto-utils": {
       "version": "3.1.8",
       "dev": true,
@@ -15835,14 +15726,6 @@
     "bigint-mod-arith": {
       "version": "3.1.2",
       "dev": true
-    },
-    "binary": {
-      "version": "0.3.0",
-      "dev": true,
-      "requires": {
-        "buffers": "~0.1.1",
-        "chainsaw": "~0.1.0"
-      }
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -15871,10 +15754,6 @@
     },
     "blakejs": {
       "version": "1.2.1",
-      "dev": true
-    },
-    "bluebird": {
-      "version": "3.4.7",
       "dev": true
     },
     "bn.js": {
@@ -15978,16 +15857,8 @@
       "version": "1.1.2",
       "dev": true
     },
-    "buffer-indexof-polyfill": {
-      "version": "1.0.2",
-      "dev": true
-    },
     "buffer-xor": {
       "version": "1.0.3",
-      "dev": true
-    },
-    "buffers": {
-      "version": "0.1.1",
       "dev": true
     },
     "busboy": {
@@ -16080,13 +15951,6 @@
         "get-func-name": "^2.0.0",
         "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
-      }
-    },
-    "chainsaw": {
-      "version": "0.1.0",
-      "dev": true,
-      "requires": {
-        "traverse": ">=0.3.0 <0.4"
       }
     },
     "chalk": {
@@ -16272,6 +16136,8 @@
     },
     "core-util-is": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
     "crc-32": {
@@ -16500,43 +16366,6 @@
     "dotenv": {
       "version": "16.0.3",
       "dev": true
-    },
-    "duplexer2": {
-      "version": "0.1.4",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.8",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
     },
     "electron-to-chromium": {
       "version": "1.4.313",
@@ -17296,25 +17125,6 @@
     },
     "fs.realpath": {
       "version": "1.0.0"
-    },
-    "fstream": {
-      "version": "1.0.12",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.7.1",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
-      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -18091,6 +17901,12 @@
         "minimatch": "^3.0.4"
       }
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true
+    },
     "immutable": {
       "version": "4.2.4",
       "dev": true
@@ -18460,6 +18276,56 @@
         "universalify": "^2.0.0"
       }
     },
+    "jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "requires": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "just-extend": {
       "version": "4.2.1",
       "dev": true
@@ -18538,6 +18404,15 @@
         "type-check": "~0.4.0"
       }
     },
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "requires": {
+        "immediate": "~3.0.5"
+      }
+    },
     "lines-and-columns": {
       "version": "1.2.4",
       "dev": true
@@ -18548,10 +18423,6 @@
       "requires": {
         "uc.micro": "^1.0.1"
       }
-    },
-    "listenercount": {
-      "version": "1.0.1",
-      "dev": true
     },
     "load-yaml-file": {
       "version": "0.2.0",
@@ -18784,13 +18655,6 @@
     "mixme": {
       "version": "0.5.5",
       "dev": true
-    },
-    "mkdirp": {
-      "version": "0.5.6",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.6"
-      }
     },
     "mkdirp-classic": {
       "version": "0.5.3",
@@ -19262,6 +19126,12 @@
         "release-zalgo": "^1.0.0"
       }
     },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
+    },
     "parent-module": {
       "version": "1.0.1",
       "requires": {
@@ -19455,6 +19325,8 @@
     },
     "process-nextick-args": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
     "process-on-spawn": {
@@ -20032,7 +19904,9 @@
       }
     },
     "semver": {
-      "version": "7.3.8",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "requires": {
         "lru-cache": "^6.0.0"
       },
@@ -20603,10 +20477,6 @@
       "version": "0.0.3",
       "dev": true
     },
-    "traverse": {
-      "version": "0.3.9",
-      "dev": true
-    },
     "tree-kill": {
       "version": "1.2.2",
       "dev": true
@@ -20836,52 +20706,6 @@
     "unpipe": {
       "version": "1.0.0",
       "dev": true
-    },
-    "unzipper": {
-      "version": "0.10.11",
-      "dev": true,
-      "requires": {
-        "big-integer": "^1.6.17",
-        "binary": "~0.3.0",
-        "bluebird": "~3.4.1",
-        "buffer-indexof-polyfill": "~1.0.0",
-        "duplexer2": "~0.1.4",
-        "fstream": "^1.0.12",
-        "graceful-fs": "^4.2.2",
-        "listenercount": "~1.0.1",
-        "readable-stream": "~2.3.6",
-        "setimmediate": "~1.0.4"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.8",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
     },
     "update-browserslist-db": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/vscode": "^1.70",
     "@typescript-eslint/eslint-plugin": "5.8.0",
     "@typescript-eslint/parser": "5.8.0",
-    "@vscode/test-electron": "2.1.3",
+    "@vscode/test-electron": "2.3.8",
     "@vscode/vsce": "2.17.0",
     "concurrently": "7.1.0",
     "dotenv": "16.0.3",

--- a/test/runTests.ts
+++ b/test/runTests.ts
@@ -20,7 +20,7 @@ import { runTests } from "@vscode/test-electron";
 
     // Download VS Code, unzip it and run the e2e test
     await runTests({
-      version: "1.83.1",
+      version: "1.70.2",
       extensionDevelopmentPath,
       extensionTestsPath,
 

--- a/test/runTests.ts
+++ b/test/runTests.ts
@@ -20,7 +20,7 @@ import { runTests } from "@vscode/test-electron";
 
     // Download VS Code, unzip it and run the e2e test
     await runTests({
-      version: "1.70.2",
+      version: "1.83.1",
       extensionDevelopmentPath,
       extensionTestsPath,
 


### PR DESCRIPTION
As the version we request is already deprecated:

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default