### PR TITLE
fix: range create error

### DIFF
--- a/server/src/frameworks/Hardhat/Hardhat2/getImportCompletions.ts
+++ b/server/src/frameworks/Hardhat/Hardhat2/getImportCompletions.ts
@@ -23,19 +23,20 @@ export function getImportCompletions(
       ? _findNodeModulesContractFilesInIndex(ctx, currentImport)
       : _findNodeModulePackagesInIndex(ctx);
 
-  return contractFilePaths.map((pathFromNodeModules): CompletionItem => {
-    const normalizedPath = normalizeSlashes(pathFromNodeModules);
+  return contractFilePaths
+    .map((pathFromNodeModules) => normalizeSlashes(pathFromNodeModules))
+    .filter((p) => p !== currentImport) // Don't suggest the current import
+    .map((normalizedPath): CompletionItem => {
+      const completionItem: CompletionItem = {
+        label: normalizedPath,
+        textEdit: replaceFor(normalizedPath, position, currentImport),
 
-    const completionItem: CompletionItem = {
-      label: normalizedPath,
-      textEdit: replaceFor(normalizedPath, position, currentImport),
+        kind: CompletionItemKind.Module,
+        documentation: "Imports the package",
+      };
 
-      kind: CompletionItemKind.Module,
-      documentation: "Imports the package",
-    };
-
-    return completionItem;
-  });
+      return completionItem;
+    });
 }
 
 function _findNodeModulesContractFilesInIndex(

--- a/server/src/services/completion/getImportPathCompletion.ts
+++ b/server/src/services/completion/getImportPathCompletion.ts
@@ -231,6 +231,11 @@ function convertFileToCompletion(
     const insertText = `${prefix}${file}`;
 
     if (fileStat.isFile() && file.slice(-4) === ".sol") {
+      // Don't suggest the current import
+      if (partial === insertText) {
+        return null;
+      }
+
       if (partial === "") {
         return {
           label,


### PR DESCRIPTION
If the import completion is triggered by deleting a quote on an existing import and readding it then, the position is the start of the import but we delete the entire length of the import line which creates a negative position triggering the bug.

Instead, we short circuit. If the import is already the suggestion we don't suggest it again.

Fixes #150.
