### PR TITLE
fix(server): rework server package file inclusion

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -17,7 +17,7 @@
   "main": "./out/index.js",
   "types": "./out/index.d.ts",
   "files": [
-    "out/**/*"
+    "out/"
   ],
   "bin": {
     "nomicfoundation-solidity-language-server": "./out/index.js"


### PR DESCRIPTION
The run of `npm pack` was not picking up `./out/**` subfolders. The `files` property has now been changed to include the entire folder.

Fixes #558.
