### PR TITLE
set Slang release flags to 20%

### DIFF
--- a/flags.json
+++ b/flags.json
@@ -1,9 +1,9 @@
 {
   "documentSymbol": {
-    "percent": 0
+    "percent": 0.2
   },
 
   "semanticHighlighting": {
-    "percent": 0
+    "percent": 0.2
   }
 }


### PR DESCRIPTION
After the [v0.8.4](https://github.com/NomicFoundation/hardhat-vscode/releases/tag/v0.8.4) release with the latest Slang fixes, we can now bump up the release flags to 20%.
