### PR TITLE
chore: improve sentry sampling

### DIFF
--- a/server/src/telemetry/SentryServerTelemetry.ts
+++ b/server/src/telemetry/SentryServerTelemetry.ts
@@ -47,9 +47,17 @@ export class SentryServerTelemetry implements Telemetry {
       throw new Error("Tracing not loaded");
     }
 
+    const traceSampleRate = this.serverState.env === "development" ? 1 : 0.001;
+
     Sentry.init({
       dsn: this.dsn,
-      tracesSampleRate: serverState.env === "development" ? 1 : 0.001,
+      tracesSampler: ({ transactionContext: { name } }) => {
+        if (name === "indexing") {
+          return 1;
+        }
+
+        return traceSampleRate;
+      },
       release:
         extensionName !== undefined && extensionVersion !== undefined
           ? `${extensionName}@${extensionVersion}`


### PR DESCRIPTION
Sample most traces as before (1 in development, 0.001 in production), but exclude the `indexing` trace, which won't be sampled.

Indexing happens once per session, and is being used to provide feature flag information. That info is significantly less useful if it is sampled.

The fine grained control is provided by swapping from a trace sampling rate to a trace sampling function, as described here: https://docs.sentry.io/platforms/javascript/guides/capacitor/configuration/sampling/#setting-a-sampling-function
