### PR TITLE
chore: Add markdown syntax support - Issue 572

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -131,10 +131,10 @@
         "scopeName": "markdown.solidity.codeblock",
         "path": "./syntaxes/solidity-markdown-injection.json",
         "injectTo": [
-            "text.html.markdown"
+          "text.html.markdown"
         ],
         "embeddedLanguages": {
-            "meta.embedded.block.solidity": "solidity"
+          "meta.embedded.block.solidity": "solidity"
         }
       }
     ],

--- a/client/package.json
+++ b/client/package.json
@@ -115,6 +115,9 @@
           ".sol"
         ],
         "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "solidity-markdown-injection"
       }
     ],
     "grammars": [
@@ -122,6 +125,17 @@
         "language": "solidity",
         "scopeName": "source.solidity",
         "path": "./syntaxes/solidity.json"
+      },
+      {
+        "language": "solidity-markdown-injection",
+        "scopeName": "markdown.solidity.codeblock",
+        "path": "./syntaxes/solidity-markdown-injection.json",
+        "injectTo": [
+            "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+            "meta.embedded.block.solidity": "solidity"
+        }
       }
     ],
     "snippets": [

--- a/client/syntaxes/solidity-markdown-injection.json
+++ b/client/syntaxes/solidity-markdown-injection.json
@@ -1,0 +1,45 @@
+{
+  "fileTypes": [],
+  "injectionSelector": "L:text.html.markdown",
+  "patterns": [
+      {
+          "include": "#solidity-code-block"
+      }
+  ],
+  "repository": {
+      "solidity-code-block": {
+          "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(solidity)(\\s+[^`~]*)?$)",
+          "name": "markup.fenced_code.block.markdown",
+          "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+          "beginCaptures": {
+              "3": {
+                  "name": "punctuation.definition.markdown"
+              },
+              "4": {
+                  "name": "fenced_code.block.language.markdown"
+              },
+              "5": {
+                  "name": "fenced_code.block.language.attributes.markdown"
+              }
+          },
+          "endCaptures": {
+              "3": {
+                  "name": "punctuation.definition.markdown"
+              }
+          },
+          "patterns": [
+              {
+                  "begin": "(^|\\G)(\\s*)(.*)",
+                  "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+                  "contentName": "meta.embedded.block.solidity",
+                  "patterns": [
+                      {
+                          "include": "source.solidity"
+                      }
+                  ]
+              }
+          ]
+      }
+  },
+  "scopeName": "markdown.solidity.codeblock"
+}


### PR DESCRIPTION
<!--
Thank you for using **Solidity for Visual Studio Code by Nomic Foundation** and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

I added markdown syntax support that was requested based on the description from here https://github.com/NomicFoundation/hardhat-vscode/issues/572
I made sure to disable any solidity extension to recreate it
<img width="656" alt="Screenshot 2024-06-05 at 19 24 16" src="https://github.com/NomicFoundation/hardhat-vscode/assets/7786627/1ba15b21-801c-4946-8231-fda1e0442947">

After applying changes, while plugins are disabled

<img width="685" alt="Screenshot 2024-06-05 at 19 24 00" src="https://github.com/NomicFoundation/hardhat-vscode/assets/7786627/b2b137a6-b009-44fe-8a49-c2788dae01e3">


