### PR TITLE
Bump Slang features to 5% of the users

### DIFF
--- a/flags.json
+++ b/flags.json
@@ -1,9 +1,9 @@
 {
   "documentSymbol": {
-    "percent": 0.01
+    "percent": 0.05
   },
 
   "semanticHighlighting": {
-    "percent": 0.01
+    "percent": 0.05
   }
 }


### PR DESCRIPTION
We handled every error so far, which were incompatible Slang version and/or analyzing incomplete pragmas.

Apart from that, we didn't really collect much data (only 2 completed transactions for symbol outlines and none for semantic highlighting) in the last 5 hours, so let's ramp it up a bit more.