### PR TITLE
chore: update labelling workflow

### DIFF
--- a/.github/workflows/add-label-to-new-issue.yml
+++ b/.github/workflows/add-label-to-new-issue.yml
@@ -3,7 +3,7 @@ name: Add label to new issue
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:
@@ -13,13 +13,10 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: "18.x"
-
       - uses: actions/github-script@v7
+        id: set-ready-or-triaging-label
         with:
+          retries: 3
           script: |
             const issue = await github.rest.issues.get({
               owner: context.issue.owner,
@@ -32,11 +29,15 @@ jobs:
             );
 
             if (statusLabel === undefined) {
+              console.log("Author association:", issue.data.author_association);
+              const isCollaborator = ["OWNER", "MEMBER", "COLLABORATOR"].includes(issue.data.author_association)
+              const label = isCollaborator ? "status:ready" : "status:triaging"
+
               await github.rest.issues.addLabels({
                 owner: context.issue.owner,
                 repo: context.issue.repo,
                 issue_number: context.issue.number,
-                labels: ["status:triaging"]
+                labels: [label]
               });
             } else {
               console.log(`Issue already has a status: ${statusLabel.name}`);


### PR DESCRIPTION
Update the labelling workflow to bring in the latest additions from Hardhat.

The update:

* Updates to `github-script@v7`
* Switches from `pull_request` to `pull_request_target`, this should resolve failures from external PRs, note however this has security implications - though the same tradeoff we have made in Hardhat
* Add a retry 
