### PR TITLE
Update Slang to `0.15.1`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,11 @@
 on:
   push:
     branches:
-      - main
+      - "*"
   pull_request:
     branches:
       - "*"
   workflow_dispatch:
-    
 
 jobs:
   build:
@@ -24,10 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "18.x"
-
-      - name: npm latest
-        run: npm i -g npm@8 && npm i -g npm@latest
+          node-version: "latest"
 
       - name: Cache Node Modules
         id: cache-node-modules
@@ -35,19 +31,12 @@ jobs:
         env:
           cache-name: cache-node-modules
         with:
-          path: |
-            node_modules
-            client/node_modules
-            server/node_modules
-            coc/node_modules
-            test/e2e/node_modules
-            test/protocol/node_modules
-            test/protocol/projects/hardhat/node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+          path: "**/node_modules"
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package.json', '**/package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: npm install
+        run: npm ci
 
       - name: Lint
         run: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
     },
     "client": {
       "name": "hardhat-solidity",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "@nomicfoundation/solidity-language-server": "0.6.16",
@@ -142,10 +142,10 @@
     },
     "coc": {
       "name": "@nomicfoundation/coc-solidity",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/solidity-language-server": "0.8.2"
+        "@nomicfoundation/solidity-language-server": "0.8.3"
       },
       "devDependencies": {
         "coc.nvim": "^0.0.80",
@@ -11698,7 +11698,7 @@
     },
     "server": {
       "name": "@nomicfoundation/solidity-language-server",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "@nomicfoundation/slang": "0.14.2",
@@ -14039,7 +14039,7 @@
     "@nomicfoundation/coc-solidity": {
       "version": "file:coc",
       "requires": {
-        "@nomicfoundation/solidity-language-server": "0.8.2",
+        "@nomicfoundation/solidity-language-server": "0.8.3",
         "coc.nvim": "^0.0.80",
         "esbuild": "^0.16.0",
         "eslint": "^7.23.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2538,155 +2538,102 @@
       }
     },
     "node_modules/@nomicfoundation/slang": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang/-/slang-0.14.2.tgz",
-      "integrity": "sha512-3CiiJHuqGo5G9oDhRUDexFMlkguwSQMDcapZtJi+vz8x53HOwH4/ZwzwaNi1ZwKGnwT3fp9dxSzxrLYImFcZhA==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang/-/slang-0.15.1.tgz",
+      "integrity": "sha512-th7nxRWRXf583uHpWUCd8U7BYxIqJX2f3oZLff/mlPkqIr45pD2hLT/o00eCjrBIR8N7vybUULZg1CeThGNk7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nomicfoundation/slang-darwin-arm64": "0.15.1",
+        "@nomicfoundation/slang-darwin-x64": "0.15.1",
+        "@nomicfoundation/slang-linux-arm64-gnu": "0.15.1",
+        "@nomicfoundation/slang-linux-arm64-musl": "0.15.1",
+        "@nomicfoundation/slang-linux-x64-gnu": "0.15.1",
+        "@nomicfoundation/slang-linux-x64-musl": "0.15.1",
+        "@nomicfoundation/slang-win32-arm64-msvc": "0.15.1",
+        "@nomicfoundation/slang-win32-ia32-msvc": "0.15.1",
+        "@nomicfoundation/slang-win32-x64-msvc": "0.15.1"
+      },
       "engines": {
         "node": ">= 10"
-      },
-      "optionalDependencies": {
-        "@nomicfoundation/slang-darwin-arm64": "0.14.2",
-        "@nomicfoundation/slang-darwin-x64": "0.14.2",
-        "@nomicfoundation/slang-linux-arm64-gnu": "0.14.2",
-        "@nomicfoundation/slang-linux-arm64-musl": "0.14.2",
-        "@nomicfoundation/slang-linux-x64-gnu": "0.14.2",
-        "@nomicfoundation/slang-linux-x64-musl": "0.14.2",
-        "@nomicfoundation/slang-win32-arm64-msvc": "0.14.2",
-        "@nomicfoundation/slang-win32-ia32-msvc": "0.14.2",
-        "@nomicfoundation/slang-win32-x64-msvc": "0.14.2"
       }
     },
     "node_modules/@nomicfoundation/slang-darwin-arm64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-arm64/-/slang-darwin-arm64-0.14.2.tgz",
