### PR TITLE
Bump Slang to 0.14.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
     },
     "client": {
       "name": "hardhat-solidity",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@nomicfoundation/solidity-language-server": "0.6.16",
@@ -142,10 +142,10 @@
     },
     "coc": {
       "name": "@nomicfoundation/coc-solidity",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/solidity-language-server": "0.8.1"
+        "@nomicfoundation/solidity-language-server": "0.8.2"
       },
       "devDependencies": {
         "coc.nvim": "^0.0.80",
@@ -12031,7 +12031,7 @@
     },
     "server": {
       "name": "@nomicfoundation/solidity-language-server",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@nomicfoundation/slang": "0.14.0",
@@ -14372,7 +14372,7 @@
     "@nomicfoundation/coc-solidity": {
       "version": "file:coc",
       "requires": {
-        "@nomicfoundation/solidity-language-server": "0.8.1",
+        "@nomicfoundation/solidity-language-server": "0.8.2",
         "coc.nvim": "^0.0.80",
         "esbuild": "^0.16.0",
         "eslint": "^7.23.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2667,28 +2667,28 @@
       }
     },
     "node_modules/@nomicfoundation/slang": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang/-/slang-0.14.0.tgz",
-      "integrity": "sha512-2VZCn/+SaAqlzRSVLuAf2j35BVIeSHbN1DQ9E1kwQSrXtVJTVzMogywLBvQE8hKKGTZIQV+Td9UV1qwxJYODVw==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang/-/slang-0.14.2.tgz",
+      "integrity": "sha512-3CiiJHuqGo5G9oDhRUDexFMlkguwSQMDcapZtJi+vz8x53HOwH4/ZwzwaNi1ZwKGnwT3fp9dxSzxrLYImFcZhA==",
       "engines": {
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@nomicfoundation/slang-darwin-arm64": "0.14.0",
-        "@nomicfoundation/slang-darwin-x64": "0.14.0",
-        "@nomicfoundation/slang-linux-arm64-gnu": "0.14.0",
-        "@nomicfoundation/slang-linux-arm64-musl": "0.14.0",
-        "@nomicfoundation/slang-linux-x64-gnu": "0.14.0",
-        "@nomicfoundation/slang-linux-x64-musl": "0.14.0",
-        "@nomicfoundation/slang-win32-arm64-msvc": "0.14.0",
-        "@nomicfoundation/slang-win32-ia32-msvc": "0.14.0",
-        "@nomicfoundation/slang-win32-x64-msvc": "0.14.0"
+        "@nomicfoundation/slang-darwin-arm64": "0.14.2",
+        "@nomicfoundation/slang-darwin-x64": "0.14.2",
+        "@nomicfoundation/slang-linux-arm64-gnu": "0.14.2",
+        "@nomicfoundation/slang-linux-arm64-musl": "0.14.2",
+        "@nomicfoundation/slang-linux-x64-gnu": "0.14.2",
+        "@nomicfoundation/slang-linux-x64-musl": "0.14.2",
+        "@nomicfoundation/slang-win32-arm64-msvc": "0.14.2",
+        "@nomicfoundation/slang-win32-ia32-msvc": "0.14.2",
+        "@nomicfoundation/slang-win32-x64-msvc": "0.14.2"
       }
     },
     "node_modules/@nomicfoundation/slang-darwin-arm64": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-arm64/-/slang-darwin-arm64-0.14.0.tgz",
-      "integrity": "sha512-bNDMnVSdw4QuScg9nonGlvEWKpZHWWcMKWrrnfvFAL1YKfsmZ3bhQqfD4LiCHSxuizxFoAKDiSaXhu/IRTalhw==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-arm64/-/slang-darwin-arm64-0.14.2.tgz",
+      "integrity": "sha512-ElMGNZHSywlfkP3X9pyym0vaNANSp33Ty/VrYXKABubj2w7+clrzPYQKSjnWv1D7qpJuZwe7SOiHCNCkTEyrVw==",
       "cpu": [
         "arm64"
       ],
@@ -2701,9 +2701,9 @@
       }
     },
     "node_modules/@nomicfoundation/slang-darwin-x64": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-x64/-/slang-darwin-x64-0.14.0.tgz",
