### PR TITLE
remove duplicate natspec syntax highlighter

### DIFF
--- a/client/syntaxes/solidity.json
+++ b/client/syntaxes/solidity.json
@@ -147,10 +147,6 @@
       "match": "(@custom:[a-z]+(-[a-z]+)*)\\b",
       "name": "storage.type.custom.natspec"
     },
-    "natspec-tag-custom": {
-      "match": "(@custom:[a-z]+(-[a-z]+)*)\\b",
-      "name": "storage.type.custom.natspec"
-    },
     "comment": {
       "patterns": [
         {


### PR DESCRIPTION
The duplicate entry is invalid JSON. Looks like the duplicate was added a while back in #169