-      "integrity": "sha512-ElMGNZHSywlfkP3X9pyym0vaNANSp33Ty/VrYXKABubj2w7+clrzPYQKSjnWv1D7qpJuZwe7SOiHCNCkTEyrVw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-arm64/-/slang-darwin-arm64-0.15.1.tgz",
+      "integrity": "sha512-taPHlCUNNztQZJze9OlZFK9cZH8Ut4Ih4QJQo5CKebXx9vWOUtmSBfKv/M2P8hiV/iL7Q5sPwR7HY9uZYnb49Q==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@nomicfoundation/slang-darwin-x64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-x64/-/slang-darwin-x64-0.14.2.tgz",
-      "integrity": "sha512-k1LjajxhsU3T0jYmTYIs8S1QAERyOz3YYNL/zhOiah2x8X/jgjHY7dAgkWABzkViQBHUKmc7x8+iUV37h6SuFA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-x64/-/slang-darwin-x64-0.15.1.tgz",
+      "integrity": "sha512-kgZh5KQe/UcbFqn1EpyrvBuT8E6I1kWSgGPtO25t90zAqFv23sMUPdn7wLpMjngkD+quIIgrzQGUtupS5YYEig==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@nomicfoundation/slang-linux-arm64-gnu": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-gnu/-/slang-linux-arm64-gnu-0.14.2.tgz",
-      "integrity": "sha512-G5ccD82NlF3ijFS1tqlidL2nlfXoFRG2tFPMFTk7etnPElwi4Tq8O0ajZkel2TYiO4LcKxPlfwpVuVR4AbT58Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-gnu/-/slang-linux-arm64-gnu-0.15.1.tgz",
+      "integrity": "sha512-Iw8mepaccKRWllPU9l+hoe88LN9fScC0Px3nFeNQy26qk1ueO0tjovP1dhTvmGwHUxacOYPqhQTUn7Iu0oxNoQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@nomicfoundation/slang-linux-arm64-musl": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-musl/-/slang-linux-arm64-musl-0.14.2.tgz",
-      "integrity": "sha512-fNeIshoExmikHokUDVbqfV9gDZxtGlJ5cFs3TdwxwWgqEp56V1ByWJ4wGPDQBTwv2p2fil/97LyxnOenHXeOkQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-musl/-/slang-linux-arm64-musl-0.15.1.tgz",
+      "integrity": "sha512-zcesdQZwRgrT7ND+3TZUjRK/uGF20EfhEfCg8ZMhrb4Q7XaK1JvtHazIs03TV8Jcs30TPkEXks8Qi0Zdfy4RuA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@nomicfoundation/slang-linux-x64-gnu": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-gnu/-/slang-linux-x64-gnu-0.14.2.tgz",
-      "integrity": "sha512-kixwVCuvq1TVemPp7Cm6VbpJKmbIcPxhHK4CatOn/Nxm2p35iSBPn/E5OiqwPTjHk+nD684WnuOsZGEvf9NKlg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-gnu/-/slang-linux-x64-gnu-0.15.1.tgz",
+      "integrity": "sha512-FSmAnzKm58TFIwx4r/wOZtqfDx0nI6AfvnOh8kLDF5OxpWW3r0q9fq8lyaUReg9C/ZgCZRBn+m5WGrNKCZcvPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@nomicfoundation/slang-linux-x64-musl": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-musl/-/slang-linux-x64-musl-0.14.2.tgz",
-      "integrity": "sha512-oX9ihC3nYyZjG19GxfFthiZJTZkOhYAqyI7YhbPh0BWfAqf3/FxADQkv+4cXv3sb+SsXo4yOVhgVuOq75qWxUw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-musl/-/slang-linux-x64-musl-0.15.1.tgz",
+      "integrity": "sha512-hnoA/dgeHQ8aS0SReABYkxf0d/Q6DdaKsaYv6ev21wyQA7TROxT1X3nekECLGu1GYLML8pzvD9vyAMBRKOkkyg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@nomicfoundation/slang-win32-arm64-msvc": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-arm64-msvc/-/slang-win32-arm64-msvc-0.14.2.tgz",
-      "integrity": "sha512-VMH2xc0q+iZQ9oGA2NhecYh6GhJAf+M2a+h0IKU+OTbmREUL1nH12huc5wmFzWSdgKyJAyVidCQvcLhgYSoSkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-arm64-msvc/-/slang-win32-arm64-msvc-0.15.1.tgz",
+      "integrity": "sha512-2H0chHQ4uTh4l4UxN5fIVHR5mKaL5mfYTID6kxxxv2+KAh68EpYWwxLlkS5So90R2WcuPvFvTVKLm/uRo4h4dg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@nomicfoundation/slang-win32-ia32-msvc": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-ia32-msvc/-/slang-win32-ia32-msvc-0.14.2.tgz",
-      "integrity": "sha512-z99gbFnAGyA8D/yZoos8S7/VgP0SHrKMt8RcAHluC1UIQ0EnNYJrGwhVVTWPv6PPphoz11nF/UyUZ2cVsBcy0Q==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-ia32-msvc/-/slang-win32-ia32-msvc-0.15.1.tgz",
+      "integrity": "sha512-CVZWBnbpFlVBg/m7bsiw70jY3p9TGH9vxq0vLEEJ56yK+QPosxPrKMcADojtGjIOjWjPSZ+lCoo5ilnW0a249g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@nomicfoundation/slang-win32-x64-msvc": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-x64-msvc/-/slang-win32-x64-msvc-0.14.2.tgz",
-      "integrity": "sha512-Av9WnISDikCW+tFf8E8+CE5bGM3K1FRC4yXnZnpPlQmQRIk4RkYQYzFMrAtDdO5NUmgSgVoCDlld5DkQ6vCQxg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-x64-msvc/-/slang-win32-x64-msvc-0.15.1.tgz",
+      "integrity": "sha512-cyER8M1fdBTzIfihy55d4LGGlN/eQxDqfRUTXgJf1VvNR98tRB0Q3nBfyh5PK2yP98B4lMt3RJYDqTQu+dOVDA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
@@ -11701,7 +11648,7 @@
       "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/slang": "0.14.2",
+        "@nomicfoundation/slang": "0.15.1",
         "@nomicfoundation/solidity-analyzer": "0.1.1"
       },
       "bin": {
@@ -14291,74 +14238,65 @@
       }
     },
     "@nomicfoundation/slang": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang/-/slang-0.14.2.tgz",