-      "integrity": "sha512-xMBg+K1ocfN/LRy5PByc+Ww58EPdrEgLeAOiLMDgwVIq2lxFN8QM2n+WHKRYvyYXjPRW414QYiR2QfNhUM+1jg==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-x64/-/slang-darwin-x64-0.14.2.tgz",
+      "integrity": "sha512-k1LjajxhsU3T0jYmTYIs8S1QAERyOz3YYNL/zhOiah2x8X/jgjHY7dAgkWABzkViQBHUKmc7x8+iUV37h6SuFA==",
       "cpu": [
         "x64"
       ],
@@ -2716,9 +2716,9 @@
       }
     },
     "node_modules/@nomicfoundation/slang-linux-arm64-gnu": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-gnu/-/slang-linux-arm64-gnu-0.14.0.tgz",
-      "integrity": "sha512-sw9XMVIuPkyyra3rNQZpVVFK3EMl4lxMAIViGu7IillbYjOWEPlHtNwCF4oO8ST5Hg9GhuodXp+Drjin8Ec8WQ==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-gnu/-/slang-linux-arm64-gnu-0.14.2.tgz",
+      "integrity": "sha512-G5ccD82NlF3ijFS1tqlidL2nlfXoFRG2tFPMFTk7etnPElwi4Tq8O0ajZkel2TYiO4LcKxPlfwpVuVR4AbT58Q==",
       "cpu": [
         "arm64"
       ],
@@ -2731,9 +2731,9 @@
       }
     },
     "node_modules/@nomicfoundation/slang-linux-arm64-musl": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-musl/-/slang-linux-arm64-musl-0.14.0.tgz",
-      "integrity": "sha512-zs/frMl6TyW0w6kt/dDIoRbNBWZ8En3K70ijBnd5DUpOG2zIbbvF+cad9aVaLwHJ1ApPq4+sahk4y+LjqLgqQQ==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-musl/-/slang-linux-arm64-musl-0.14.2.tgz",
+      "integrity": "sha512-fNeIshoExmikHokUDVbqfV9gDZxtGlJ5cFs3TdwxwWgqEp56V1ByWJ4wGPDQBTwv2p2fil/97LyxnOenHXeOkQ==",
       "cpu": [
         "arm64"
       ],
@@ -2746,9 +2746,9 @@
       }
     },
     "node_modules/@nomicfoundation/slang-linux-x64-gnu": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-gnu/-/slang-linux-x64-gnu-0.14.0.tgz",
-      "integrity": "sha512-CD1sJkcsrYjXfB74zJkXOYHUMNLrKjJBs2CSgXRsD94leSJQX7RLlGdWA1pLfUtbXcrTVA7Qivuylk0UNqq+zA==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-gnu/-/slang-linux-x64-gnu-0.14.2.tgz",
+      "integrity": "sha512-kixwVCuvq1TVemPp7Cm6VbpJKmbIcPxhHK4CatOn/Nxm2p35iSBPn/E5OiqwPTjHk+nD684WnuOsZGEvf9NKlg==",
       "cpu": [
         "x64"
       ],
@@ -2761,9 +2761,9 @@
       }
     },
     "node_modules/@nomicfoundation/slang-linux-x64-musl": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-musl/-/slang-linux-x64-musl-0.14.0.tgz",
-      "integrity": "sha512-H3wmgZLXexeXPtFBrdW5QIsOiQXbtTqRRL8HGO9LOEIaPcLE/6HqFeZ46udFhm82/dIR6BFH6X6ADZoCHzGJHA==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-musl/-/slang-linux-x64-musl-0.14.2.tgz",
+      "integrity": "sha512-oX9ihC3nYyZjG19GxfFthiZJTZkOhYAqyI7YhbPh0BWfAqf3/FxADQkv+4cXv3sb+SsXo4yOVhgVuOq75qWxUw==",
       "cpu": [
         "x64"
       ],
@@ -2776,9 +2776,9 @@
       }
     },
     "node_modules/@nomicfoundation/slang-win32-arm64-msvc": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-arm64-msvc/-/slang-win32-arm64-msvc-0.14.0.tgz",
