### PR TITLE
Bump required VS Code version to ^1.86

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
           cache-name: cache-vscode
         with:
           path: .vscode-test
-          key: ${{ runner.os }}-vscode-1.70.2
+          key: ${{ runner.os }}-vscode-1.86.0
 
       - name: Run E2E tests
         uses: coactions/setup-xvfb@v1.0.1

--- a/client/package.json
+++ b/client/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/NomicFoundation/hardhat-vscode/issues"
   },
   "engines": {
-    "vscode": "^1.70.2"
+    "vscode": "^1.86.0"
   },
   "activationEvents": [
     "onLanguage:solidity",
@@ -58,7 +58,7 @@
   "devDependencies": {
     "@sentry/types": "6.19.1",
     "@types/prettier": "2.6.0",
-    "@types/vscode": "^1.70",
+    "@types/vscode": "^1.86",
     "eslint": "^7.23.0",
     "rimraf": "3.0.2",
     "prettier": "2.5.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",
         "@types/module-alias": "2.0.1",
-        "@types/vscode": "^1.70",
+        "@types/vscode": "^1.86",
         "@typescript-eslint/eslint-plugin": "5.8.0",
         "@typescript-eslint/parser": "5.8.0",
         "@vscode/test-electron": "2.3.8",
@@ -49,13 +49,13 @@
       "devDependencies": {
         "@sentry/types": "6.19.1",
         "@types/prettier": "2.6.0",
-        "@types/vscode": "^1.70",
+        "@types/vscode": "^1.86",
         "eslint": "^7.23.0",
         "prettier": "2.5.1",
         "rimraf": "3.0.2"
       },
       "engines": {
-        "vscode": "^1.70.2"
+        "vscode": "^1.86.0"
       }
     },
     "client/node_modules/@nomicfoundation/solidity-language-server": {
@@ -3428,9 +3428,10 @@
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.75.1",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.88.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.88.0.tgz",
+      "integrity": "sha512-rWY+Bs6j/f1lvr8jqZTyp5arRMfovdxolcqGi+//+cPDOh8SBvzXH90e7BiSXct5HJ9HGW6jATchbRTpTJpEkw==",
+      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "13.0.12",
@@ -15626,7 +15627,9 @@
       }
     },
     "@types/vscode": {
-      "version": "1.75.1",
+      "version": "1.88.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.88.0.tgz",
+      "integrity": "sha512-rWY+Bs6j/f1lvr8jqZTyp5arRMfovdxolcqGi+//+cPDOh8SBvzXH90e7BiSXct5HJ9HGW6jATchbRTpTJpEkw==",
       "dev": true
     },
     "@types/yargs": {
@@ -17987,7 +17990,7 @@
         "@sentry/node": "6.19.1",
         "@sentry/types": "6.19.1",
         "@types/prettier": "2.6.0",
-        "@types/vscode": "^1.70",
+        "@types/vscode": "^1.86",
         "eslint": "^7.23.0",
         "prettier": "2.5.1",
         "rimraf": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/glob": "^7.1.3",
     "@types/mocha": "^8.2.2",
     "@types/module-alias": "2.0.1",
-    "@types/vscode": "^1.70",
+    "@types/vscode": "^1.86",
     "@typescript-eslint/eslint-plugin": "5.8.0",
     "@typescript-eslint/parser": "5.8.0",
     "@vscode/test-electron": "2.3.8",

--- a/test/e2e/tests/commands/clean.test.ts
+++ b/test/e2e/tests/commands/clean.test.ts
@@ -3,7 +3,6 @@ import { existsSync, mkdirSync } from "fs";
 import path from "path";
 import * as vscode from "vscode";
 import { waitForUI } from "../../helpers/editor";
-import { sleep } from "../../helpers/sleep";
 import { getRootPath } from "../../helpers/workspace";
 
 suite("task - clean", function () {
@@ -20,22 +19,11 @@ suite("task - clean", function () {
 
     // Run clean task
     await vscode.commands.executeCommand("workbench.action.tasks.runTask", {
-      task: "hardhat: clean main",
+      type: "hardhat",
+      task: "clean",
     });
     await waitForUI();
 
-    await sleep(1000);
-
-    await vscode.commands.executeCommand(
-      "workbench.action.acceptSelectedQuickOpenItem"
-    );
-    await sleep(1000);
-
-    await vscode.commands.executeCommand(
-      "workbench.action.acceptSelectedQuickOpenItem"
-    );
-
-    // Wait for task to finish
     await new Promise((resolve) => vscode.tasks.onDidEndTask(resolve));
 
     // Assert the artifacts were removed

--- a/test/e2e/tests/commands/clean.test.ts
+++ b/test/e2e/tests/commands/clean.test.ts
@@ -24,6 +24,7 @@ suite("task - clean", function () {
     });
     await waitForUI();
 
+    // Wait for the task to finish
     await new Promise((resolve) => vscode.tasks.onDidEndTask(resolve));
 
     // Assert the artifacts were removed

--- a/test/runTests.ts
+++ b/test/runTests.ts
@@ -20,7 +20,7 @@ import { runTests } from "@vscode/test-electron";
 
     // Download VS Code, unzip it and run the e2e test
     await runTests({
-      version: "1.70.2",
+      version: "1.86.0",
       extensionDevelopmentPath,
       extensionTestsPath,
 


### PR DESCRIPTION
This is required since we will not bundle Slang, requiring at least GLIBC 2.28, see https://github.com/NomicFoundation/slang/pull/909.