### PR TITLE
release: 0.8.2

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -4,13 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.8.1 - 2024-03-25
+## 0.8.2 - 2024-04-22
+
+### Added
+
+- Run Semantic Highlighting and document symbols on later solc versions not yet support by the Slang parser (behind feature flag) ([562](https://github.com/NomicFoundation/hardhat-vscode/pull/562))
+
+## 0.8.1 - 2024-04-18
 
 ### Fixed
 
 - Fix packaging file inclusions on the language server ([558](https://github.com/NomicFoundation/hardhat-vscode/issues/558))
 
-## 0.8.0 - 2024-03-25
+## 0.8.0 - 2024-04-17
 
 ### Added
 

--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
   "displayName": "Solidity",
   "description": "Solidity and Hardhat support by the Hardhat team",
   "license": "MIT",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "main": "./out/extension.js",
   "module": "./out/extension.js",

--- a/coc/package.json
+++ b/coc/package.json
@@ -2,7 +2,7 @@
   "name": "@nomicfoundation/coc-solidity",
   "description": "Solidity and Hardhat support for coc.nvim",
   "license": "MIT",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "author": "Nomic Foundation",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     "clean": "rimraf out .nyc_output coverage *.tsbuildinfo *.log"
   },
   "dependencies": {
-    "@nomicfoundation/solidity-language-server": "0.8.1"
+    "@nomicfoundation/solidity-language-server": "0.8.2"
   },
   "devDependencies": {
     "coc.nvim": "^0.0.80",

--- a/flags.json
+++ b/flags.json
@@ -1,9 +1,9 @@
 {
   "documentSymbol": {
-    "percent": 0.01
+    "percent": 0.05
   },
 
   "semanticHighlighting": {
-    "percent": 0.01
+    "percent": 0.05
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "name": "@nomicfoundation/solidity-language-server",
   "description": "Solidity language server by Nomic Foundation",
   "license": "MIT",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "author": "Nomic Foundation",
   "repository": {
     "type": "git",

--- a/server/src/services/documentSymbol/onDocumentSymbol.ts
+++ b/server/src/services/documentSymbol/onDocumentSymbol.ts
@@ -5,10 +5,11 @@ import { DocumentSymbolParams } from "vscode-languageserver/node";
 import { DocumentSymbol, SymbolInformation } from "vscode-languageserver-types";
 import { analyze } from "@nomicfoundation/solidity-analyzer";
 import _ from "lodash";
+import { Language } from "@nomicfoundation/slang/language";
 import { RuleKind } from "@nomicfoundation/slang/kinds";
 import { RuleNode } from "@nomicfoundation/slang/cst";
 import { ServerState } from "../../types";
-import { getLanguage } from "../../parser/slangHelpers";
+import { resolveVersion } from "../../parser/slangHelpers";
 import { SymbolTreeBuilder } from "./SymbolTreeBuilder";
 import { StructDefinition } from "./visitors/StructDefinition";
 import { StructMember } from "./visitors/StructMember";
@@ -53,8 +54,10 @@ export function onDocumentSymbol(serverState: ServerState) {
       const { versionPragmas } = analyze(text);
       span.finish();
 
+      const resolvedVersion = resolveVersion(logger, versionPragmas);
+
       try {
-        const language = getLanguage(versionPragmas);
+        const language = new Language(resolvedVersion);
 
         // Parse using slang
         span = transaction.startChild({ op: "slang-parsing" });

--- a/server/src/services/semanticHighlight/onSemanticTokensFull.ts
+++ b/server/src/services/semanticHighlight/onSemanticTokensFull.ts
@@ -7,10 +7,11 @@ import {
 } from "vscode-languageserver-protocol";
 import _, { Dictionary } from "lodash";
 import { analyze } from "@nomicfoundation/solidity-analyzer";
+import { Language } from "@nomicfoundation/slang/language";
 import { RuleKind, TokenKind } from "@nomicfoundation/slang/kinds";
 import { TokenNode } from "@nomicfoundation/slang/cst";
 import { ServerState } from "../../types";
-import { getLanguage } from "../../parser/slangHelpers";
+import { resolveVersion } from "../../parser/slangHelpers";
 import { CustomTypeHighlighter } from "./highlighters/CustomTypeHighlighter";
 import { SemanticTokensBuilder } from "./SemanticTokensBuilder";
 import { FunctionDefinitionHighlighter } from "./highlighters/FunctionDefinitionHighlighter";
@@ -54,9 +55,10 @@ export function onSemanticTokensFull(serverState: ServerState) {
         const { versionPragmas } = analyze(text);
         span.finish();
 
-        const language = getLanguage(versionPragmas);
+        const resolvedVersion = resolveVersion(logger, versionPragmas);
 
         try {
+          const language = new Language(resolvedVersion);
           // Parse using slang
           span = transaction.startChild({ op: "slang-parsing" });
 


### PR DESCRIPTION
## 0.8.2 - 2024-04-22

### Added

- Run Semantic Highlighting and document symbols on later solc versions not yet support by the Slang parser (behind feature flag) ([562](https://github.com/NomicFoundation/hardhat-vscode/pull/562))