-      "integrity": "sha512-cLrZEiGY2LqNDuaWuoHc3s188H8MmtexB2qo7z8d3t1wwvVcwUE7k7hwyIyMy01BV11AmUy27l+qpk7WEVxocg==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-arm64-msvc/-/slang-win32-arm64-msvc-0.14.2.tgz",
+      "integrity": "sha512-VMH2xc0q+iZQ9oGA2NhecYh6GhJAf+M2a+h0IKU+OTbmREUL1nH12huc5wmFzWSdgKyJAyVidCQvcLhgYSoSkw==",
       "cpu": [
         "arm64"
       ],
@@ -2791,9 +2791,9 @@
       }
     },
     "node_modules/@nomicfoundation/slang-win32-ia32-msvc": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-ia32-msvc/-/slang-win32-ia32-msvc-0.14.0.tgz",
-      "integrity": "sha512-jKYmrvjcGnqE34iC5eJnQvNExI5QdydP28hZByRGIaDQqXW0dCfbKsSnG7zbhI794bIabO1ton6PxHRCOX9XnQ==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-ia32-msvc/-/slang-win32-ia32-msvc-0.14.2.tgz",
+      "integrity": "sha512-z99gbFnAGyA8D/yZoos8S7/VgP0SHrKMt8RcAHluC1UIQ0EnNYJrGwhVVTWPv6PPphoz11nF/UyUZ2cVsBcy0Q==",
       "cpu": [
         "ia32"
       ],
@@ -2806,9 +2806,9 @@
       }
     },
     "node_modules/@nomicfoundation/slang-win32-x64-msvc": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-x64-msvc/-/slang-win32-x64-msvc-0.14.0.tgz",
-      "integrity": "sha512-iPxH1ElgTDDrEq8pu9YZikV2yTNWjfXiFOvWbvyXhAcv7UWqkFnz04eGeY1Fu4VTh58jNso+BiSaRkP8liyBbg==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-x64-msvc/-/slang-win32-x64-msvc-0.14.2.tgz",
+      "integrity": "sha512-Av9WnISDikCW+tFf8E8+CE5bGM3K1FRC4yXnZnpPlQmQRIk4RkYQYzFMrAtDdO5NUmgSgVoCDlld5DkQ6vCQxg==",
       "cpu": [
         "x64"
       ],
@@ -12034,7 +12034,7 @@
       "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/slang": "0.14.0",
+        "@nomicfoundation/slang": "0.14.2",
         "@nomicfoundation/solidity-analyzer": "0.1.1"
       },
       "bin": {
@@ -14811,73 +14811,73 @@
       }
     },
     "@nomicfoundation/slang": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang/-/slang-0.14.0.tgz",
-      "integrity": "sha512-2VZCn/+SaAqlzRSVLuAf2j35BVIeSHbN1DQ9E1kwQSrXtVJTVzMogywLBvQE8hKKGTZIQV+Td9UV1qwxJYODVw==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang/-/slang-0.14.2.tgz",
+      "integrity": "sha512-3CiiJHuqGo5G9oDhRUDexFMlkguwSQMDcapZtJi+vz8x53HOwH4/ZwzwaNi1ZwKGnwT3fp9dxSzxrLYImFcZhA==",
       "requires": {
-        "@nomicfoundation/slang-darwin-arm64": "0.14.0",
-        "@nomicfoundation/slang-darwin-x64": "0.14.0",
-        "@nomicfoundation/slang-linux-arm64-gnu": "0.14.0",
-        "@nomicfoundation/slang-linux-arm64-musl": "0.14.0",
-        "@nomicfoundation/slang-linux-x64-gnu": "0.14.0",
-        "@nomicfoundation/slang-linux-x64-musl": "0.14.0",
-        "@nomicfoundation/slang-win32-arm64-msvc": "0.14.0",
-        "@nomicfoundation/slang-win32-ia32-msvc": "0.14.0",
-        "@nomicfoundation/slang-win32-x64-msvc": "0.14.0"
+        "@nomicfoundation/slang-darwin-arm64": "0.14.2",
+        "@nomicfoundation/slang-darwin-x64": "0.14.2",
+        "@nomicfoundation/slang-linux-arm64-gnu": "0.14.2",
+        "@nomicfoundation/slang-linux-arm64-musl": "0.14.2",
+        "@nomicfoundation/slang-linux-x64-gnu": "0.14.2",
+        "@nomicfoundation/slang-linux-x64-musl": "0.14.2",
+        "@nomicfoundation/slang-win32-arm64-msvc": "0.14.2",
+        "@nomicfoundation/slang-win32-ia32-msvc": "0.14.2",
+        "@nomicfoundation/slang-win32-x64-msvc": "0.14.2"
       }
     },
     "@nomicfoundation/slang-darwin-arm64": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-arm64/-/slang-darwin-arm64-0.14.0.tgz",