-      "integrity": "sha512-3CiiJHuqGo5G9oDhRUDexFMlkguwSQMDcapZtJi+vz8x53HOwH4/ZwzwaNi1ZwKGnwT3fp9dxSzxrLYImFcZhA==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang/-/slang-0.15.1.tgz",
+      "integrity": "sha512-th7nxRWRXf583uHpWUCd8U7BYxIqJX2f3oZLff/mlPkqIr45pD2hLT/o00eCjrBIR8N7vybUULZg1CeThGNk7g==",
       "requires": {
-        "@nomicfoundation/slang-darwin-arm64": "0.14.2",
-        "@nomicfoundation/slang-darwin-x64": "0.14.2",
-        "@nomicfoundation/slang-linux-arm64-gnu": "0.14.2",
-        "@nomicfoundation/slang-linux-arm64-musl": "0.14.2",
-        "@nomicfoundation/slang-linux-x64-gnu": "0.14.2",
-        "@nomicfoundation/slang-linux-x64-musl": "0.14.2",
-        "@nomicfoundation/slang-win32-arm64-msvc": "0.14.2",
-        "@nomicfoundation/slang-win32-ia32-msvc": "0.14.2",
-        "@nomicfoundation/slang-win32-x64-msvc": "0.14.2"
+        "@nomicfoundation/slang-darwin-arm64": "0.15.1",
+        "@nomicfoundation/slang-darwin-x64": "0.15.1",
+        "@nomicfoundation/slang-linux-arm64-gnu": "0.15.1",
+        "@nomicfoundation/slang-linux-arm64-musl": "0.15.1",
+        "@nomicfoundation/slang-linux-x64-gnu": "0.15.1",
+        "@nomicfoundation/slang-linux-x64-musl": "0.15.1",
+        "@nomicfoundation/slang-win32-arm64-msvc": "0.15.1",
+        "@nomicfoundation/slang-win32-ia32-msvc": "0.15.1",
+        "@nomicfoundation/slang-win32-x64-msvc": "0.15.1"
       }
     },
     "@nomicfoundation/slang-darwin-arm64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-arm64/-/slang-darwin-arm64-0.14.2.tgz",
-      "integrity": "sha512-ElMGNZHSywlfkP3X9pyym0vaNANSp33Ty/VrYXKABubj2w7+clrzPYQKSjnWv1D7qpJuZwe7SOiHCNCkTEyrVw==",
-      "optional": true
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-arm64/-/slang-darwin-arm64-0.15.1.tgz",
+      "integrity": "sha512-taPHlCUNNztQZJze9OlZFK9cZH8Ut4Ih4QJQo5CKebXx9vWOUtmSBfKv/M2P8hiV/iL7Q5sPwR7HY9uZYnb49Q=="
     },
     "@nomicfoundation/slang-darwin-x64": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-x64/-/slang-darwin-x64-0.14.2.tgz",
-      "integrity": "sha512-k1LjajxhsU3T0jYmTYIs8S1QAERyOz3YYNL/zhOiah2x8X/jgjHY7dAgkWABzkViQBHUKmc7x8+iUV37h6SuFA==",
-      "optional": true
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-x64/-/slang-darwin-x64-0.15.1.tgz",
+      "integrity": "sha512-kgZh5KQe/UcbFqn1EpyrvBuT8E6I1kWSgGPtO25t90zAqFv23sMUPdn7wLpMjngkD+quIIgrzQGUtupS5YYEig=="
     },
     "@nomicfoundation/slang-linux-arm64-gnu": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-gnu/-/slang-linux-arm64-gnu-0.14.2.tgz",
-      "integrity": "sha512-G5ccD82NlF3ijFS1tqlidL2nlfXoFRG2tFPMFTk7etnPElwi4Tq8O0ajZkel2TYiO4LcKxPlfwpVuVR4AbT58Q==",
-      "optional": true
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-gnu/-/slang-linux-arm64-gnu-0.15.1.tgz",
+      "integrity": "sha512-Iw8mepaccKRWllPU9l+hoe88LN9fScC0Px3nFeNQy26qk1ueO0tjovP1dhTvmGwHUxacOYPqhQTUn7Iu0oxNoQ=="
     },
     "@nomicfoundation/slang-linux-arm64-musl": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-musl/-/slang-linux-arm64-musl-0.14.2.tgz",
-      "integrity": "sha512-fNeIshoExmikHokUDVbqfV9gDZxtGlJ5cFs3TdwxwWgqEp56V1ByWJ4wGPDQBTwv2p2fil/97LyxnOenHXeOkQ==",
-      "optional": true
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-musl/-/slang-linux-arm64-musl-0.15.1.tgz",
+      "integrity": "sha512-zcesdQZwRgrT7ND+3TZUjRK/uGF20EfhEfCg8ZMhrb4Q7XaK1JvtHazIs03TV8Jcs30TPkEXks8Qi0Zdfy4RuA=="
     },
     "@nomicfoundation/slang-linux-x64-gnu": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-gnu/-/slang-linux-x64-gnu-0.14.2.tgz",
-      "integrity": "sha512-kixwVCuvq1TVemPp7Cm6VbpJKmbIcPxhHK4CatOn/Nxm2p35iSBPn/E5OiqwPTjHk+nD684WnuOsZGEvf9NKlg==",
-      "optional": true
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-gnu/-/slang-linux-x64-gnu-0.15.1.tgz",
+      "integrity": "sha512-FSmAnzKm58TFIwx4r/wOZtqfDx0nI6AfvnOh8kLDF5OxpWW3r0q9fq8lyaUReg9C/ZgCZRBn+m5WGrNKCZcvPQ=="
     },
     "@nomicfoundation/slang-linux-x64-musl": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-musl/-/slang-linux-x64-musl-0.14.2.tgz",
