### PR TITLE
feat: Use the latest version support by Slang even if not resolved

### DIFF
--- a/server/src/services/documentSymbol/onDocumentSymbol.ts
+++ b/server/src/services/documentSymbol/onDocumentSymbol.ts
@@ -5,10 +5,11 @@ import { DocumentSymbolParams } from "vscode-languageserver/node";
 import { DocumentSymbol, SymbolInformation } from "vscode-languageserver-types";
 import { analyze } from "@nomicfoundation/solidity-analyzer";
 import _ from "lodash";
+import { Language } from "@nomicfoundation/slang/language";
 import { RuleKind } from "@nomicfoundation/slang/kinds";
 import { RuleNode } from "@nomicfoundation/slang/cst";
 import { ServerState } from "../../types";
-import { getLanguage } from "../../parser/slangHelpers";
+import { resolveVersion } from "../../parser/slangHelpers";
 import { SymbolTreeBuilder } from "./SymbolTreeBuilder";
 import { StructDefinition } from "./visitors/StructDefinition";
 import { StructMember } from "./visitors/StructMember";
@@ -53,8 +54,10 @@ export function onDocumentSymbol(serverState: ServerState) {
       const { versionPragmas } = analyze(text);
       span.finish();
 
+      const resolvedVersion = resolveVersion(logger, versionPragmas);
+
       try {
-        const language = getLanguage(versionPragmas);
+        const language = new Language(resolvedVersion);
 
         // Parse using slang
         span = transaction.startChild({ op: "slang-parsing" });

--- a/server/src/services/semanticHighlight/onSemanticTokensFull.ts
+++ b/server/src/services/semanticHighlight/onSemanticTokensFull.ts
@@ -7,10 +7,11 @@ import {
 } from "vscode-languageserver-protocol";
 import _, { Dictionary } from "lodash";
 import { analyze } from "@nomicfoundation/solidity-analyzer";
+import { Language } from "@nomicfoundation/slang/language";
 import { RuleKind, TokenKind } from "@nomicfoundation/slang/kinds";
 import { TokenNode } from "@nomicfoundation/slang/cst";
 import { ServerState } from "../../types";
-import { getLanguage } from "../../parser/slangHelpers";
+import { resolveVersion } from "../../parser/slangHelpers";
 import { CustomTypeHighlighter } from "./highlighters/CustomTypeHighlighter";
 import { SemanticTokensBuilder } from "./SemanticTokensBuilder";
 import { FunctionDefinitionHighlighter } from "./highlighters/FunctionDefinitionHighlighter";
@@ -54,9 +55,10 @@ export function onSemanticTokensFull(serverState: ServerState) {
         const { versionPragmas } = analyze(text);
         span.finish();
 
-        const language = getLanguage(versionPragmas);
+        const resolvedVersion = resolveVersion(logger, versionPragmas);
 
         try {
+          const language = new Language(resolvedVersion);
           // Parse using slang
           span = transaction.startChild({ op: "slang-parsing" });
 


### PR DESCRIPTION
This is arguably more useful approach - we designed our parser to be error-tolerant and it makes more sense to offer slightly incomplete experience rather than just suddenly turning off all features just because the user is using a slightly newer version that may not get full coverage.