-      "integrity": "sha512-bNDMnVSdw4QuScg9nonGlvEWKpZHWWcMKWrrnfvFAL1YKfsmZ3bhQqfD4LiCHSxuizxFoAKDiSaXhu/IRTalhw==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-arm64/-/slang-darwin-arm64-0.14.2.tgz",
+      "integrity": "sha512-ElMGNZHSywlfkP3X9pyym0vaNANSp33Ty/VrYXKABubj2w7+clrzPYQKSjnWv1D7qpJuZwe7SOiHCNCkTEyrVw==",
       "optional": true
     },
     "@nomicfoundation/slang-darwin-x64": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-x64/-/slang-darwin-x64-0.14.0.tgz",
-      "integrity": "sha512-xMBg+K1ocfN/LRy5PByc+Ww58EPdrEgLeAOiLMDgwVIq2lxFN8QM2n+WHKRYvyYXjPRW414QYiR2QfNhUM+1jg==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-x64/-/slang-darwin-x64-0.14.2.tgz",
+      "integrity": "sha512-k1LjajxhsU3T0jYmTYIs8S1QAERyOz3YYNL/zhOiah2x8X/jgjHY7dAgkWABzkViQBHUKmc7x8+iUV37h6SuFA==",
       "optional": true
     },
     "@nomicfoundation/slang-linux-arm64-gnu": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-gnu/-/slang-linux-arm64-gnu-0.14.0.tgz",
-      "integrity": "sha512-sw9XMVIuPkyyra3rNQZpVVFK3EMl4lxMAIViGu7IillbYjOWEPlHtNwCF4oO8ST5Hg9GhuodXp+Drjin8Ec8WQ==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-gnu/-/slang-linux-arm64-gnu-0.14.2.tgz",
+      "integrity": "sha512-G5ccD82NlF3ijFS1tqlidL2nlfXoFRG2tFPMFTk7etnPElwi4Tq8O0ajZkel2TYiO4LcKxPlfwpVuVR4AbT58Q==",
       "optional": true
     },
     "@nomicfoundation/slang-linux-arm64-musl": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-musl/-/slang-linux-arm64-musl-0.14.0.tgz",
-      "integrity": "sha512-zs/frMl6TyW0w6kt/dDIoRbNBWZ8En3K70ijBnd5DUpOG2zIbbvF+cad9aVaLwHJ1ApPq4+sahk4y+LjqLgqQQ==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-musl/-/slang-linux-arm64-musl-0.14.2.tgz",
+      "integrity": "sha512-fNeIshoExmikHokUDVbqfV9gDZxtGlJ5cFs3TdwxwWgqEp56V1ByWJ4wGPDQBTwv2p2fil/97LyxnOenHXeOkQ==",
       "optional": true
     },
     "@nomicfoundation/slang-linux-x64-gnu": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-gnu/-/slang-linux-x64-gnu-0.14.0.tgz",
-      "integrity": "sha512-CD1sJkcsrYjXfB74zJkXOYHUMNLrKjJBs2CSgXRsD94leSJQX7RLlGdWA1pLfUtbXcrTVA7Qivuylk0UNqq+zA==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-gnu/-/slang-linux-x64-gnu-0.14.2.tgz",
+      "integrity": "sha512-kixwVCuvq1TVemPp7Cm6VbpJKmbIcPxhHK4CatOn/Nxm2p35iSBPn/E5OiqwPTjHk+nD684WnuOsZGEvf9NKlg==",
       "optional": true
     },
     "@nomicfoundation/slang-linux-x64-musl": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-musl/-/slang-linux-x64-musl-0.14.0.tgz",