-      "integrity": "sha512-oX9ihC3nYyZjG19GxfFthiZJTZkOhYAqyI7YhbPh0BWfAqf3/FxADQkv+4cXv3sb+SsXo4yOVhgVuOq75qWxUw==",
-      "optional": true
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-musl/-/slang-linux-x64-musl-0.15.1.tgz",
+      "integrity": "sha512-hnoA/dgeHQ8aS0SReABYkxf0d/Q6DdaKsaYv6ev21wyQA7TROxT1X3nekECLGu1GYLML8pzvD9vyAMBRKOkkyg=="
     },
     "@nomicfoundation/slang-win32-arm64-msvc": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-arm64-msvc/-/slang-win32-arm64-msvc-0.14.2.tgz",
-      "integrity": "sha512-VMH2xc0q+iZQ9oGA2NhecYh6GhJAf+M2a+h0IKU+OTbmREUL1nH12huc5wmFzWSdgKyJAyVidCQvcLhgYSoSkw==",
-      "optional": true
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-arm64-msvc/-/slang-win32-arm64-msvc-0.15.1.tgz",
+      "integrity": "sha512-2H0chHQ4uTh4l4UxN5fIVHR5mKaL5mfYTID6kxxxv2+KAh68EpYWwxLlkS5So90R2WcuPvFvTVKLm/uRo4h4dg=="
     },
     "@nomicfoundation/slang-win32-ia32-msvc": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-ia32-msvc/-/slang-win32-ia32-msvc-0.14.2.tgz",
-      "integrity": "sha512-z99gbFnAGyA8D/yZoos8S7/VgP0SHrKMt8RcAHluC1UIQ0EnNYJrGwhVVTWPv6PPphoz11nF/UyUZ2cVsBcy0Q==",
-      "optional": true
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-ia32-msvc/-/slang-win32-ia32-msvc-0.15.1.tgz",
+      "integrity": "sha512-CVZWBnbpFlVBg/m7bsiw70jY3p9TGH9vxq0vLEEJ56yK+QPosxPrKMcADojtGjIOjWjPSZ+lCoo5ilnW0a249g=="
     },
     "@nomicfoundation/slang-win32-x64-msvc": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-x64-msvc/-/slang-win32-x64-msvc-0.14.2.tgz",
-      "integrity": "sha512-Av9WnISDikCW+tFf8E8+CE5bGM3K1FRC4yXnZnpPlQmQRIk4RkYQYzFMrAtDdO5NUmgSgVoCDlld5DkQ6vCQxg==",
-      "optional": true
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-x64-msvc/-/slang-win32-x64-msvc-0.15.1.tgz",
+      "integrity": "sha512-cyER8M1fdBTzIfihy55d4LGGlN/eQxDqfRUTXgJf1VvNR98tRB0Q3nBfyh5PK2yP98B4lMt3RJYDqTQu+dOVDA=="
     },
     "@nomicfoundation/solidity-analyzer": {
       "version": "0.1.1",
@@ -14439,7 +14377,7 @@
       "version": "file:server",
       "requires": {
         "@istanbuljs/nyc-config-typescript": "1.0.2",
-        "@nomicfoundation/slang": "0.14.2",
+        "@nomicfoundation/slang": "0.15.1",
         "@nomicfoundation/solidity-analyzer": "0.1.1",
         "@sentry/node": "7.32.1",
         "@sentry/tracing": "7.32.1",

--- a/server/package.json
+++ b/server/package.json
@@ -87,7 +87,7 @@
     "yaml": "^2.2.1"
   },
   "dependencies": {
-    "@nomicfoundation/slang": "0.14.2",
+    "@nomicfoundation/slang": "0.15.1",
     "@nomicfoundation/solidity-analyzer": "0.1.1"
   }
 }

--- a/server/src/parser/slangHelpers.ts
+++ b/server/src/parser/slangHelpers.ts
@@ -1,24 +1,22 @@
-import { RuleNode, TokenNode } from "@nomicfoundation/slang/cst";
-import { RuleKind, TokenKind } from "@nomicfoundation/slang/kinds";
-import { TextRange } from "@nomicfoundation/slang/text_index";
+import { TextIndex, TextRange } from "@nomicfoundation/slang/text_index";
 import _ from "lodash";
-import { TextDocument } from "vscode-languageserver-textdocument";
-import { Range } from "vscode-languageserver-types";
+import { Range, Position } from "vscode-languageserver-types";
 import { Language } from "@nomicfoundation/slang/language";
 import semver from "semver";
 import { Logger } from "../utils/Logger";
 import { getPlatform } from "../utils/operatingSystem";
 