-      "integrity": "sha512-H3wmgZLXexeXPtFBrdW5QIsOiQXbtTqRRL8HGO9LOEIaPcLE/6HqFeZ46udFhm82/dIR6BFH6X6ADZoCHzGJHA==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-musl/-/slang-linux-x64-musl-0.14.2.tgz",
+      "integrity": "sha512-oX9ihC3nYyZjG19GxfFthiZJTZkOhYAqyI7YhbPh0BWfAqf3/FxADQkv+4cXv3sb+SsXo4yOVhgVuOq75qWxUw==",
       "optional": true
     },
     "@nomicfoundation/slang-win32-arm64-msvc": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-arm64-msvc/-/slang-win32-arm64-msvc-0.14.0.tgz",
-      "integrity": "sha512-cLrZEiGY2LqNDuaWuoHc3s188H8MmtexB2qo7z8d3t1wwvVcwUE7k7hwyIyMy01BV11AmUy27l+qpk7WEVxocg==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-arm64-msvc/-/slang-win32-arm64-msvc-0.14.2.tgz",
+      "integrity": "sha512-VMH2xc0q+iZQ9oGA2NhecYh6GhJAf+M2a+h0IKU+OTbmREUL1nH12huc5wmFzWSdgKyJAyVidCQvcLhgYSoSkw==",
       "optional": true
     },
     "@nomicfoundation/slang-win32-ia32-msvc": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-ia32-msvc/-/slang-win32-ia32-msvc-0.14.0.tgz",
-      "integrity": "sha512-jKYmrvjcGnqE34iC5eJnQvNExI5QdydP28hZByRGIaDQqXW0dCfbKsSnG7zbhI794bIabO1ton6PxHRCOX9XnQ==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-ia32-msvc/-/slang-win32-ia32-msvc-0.14.2.tgz",
+      "integrity": "sha512-z99gbFnAGyA8D/yZoos8S7/VgP0SHrKMt8RcAHluC1UIQ0EnNYJrGwhVVTWPv6PPphoz11nF/UyUZ2cVsBcy0Q==",
       "optional": true
     },
     "@nomicfoundation/slang-win32-x64-msvc": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-x64-msvc/-/slang-win32-x64-msvc-0.14.0.tgz",
-      "integrity": "sha512-iPxH1ElgTDDrEq8pu9YZikV2yTNWjfXiFOvWbvyXhAcv7UWqkFnz04eGeY1Fu4VTh58jNso+BiSaRkP8liyBbg==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-x64-msvc/-/slang-win32-x64-msvc-0.14.2.tgz",
+      "integrity": "sha512-Av9WnISDikCW+tFf8E8+CE5bGM3K1FRC4yXnZnpPlQmQRIk4RkYQYzFMrAtDdO5NUmgSgVoCDlld5DkQ6vCQxg==",
       "optional": true
     },
     "@nomicfoundation/solidity-analyzer": {
@@ -14959,7 +14959,7 @@
       "version": "file:server",
       "requires": {
         "@istanbuljs/nyc-config-typescript": "1.0.2",
-        "@nomicfoundation/slang": "0.14.0",
+        "@nomicfoundation/slang": "0.14.2",
         "@nomicfoundation/solidity-analyzer": "0.1.1",
         "@sentry/node": "7.32.1",
         "@sentry/tracing": "7.32.1",

--- a/server/package.json
+++ b/server/package.json
@@ -87,7 +87,7 @@
     "yaml": "^2.2.1"
   },
   "dependencies": {
-    "@nomicfoundation/slang": "0.14.0",
+    "@nomicfoundation/slang": "0.14.2",
     "@nomicfoundation/solidity-analyzer": "0.1.1"
   }
 }


### PR DESCRIPTION
This pulls in support for latest Solidity 0.8.25 and contains a bugfix that allows to correctly parse `f.address` for function pointers in the assembly; other than that, it's passing Sanctuary tests for mainnet and popular L2s like Arbitrum, BSC, Polygon or Optimism.

Hopefully this will get rid of the "Unsupported version" errors in Sentry that we were receiving lately; also the language coverage should be fairly complete now.