-export type SlangNode = RuleNode | TokenNode;
-export type NodeKind = RuleKind | TokenKind;
-
-export function slangToVSCodeRange(
-  doc: TextDocument,
-  slangRange: TextRange
-): Range {
+export function slangToVSCodeRange(range: TextRange): Range {
   return {
-    start: doc.positionAt(slangRange.start.utf16),
-    end: doc.positionAt(slangRange.end.utf16),
+    start: slangToVSCodePosition(range.start),
+    end: slangToVSCodePosition(range.end),
+  };
+}
+
+export function slangToVSCodePosition(position: TextIndex): Position {
+  return {
+    line: position.line,
+    character: position.column,
   };
 }
 

--- a/server/src/services/documentSymbol/SymbolFinder.ts
+++ b/server/src/services/documentSymbol/SymbolFinder.ts
@@ -1,41 +1,37 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { SymbolKind } from "vscode-languageserver-types";
 import _ from "lodash";
-import { TokenNode } from "@nomicfoundation/slang/cst";
-import { query, text_index } from "@nomicfoundation/slang/generated";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { TerminalNode } from "@nomicfoundation/slang/cst";
+import { TextRange } from "@nomicfoundation/slang/text_index";
+import { Query, QueryMatch } from "@nomicfoundation/slang/query";
 
 export interface SymbolData {
-  range: text_index.TextRange;
+  range: TextRange;
   name: string;
   symbolKind: SymbolKind;
 }
 
 export abstract class SymbolFinder {
-  public abstract ruleKind: RuleKind;
-  public abstract symbolKind: SymbolKind;
-  public abstract query: string;
+  public abstract readonly symbolKind: SymbolKind;
+  public abstract readonly query: Query;
 
-  public onResult(result: query.QueryResult): SymbolData | undefined {
+  public findSymbol(match: QueryMatch): SymbolData {
     // Ensure definition rule and name identifier are present
-    if (
-      result.bindings.definition === undefined ||
-      result.bindings.identifier === undefined
-    ) {
+    const { definition, identifier } = match.captures;
+
+    if (definition === undefined || identifier === undefined) {
       throw new Error(
-        `Bindings @definition or @identifier not present in query result. Query: ${
-          this.query
-        }, Bindings: ${JSON.stringify(result.bindings)}`
+        `Captures @definition or @identifier not present in query match.
+         Query: '${this.query}'
+         Captures: ${JSON.stringify(match, undefined, 2)}`
       );
     }
 
-    // Check that the rule kind matches
-    const definition = result.bindings.definition[0];
-
-    const identifierNode = result.bindings.identifier[0].node() as TokenNode;
+    const definitionCursor = definition[0];
+    const identifierNode = identifier[0].node() as TerminalNode;
 
     return {
-      range: definition.textRange,
+      range: definitionCursor.textRange,
       symbolKind: this.symbolKind,
       name: identifierNode.text,
     };

--- a/server/src/services/documentSymbol/finders/ConstantDefinition.ts
+++ b/server/src/services/documentSymbol/finders/ConstantDefinition.ts
@@ -1,16 +1,15 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { SymbolFinder } from "../SymbolFinder";
 
 export class ConstantDefinition extends SymbolFinder {
-  public ruleKind = RuleKind.ConstantDefinition;
-  public symbolKind = SymbolKind.Constant;
+  public override readonly symbolKind = SymbolKind.Constant;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    @definition [ConstantDefinition
       ...
-      @identifier [name:_]
+      @identifier name: [_]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/documentSymbol/finders/ConstructorDefinition.ts
+++ b/server/src/services/documentSymbol/finders/ConstructorDefinition.ts
@@ -1,16 +1,15 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { SymbolFinder } from "../SymbolFinder";
 
 export class ConstructorDefinition extends SymbolFinder {
-  public ruleKind = RuleKind.ConstructorDefinition;
-  public symbolKind = SymbolKind.Constructor;
+  public override readonly symbolKind = SymbolKind.Constructor;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    @definition [ConstructorDefinition
       ...
       @identifier [ConstructorKeyword]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/documentSymbol/finders/ContractDefinition.ts
+++ b/server/src/services/documentSymbol/finders/ContractDefinition.ts
@@ -1,16 +1,15 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { SymbolFinder } from "../SymbolFinder";
 
 export class ContractDefinition extends SymbolFinder {
-  public ruleKind = RuleKind.ContractDefinition;
-  public symbolKind = SymbolKind.Class;
+  public override readonly symbolKind = SymbolKind.Class;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    @definition [ContractDefinition
       ...
-      @identifier [name:_]
+      @identifier name: [_]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/documentSymbol/finders/EnumDefinition.ts
+++ b/server/src/services/documentSymbol/finders/EnumDefinition.ts
@@ -1,16 +1,15 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { SymbolFinder } from "../SymbolFinder";
 
 export class EnumDefinition extends SymbolFinder {
-  public ruleKind = RuleKind.EnumDefinition;
-  public symbolKind = SymbolKind.Enum;
+  public override readonly symbolKind = SymbolKind.Enum;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    @definition [EnumDefinition
       ...
-      @identifier [name:_]
+      @identifier name: [_]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/documentSymbol/finders/ErrorDefinition.ts
+++ b/server/src/services/documentSymbol/finders/ErrorDefinition.ts
@@ -1,16 +1,15 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { SymbolFinder } from "../SymbolFinder";
 
 export class ErrorDefinition extends SymbolFinder {
-  public ruleKind = RuleKind.ErrorDefinition;
-  public symbolKind = SymbolKind.Event;
+  public override readonly symbolKind = SymbolKind.Event;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    @definition [ErrorDefinition
       ...
-      @identifier [name:_]
+      @identifier name: [_]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/documentSymbol/finders/EventDefinition.ts
+++ b/server/src/services/documentSymbol/finders/EventDefinition.ts
@@ -1,16 +1,15 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { SymbolFinder } from "../SymbolFinder";
 
 export class EventDefinition extends SymbolFinder {
-  public ruleKind = RuleKind.EventDefinition;
-  public symbolKind = SymbolKind.Event;
+  public override readonly symbolKind = SymbolKind.Event;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    @definition [EventDefinition
       ...
-      @identifier [name:_]
+      @identifier name: [_]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/documentSymbol/finders/FallbackFunctionDefinition.ts
+++ b/server/src/services/documentSymbol/finders/FallbackFunctionDefinition.ts
@@ -1,16 +1,15 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { SymbolFinder } from "../SymbolFinder";
 
 export class FallbackFunctionDefinition extends SymbolFinder {
-  public ruleKind = RuleKind.FallbackFunctionDefinition;
-  public symbolKind = SymbolKind.Function;
+  public override readonly symbolKind = SymbolKind.Function;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    @definition [FallbackFunctionDefinition
       ...
       @identifier [FallbackKeyword]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/documentSymbol/finders/FunctionDefinition.ts
+++ b/server/src/services/documentSymbol/finders/FunctionDefinition.ts
@@ -1,20 +1,19 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { SymbolFinder } from "../SymbolFinder";
 
 export class FunctionDefinition extends SymbolFinder {
-  public ruleKind = RuleKind.FunctionDefinition;
-  public symbolKind = SymbolKind.Function;
+  public override readonly symbolKind = SymbolKind.Function;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    @definition [FunctionDefinition
       ...
       [FunctionName
         ...
-        @identifier [variant:_]
+        @identifier variant: [_]
         ...
       ]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/documentSymbol/finders/InterfaceDefinition.ts
+++ b/server/src/services/documentSymbol/finders/InterfaceDefinition.ts
@@ -1,16 +1,15 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { SymbolFinder } from "../SymbolFinder";
 
 export class InterfaceDefinition extends SymbolFinder {
-  public ruleKind = RuleKind.InterfaceDefinition;
-  public symbolKind = SymbolKind.Interface;
+  public override readonly symbolKind = SymbolKind.Interface;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    @definition [InterfaceDefinition
       ...
-      @identifier [name:_]
+      @identifier name: [_]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/documentSymbol/finders/LibraryDefinition.ts
+++ b/server/src/services/documentSymbol/finders/LibraryDefinition.ts
@@ -1,16 +1,15 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { SymbolFinder } from "../SymbolFinder";
 
 export class LibraryDefinition extends SymbolFinder {
-  public ruleKind = RuleKind.LibraryDefinition;
-  public symbolKind = SymbolKind.Class;
+  public override readonly symbolKind = SymbolKind.Class;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    @definition [LibraryDefinition
       ...
-      @identifier [name:_]
+      @identifier name: [_]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/documentSymbol/finders/ModifierDefinition.ts
+++ b/server/src/services/documentSymbol/finders/ModifierDefinition.ts
@@ -1,16 +1,15 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { SymbolFinder } from "../SymbolFinder";
 
 export class ModifierDefinition extends SymbolFinder {
-  public ruleKind = RuleKind.ModifierDefinition;
-  public symbolKind = SymbolKind.Function;
+  public override readonly symbolKind = SymbolKind.Function;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    @definition [ModifierDefinition
       ...
-      @identifier [name:_]
+      @identifier name: [_]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/documentSymbol/finders/ReceiveFunctionDefinition.ts
+++ b/server/src/services/documentSymbol/finders/ReceiveFunctionDefinition.ts
@@ -1,16 +1,15 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { SymbolFinder } from "../SymbolFinder";
 
 export class ReceiveFunctionDefinition extends SymbolFinder {
-  public ruleKind = RuleKind.ReceiveFunctionDefinition;
-  public symbolKind = SymbolKind.Function;
+  public override readonly symbolKind = SymbolKind.Function;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    @definition [ReceiveFunctionDefinition
       ...
       @identifier [ReceiveKeyword]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/documentSymbol/finders/StateVariableDefinition.ts
+++ b/server/src/services/documentSymbol/finders/StateVariableDefinition.ts
@@ -1,16 +1,15 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { SymbolFinder } from "../SymbolFinder";
 
 export class StateVariableDefinition extends SymbolFinder {
-  public ruleKind = RuleKind.StateVariableDefinition;
-  public symbolKind = SymbolKind.Property;
+  public override readonly symbolKind = SymbolKind.Property;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    @definition [StateVariableDefinition
       ...
-      @identifier [name:_]
+      @identifier name: [_]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/documentSymbol/finders/StructDefinition.ts
+++ b/server/src/services/documentSymbol/finders/StructDefinition.ts
@@ -1,16 +1,15 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { SymbolFinder } from "../SymbolFinder";
 
 export class StructDefinition extends SymbolFinder {
-  public ruleKind = RuleKind.StructDefinition;
-  public symbolKind = SymbolKind.Struct;
+  public override readonly symbolKind = SymbolKind.Struct;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    @definition [StructDefinition
       ...
-      @identifier [name:_]
+      @identifier name: [_]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/documentSymbol/finders/StructMember.ts
+++ b/server/src/services/documentSymbol/finders/StructMember.ts
@@ -1,16 +1,15 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { SymbolFinder } from "../SymbolFinder";
 
 export class StructMember extends SymbolFinder {
-  public ruleKind = RuleKind.StructMember;
-  public symbolKind = SymbolKind.Property;
+  public override readonly symbolKind = SymbolKind.Property;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    @definition [StructMember
       ...
-      @identifier [name:_]
+      @identifier name: [_]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/documentSymbol/finders/UnnamedFunctionDefinition.ts
+++ b/server/src/services/documentSymbol/finders/UnnamedFunctionDefinition.ts
@@ -1,16 +1,15 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { SymbolFinder } from "../SymbolFinder";
 
 export class UnnamedFunctionDefinition extends SymbolFinder {
-  public ruleKind = RuleKind.UnnamedFunctionDefinition;
-  public symbolKind = SymbolKind.Function;
+  public override readonly symbolKind = SymbolKind.Function;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    @definition [UnnamedFunctionDefinition
       ...
       @identifier [FunctionKeyword]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/documentSymbol/finders/UserDefinedValueTypeDefinition.ts
+++ b/server/src/services/documentSymbol/finders/UserDefinedValueTypeDefinition.ts
@@ -1,16 +1,15 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { SymbolFinder } from "../SymbolFinder";
 
 export class UserDefinedValueTypeDefinition extends SymbolFinder {
-  public ruleKind = RuleKind.UserDefinedValueTypeDefinition;
-  public symbolKind = SymbolKind.TypeParameter;
+  public override readonly symbolKind = SymbolKind.TypeParameter;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    @definition [UserDefinedValueTypeDefinition
       ...
-      @identifier [name:_]
+      @identifier name: [_]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/documentSymbol/finders/VariableDeclarationStatement.ts
+++ b/server/src/services/documentSymbol/finders/VariableDeclarationStatement.ts
@@ -1,16 +1,15 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { SymbolFinder } from "../SymbolFinder";
 
 export class VariableDeclarationStatement extends SymbolFinder {
-  public ruleKind = RuleKind.VariableDeclarationStatement;
-  public symbolKind = SymbolKind.Variable;
+  public override readonly symbolKind = SymbolKind.Variable;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    @definition [VariableDeclarationStatement
       ...
-      @identifier [name:_]
+      @identifier name: [_]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/documentSymbol/finders/YulFunctionDefinition.ts
+++ b/server/src/services/documentSymbol/finders/YulFunctionDefinition.ts
@@ -1,16 +1,15 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { SymbolFinder } from "../SymbolFinder";
 
 export class YulFunctionDefinition extends SymbolFinder {
-  public ruleKind = RuleKind.YulFunctionDefinition;
-  public symbolKind = SymbolKind.Function;
+  public override readonly symbolKind = SymbolKind.Function;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    @definition [YulFunctionDefinition
       ...
-      @identifier [name:_]
+      @identifier name: [_]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/semanticHighlight/SemanticTokensBuilder.ts
+++ b/server/src/services/semanticHighlight/SemanticTokensBuilder.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { text_index } from "@nomicfoundation/slang/generated";
+import { TextRange } from "@nomicfoundation/slang/text_index";
 import { getTokenTypeIndex } from "./tokenTypes";
 
 // Helps building a SemanticTokens response by providing slang nodes and supported token types
@@ -13,7 +13,7 @@ export class SemanticTokensBuilder {
   constructor(private document: TextDocument) {}
 
   public addToken(
-    textRange: text_index.TextRange,
+    textRange: TextRange,
     type: SemanticTokenTypes,
     modifiers = 0
   ) {

--- a/server/src/services/semanticHighlight/highlighters/ContractDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/ContractDefinitionHighlighter.ts
@@ -1,17 +1,16 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { Highlighter } from "../Highlighter";
 
 // Highlights contract definitions
 export class ContractDefinitionHighlighter extends Highlighter {
-  public ruleKind = RuleKind.ContractDefinition;
-  public semanticTokenType = SemanticTokenTypes.type;
+  public override readonly semanticTokenType = SemanticTokenTypes.type;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    [ContractDefinition
       ...
-      @identifier [name:_]
+      @identifier name: [_]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/semanticHighlight/highlighters/CustomTypeHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/CustomTypeHighlighter.ts
@@ -1,14 +1,13 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { Highlighter } from "../Highlighter";
 
 // Highlights custom type names
 export class CustomTypeHighlighter extends Highlighter {
-  public ruleKind = RuleKind.TypeName;
-  public semanticTokenType = SemanticTokenTypes.type;
+  public override readonly semanticTokenType = SemanticTokenTypes.type;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    [TypeName
       ...
       [IdentifierPath
         ...
@@ -17,5 +16,5 @@ export class CustomTypeHighlighter extends Highlighter {
       ]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/semanticHighlight/highlighters/EnumDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/EnumDefinitionHighlighter.ts
@@ -1,16 +1,15 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { Highlighter } from "../Highlighter";
 
 export class EnumDefinitionHighlighter extends Highlighter {
-  public ruleKind = RuleKind.EnumDefinition;
-  public semanticTokenType = SemanticTokenTypes.type;
+  public override readonly semanticTokenType = SemanticTokenTypes.type;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    [EnumDefinition
       ...
-      @identifier [name:_]
+      @identifier name: [_]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/semanticHighlight/highlighters/ErrorDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/ErrorDefinitionHighlighter.ts
@@ -1,16 +1,15 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { Highlighter } from "../Highlighter";
 
 export class ErrorDefinitionHighlighter extends Highlighter {
-  public ruleKind = RuleKind.ErrorDefinition;
-  public semanticTokenType = SemanticTokenTypes.type;
+  public override readonly semanticTokenType = SemanticTokenTypes.type;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    [ErrorDefinition
       ...
-      @identifier [name:_]
+      @identifier name: [_]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/semanticHighlight/highlighters/EventDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/EventDefinitionHighlighter.ts
@@ -1,17 +1,16 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { Highlighter } from "../Highlighter";
 
 // Highlights event definitions
 export class EventDefinitionHighlighter extends Highlighter {
-  public ruleKind = RuleKind.EventDefinition;
-  public semanticTokenType = SemanticTokenTypes.type;
+  public override readonly semanticTokenType = SemanticTokenTypes.type;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    [EventDefinition
       ...
-      @identifier [name:_]
+      @identifier name: [_]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/semanticHighlight/highlighters/EventEmissionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/EventEmissionHighlighter.ts
@@ -1,15 +1,14 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { Highlighter } from "../Highlighter";
 import {} from "../../../parser/slangHelpers";
 
 // Highlights event emissions
 export class EventEmissionHighlighter extends Highlighter {
-  public ruleKind = RuleKind.EmitStatement;
-  public semanticTokenType = SemanticTokenTypes.type;
+  public override readonly semanticTokenType = SemanticTokenTypes.type;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    [EmitStatement
       ...
       [IdentifierPath
         ...
@@ -18,5 +17,5 @@ export class EventEmissionHighlighter extends Highlighter {
       ]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/semanticHighlight/highlighters/FunctionCallHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/FunctionCallHighlighter.ts
@@ -1,14 +1,13 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { Highlighter } from "../Highlighter";
 
 // Highlights function calls
 export class FunctionCallHighlighter extends Highlighter {
-  public ruleKind = RuleKind.FunctionCallExpression;
-  public semanticTokenType = SemanticTokenTypes.function;
+  public override readonly semanticTokenType = SemanticTokenTypes.function;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    [FunctionCallExpression
       ...
       [Expression
         ...
@@ -17,5 +16,5 @@ export class FunctionCallHighlighter extends Highlighter {
       ]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/semanticHighlight/highlighters/FunctionDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/FunctionDefinitionHighlighter.ts
@@ -1,14 +1,13 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { Highlighter } from "../Highlighter";
 
 // Highlights function definitions
 export class FunctionDefinitionHighlighter extends Highlighter {
-  public ruleKind = RuleKind.FunctionDefinition;
-  public semanticTokenType = SemanticTokenTypes.function;
+  public override readonly semanticTokenType = SemanticTokenTypes.function;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    [FunctionDefinition
       ...
       [FunctionName
         ...
@@ -17,5 +16,5 @@ export class FunctionDefinitionHighlighter extends Highlighter {
       ]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/semanticHighlight/highlighters/InterfaceDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/InterfaceDefinitionHighlighter.ts
@@ -1,17 +1,16 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { Highlighter } from "../Highlighter";
 
 // Highlights interface definitions
 export class InterfaceDefinitionHighlighter extends Highlighter {
-  public ruleKind = RuleKind.InterfaceDefinition;
-  public semanticTokenType = SemanticTokenTypes.type;
+  public override readonly semanticTokenType = SemanticTokenTypes.type;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    [InterfaceDefinition
       ...
-      @identifier [name:_]
+      @identifier name: [_]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/semanticHighlight/highlighters/LibraryDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/LibraryDefinitionHighlighter.ts
@@ -1,16 +1,15 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { Highlighter } from "../Highlighter";
 
 export class LibraryDefinitionHighlighter extends Highlighter {
-  public ruleKind = RuleKind.LibraryDefinition;
-  public semanticTokenType = SemanticTokenTypes.type;
+  public override readonly semanticTokenType = SemanticTokenTypes.type;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    [LibraryDefinition
       ...
-      @identifier [name:_]
+      @identifier name: [_]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/semanticHighlight/highlighters/StructDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/StructDefinitionHighlighter.ts
@@ -1,17 +1,16 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { Highlighter } from "../Highlighter";
 
 // Highlights struct definitions
 export class StructDefinitionHighlighter extends Highlighter {
-  public ruleKind = RuleKind.StructDefinition;
-  public semanticTokenType = SemanticTokenTypes.type;
+  public override readonly semanticTokenType = SemanticTokenTypes.type;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    [StructDefinition
       ...
-      @identifier [name:_]
+      @identifier name: [_]
       ...
     ]
-  `;
+  `);
 }

--- a/server/src/services/semanticHighlight/highlighters/UserDefinedValueTypeDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/UserDefinedValueTypeDefinitionHighlighter.ts
@@ -1,16 +1,15 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { RuleKind } from "@nomicfoundation/slang/kinds";
+import { Query } from "@nomicfoundation/slang/query";
 import { Highlighter } from "../Highlighter";
 
 export class UserDefinedValueTypeDefinitionHighlighter extends Highlighter {
-  public ruleKind = RuleKind.UserDefinedValueTypeDefinition;
-  public semanticTokenType = SemanticTokenTypes.type;
+  public override readonly semanticTokenType = SemanticTokenTypes.type;
 
-  public query = `
-    @definition [${this.ruleKind}
+  public override readonly query = Query.parse(`
+    [UserDefinedValueTypeDefinition
       ...
-      @identifier [name:_]
+      @identifier name: [_]
       ...
     ]
-  `;
+  `);
 }

--- a/server/test/services/documentSymbol/queries.ts
+++ b/server/test/services/documentSymbol/queries.ts
@@ -1,0 +1,8 @@
+import { expect } from "chai";
+import { createFinders } from "@services/documentSymbol/onDocumentSymbol";
+
+describe("documentSymbol", () => {
+  it("can create and parse all queries successfully", () => {
+    expect(() => createFinders()).to.not.throw();
+  });
+});

--- a/server/test/services/semanticHighlight/queries.ts
+++ b/server/test/services/semanticHighlight/queries.ts
@@ -1,0 +1,8 @@
+import { expect } from "chai";
+import { createHighlighters } from "@services/semanticHighlight/onSemanticTokensFull";
+
+describe("semanticHighlight", () => {
+  it("can create and parse all queries successfully", () => {
+    expect(() => createHighlighters()).to.not.throw();
+  });
+});


### PR DESCRIPTION
- Fixes a bug in CI scripts where it ignores outdated lock files. Now we run `npm ci` to actually check for that.
- Upgraded to the newest Slang release, and updating the lock file accourdingly.
- Additionally, now we parse/cache all queries once for all feature requests, instead of repeating it with each incoming one.
- Added unit tests for the queries, to make it easier to detect syntax errors in test failures, rather than launching the editor and inspecting the error logs of the server.