### PR TITLE
chore: bump version to v0.8.5

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.8.5 - 2024-08-15
+
+### Added
+
+- Bump Slang to 0.16.0 ([588](https://github.com/NomicFoundation/hardhat-vscode/pull/588))
+
 ## 0.8.4 - 2024-06-24
 
 ### Added

--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
   "displayName": "Solidity",
   "description": "Solidity and Hardhat support by the Hardhat team",
   "license": "MIT",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "private": true,
   "main": "./out/extension.js",
   "module": "./out/extension.js",

--- a/coc/package.json
+++ b/coc/package.json
@@ -2,7 +2,7 @@
   "name": "@nomicfoundation/coc-solidity",
   "description": "Solidity and Hardhat support for coc.nvim",
   "license": "MIT",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "author": "Nomic Foundation",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     "clean": "rimraf out .nyc_output coverage *.tsbuildinfo *.log"
   },
   "dependencies": {
-    "@nomicfoundation/solidity-language-server": "0.8.4"
+    "@nomicfoundation/solidity-language-server": "0.8.5"
   },
   "devDependencies": {
     "coc.nvim": "^0.0.80",

--- a/docs/publish-extension.md
+++ b/docs/publish-extension.md
@@ -5,45 +5,45 @@ To publish `hardhat-solidity` you need to do next steps:
 1. `git fetch`, Checkout out `development`, then ensure your branch is up to date `git pull --ff-only`
 2. Perform a clean install and build (will lose all uncommitted changes):
 
-```
-git clean -fdx .
-npm install
-npm run build
-```
+   ```sh
+   git clean -fdx .
+   npm install
+   npm run build
+   ```
 
 3. Run a full check, stopping on failure: `npm run fullcheck`, optionally you can check that each commit meets our build requirements with: `git rebase main --exec "npm install && npm run fullcheck"`
 4. Confirm the commits represent the features for the release
 5. Branch into a release branch named for the current date: `git checkout -b release/yyyy-mm-dd`
 6. Update the version based on semver, ensure it is updated in:
 
-- the client `./client/package.json`
-- the language server package.json `./server/package.json`
-- the coc extension package.json, both its version and its dep on the language server, at `./coc/package.json`
+   - the client `./client/package.json`
+   - the language server package.json `./server/package.json`
+   - the coc extension package.json, both its version and its dep on the language server, at `./coc/package.json`
 
 7. Update the changelog in `./client/CHANGELOG.md` by adding a new entry for the new version based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 8. Commit the package version and changelog change as a version bump commit:
 
-```
-chore: bump version to v0.x.x
+   ```git
+   chore: bump version to v0.x.x
 
-Update the package version and changelog for the `0.x.x - yyyy-mm-dd`
-release.
-```
+   Update the package version and changelog for the `0.x.x - yyyy-mm-dd`
+   release.
+   ```
 
-9. Push the release branch and open a pull request using the new changelog entry as the PR description
+9. Push the release branch and open a pull request against `main` using the new changelog entry as the PR description
 
 10. Ensure .env file is populated with GA and Sentry secrets before packaging (see `./env.example`)
 
 11. Generate a release candidate vsix file with `npm run package`, the vsix file should appear in the `./client` folder with the new version number
 
-12. Manually run smoke tests on the new features across:
+12. Manually run smoke tests on the new features across all supported platforms, using contracts from <https://github.com/NomicFoundation/smoke-tests-vscode>:
 
-- mac os x
-- windows
-- vscode running against docker
+    - mac os x
+    - windows
+    - linux (vscode running against docker)
 
 13. Ensure that metrics are reported correctly in both Google Analytics and Sentry for the new version.
-14. On a successful check, `rebase merge` the release branch into main
+14. On a successful check, `rebase merge` the PR into `main` branch.
 15. Switch to main branch and pull the latest changes
 16. Git tag the version, `git tag -a v0.x.x -m "v0.x.x"` and push the tag `git push --follow-tags`
 17. Publish the language server npm package, `cd ./server && npm publish`
@@ -52,19 +52,18 @@ release.
 20. Upload the vsix file to openvsx, `npx ovsx publish client/hardhat-solidity-0.X.X.vsix -p $OVSX_TOKEN`
 21. Create a release on github off of the pushed tag
 
-- use the added changelog section as the body of the release
-- append the Nomic is Hiring section to the end of the release not:
+    - use the added changelog section as the body of the release
+    - upload the vsix file as an asset.
+    - append the Nomic is Hiring section to the end of the release note:
 
-```markdown
----
-> 💡 **The Nomic Foundation is hiring! Check [our open positions](https://www.nomic.foundation/jobs).**
----
-```
-
-- upload the vsix file as an asset
+    ```markdown
+    ---
+    > 💡 **The Nomic Foundation is hiring! Check [our open positions](https://www.nomic.foundation/jobs).**
+    ---
+    ```
 
 22. Rebase `development` onto `main`, and force push back to github
 23. Update the discord announcements channel
 
-- link to the release entry on github (i.e. `https://github.com/NomicFoundation/hardhat-vscode/releases/tag/v0.x.x`)
-- give a few sentences of description of why users should be excited about this release
+    - link to the release entry on github (i.e. `https://github.com/NomicFoundation/hardhat-vscode/releases/tag/v0.x.x`)
+    - give a few sentences of description of why users should be excited about this release

--- a/flags.json
+++ b/flags.json
@@ -1,9 +1,9 @@
 {
   "documentSymbol": {
-    "percent": 0
+    "percent": 0.2
   },
 
   "semanticHighlighting": {
-    "percent": 0
+    "percent": 0.2
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
     },
     "client": {
       "name": "hardhat-solidity",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
         "@nomicfoundation/solidity-language-server": "0.6.16",
@@ -142,10 +142,10 @@
     },
     "coc": {
       "name": "@nomicfoundation/coc-solidity",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/solidity-language-server": "0.8.3"
+        "@nomicfoundation/solidity-language-server": "0.8.4"
       },
       "devDependencies": {
         "coc.nvim": "^0.0.80",
@@ -2538,101 +2538,101 @@
       }
     },
     "node_modules/@nomicfoundation/slang": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang/-/slang-0.15.1.tgz",
-      "integrity": "sha512-th7nxRWRXf583uHpWUCd8U7BYxIqJX2f3oZLff/mlPkqIr45pD2hLT/o00eCjrBIR8N7vybUULZg1CeThGNk7g==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang/-/slang-0.16.0.tgz",
+      "integrity": "sha512-JBI+X+6/1WnaVNvnWp7o9PRbIFpgxKDmEKzYnMUfrBGFmm7rT2PsvFvVBoZPeM09B0AFYK+XJt9tqnbJvzhlLw==",
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/slang-darwin-arm64": "0.15.1",
-        "@nomicfoundation/slang-darwin-x64": "0.15.1",
-        "@nomicfoundation/slang-linux-arm64-gnu": "0.15.1",
-        "@nomicfoundation/slang-linux-arm64-musl": "0.15.1",
-        "@nomicfoundation/slang-linux-x64-gnu": "0.15.1",
-        "@nomicfoundation/slang-linux-x64-musl": "0.15.1",
-        "@nomicfoundation/slang-win32-arm64-msvc": "0.15.1",
-        "@nomicfoundation/slang-win32-ia32-msvc": "0.15.1",
-        "@nomicfoundation/slang-win32-x64-msvc": "0.15.1"
+        "@nomicfoundation/slang-darwin-arm64": "0.16.0",
+        "@nomicfoundation/slang-darwin-x64": "0.16.0",
+        "@nomicfoundation/slang-linux-arm64-gnu": "0.16.0",
+        "@nomicfoundation/slang-linux-arm64-musl": "0.16.0",
+        "@nomicfoundation/slang-linux-x64-gnu": "0.16.0",
+        "@nomicfoundation/slang-linux-x64-musl": "0.16.0",
+        "@nomicfoundation/slang-win32-arm64-msvc": "0.16.0",
+        "@nomicfoundation/slang-win32-ia32-msvc": "0.16.0",
+        "@nomicfoundation/slang-win32-x64-msvc": "0.16.0"
       },
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@nomicfoundation/slang-darwin-arm64": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-arm64/-/slang-darwin-arm64-0.15.1.tgz",
-      "integrity": "sha512-taPHlCUNNztQZJze9OlZFK9cZH8Ut4Ih4QJQo5CKebXx9vWOUtmSBfKv/M2P8hiV/iL7Q5sPwR7HY9uZYnb49Q==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-arm64/-/slang-darwin-arm64-0.16.0.tgz",
+      "integrity": "sha512-tdrpV2/sEy9pWevl6pg2qdG8chV5R2lO80D0vgwP3FTd27vwLRgAdSMSUlhtVSb8NWKx6E1dagjjNfabUzmZpQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@nomicfoundation/slang-darwin-x64": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-x64/-/slang-darwin-x64-0.15.1.tgz",
-      "integrity": "sha512-kgZh5KQe/UcbFqn1EpyrvBuT8E6I1kWSgGPtO25t90zAqFv23sMUPdn7wLpMjngkD+quIIgrzQGUtupS5YYEig==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-x64/-/slang-darwin-x64-0.16.0.tgz",
+      "integrity": "sha512-a4OsidbwzaKOR7693ImYUSRKnmOs1xvTJviln0bc9nr6fngSkzXF7ijlHL/9/FrBhCIR+jY2ozmncWNOmqrvjQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@nomicfoundation/slang-linux-arm64-gnu": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-gnu/-/slang-linux-arm64-gnu-0.15.1.tgz",
-      "integrity": "sha512-Iw8mepaccKRWllPU9l+hoe88LN9fScC0Px3nFeNQy26qk1ueO0tjovP1dhTvmGwHUxacOYPqhQTUn7Iu0oxNoQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-gnu/-/slang-linux-arm64-gnu-0.16.0.tgz",
+      "integrity": "sha512-4kHqeVbJ6HvmhSIP3p/vS4SjiaC8/TRbeh+6jT77mr6fb6fVxUcVdNwCTVPocn7GRx1rYAsuYqjYZkeS72ubzg==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@nomicfoundation/slang-linux-arm64-musl": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-musl/-/slang-linux-arm64-musl-0.15.1.tgz",
-      "integrity": "sha512-zcesdQZwRgrT7ND+3TZUjRK/uGF20EfhEfCg8ZMhrb4Q7XaK1JvtHazIs03TV8Jcs30TPkEXks8Qi0Zdfy4RuA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-musl/-/slang-linux-arm64-musl-0.16.0.tgz",
+      "integrity": "sha512-seuEaQSEGa3yqBI6Y/HH4X10+f7BNkX5OzOTNjWejqSIFAVBj0mWNBNWetT2YWDHRqiOSm5khD3+8LaSvShDRQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@nomicfoundation/slang-linux-x64-gnu": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-gnu/-/slang-linux-x64-gnu-0.15.1.tgz",
-      "integrity": "sha512-FSmAnzKm58TFIwx4r/wOZtqfDx0nI6AfvnOh8kLDF5OxpWW3r0q9fq8lyaUReg9C/ZgCZRBn+m5WGrNKCZcvPQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-gnu/-/slang-linux-x64-gnu-0.16.0.tgz",
+      "integrity": "sha512-DI8sIWhz1EsuAE2L4vlBM48WaSaWpRgUixG1ZHIlxpTwzn6s+DxmfAxmOcBeLpNdtfba9eSpqF+2539zllktPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@nomicfoundation/slang-linux-x64-musl": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-musl/-/slang-linux-x64-musl-0.15.1.tgz",
-      "integrity": "sha512-hnoA/dgeHQ8aS0SReABYkxf0d/Q6DdaKsaYv6ev21wyQA7TROxT1X3nekECLGu1GYLML8pzvD9vyAMBRKOkkyg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-musl/-/slang-linux-x64-musl-0.16.0.tgz",
+      "integrity": "sha512-80obGwJ336r5wxQ/dLzEDp1nlAYtMWdnP5G5T2JmCnIkxxEVnyQIH62VcK6mc7RMSVeAlL1RGGx2LdNbk9V4QA==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@nomicfoundation/slang-win32-arm64-msvc": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-arm64-msvc/-/slang-win32-arm64-msvc-0.15.1.tgz",
-      "integrity": "sha512-2H0chHQ4uTh4l4UxN5fIVHR5mKaL5mfYTID6kxxxv2+KAh68EpYWwxLlkS5So90R2WcuPvFvTVKLm/uRo4h4dg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-arm64-msvc/-/slang-win32-arm64-msvc-0.16.0.tgz",
+      "integrity": "sha512-hcmsfXjRaCuy5/eUhrdDOnE5uqfJ0vVXvon5mTHaWzf6UE4REIx3vJwf/t4QQu1Q4mKKO5ZxzauBdzRtbhOKsw==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@nomicfoundation/slang-win32-ia32-msvc": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-ia32-msvc/-/slang-win32-ia32-msvc-0.15.1.tgz",
-      "integrity": "sha512-CVZWBnbpFlVBg/m7bsiw70jY3p9TGH9vxq0vLEEJ56yK+QPosxPrKMcADojtGjIOjWjPSZ+lCoo5ilnW0a249g==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-ia32-msvc/-/slang-win32-ia32-msvc-0.16.0.tgz",
+      "integrity": "sha512-W9959+Tdq71kkE5EGxoQWBxhpe9bjxpY7ozDoPjz2lBzaGi8X24z4toS6us3W83URIf6Cve0VizAX4fz5MWjFw==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@nomicfoundation/slang-win32-x64-msvc": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-x64-msvc/-/slang-win32-x64-msvc-0.15.1.tgz",
-      "integrity": "sha512-cyER8M1fdBTzIfihy55d4LGGlN/eQxDqfRUTXgJf1VvNR98tRB0Q3nBfyh5PK2yP98B4lMt3RJYDqTQu+dOVDA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-x64-msvc/-/slang-win32-x64-msvc-0.16.0.tgz",
+      "integrity": "sha512-sOKuMtm3g62ugdhgpWqjF+o3clIR4eAIiAbx6oRPGB/9fPukgZnI5untsgTYJyVldAzby7jlIQ4R7df18aNraw==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -11645,10 +11645,10 @@
     },
     "server": {
       "name": "@nomicfoundation/solidity-language-server",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/slang": "0.15.1",
+        "@nomicfoundation/slang": "0.16.0",
         "@nomicfoundation/solidity-analyzer": "0.1.1"
       },
       "bin": {
@@ -13986,7 +13986,7 @@
     "@nomicfoundation/coc-solidity": {
       "version": "file:coc",
       "requires": {
-        "@nomicfoundation/solidity-language-server": "0.8.3",
+        "@nomicfoundation/solidity-language-server": "0.8.4",
         "coc.nvim": "^0.0.80",
         "esbuild": "^0.16.0",
         "eslint": "^7.23.0"
@@ -14238,65 +14238,65 @@
       }
     },
     "@nomicfoundation/slang": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang/-/slang-0.15.1.tgz",
-      "integrity": "sha512-th7nxRWRXf583uHpWUCd8U7BYxIqJX2f3oZLff/mlPkqIr45pD2hLT/o00eCjrBIR8N7vybUULZg1CeThGNk7g==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang/-/slang-0.16.0.tgz",
+      "integrity": "sha512-JBI+X+6/1WnaVNvnWp7o9PRbIFpgxKDmEKzYnMUfrBGFmm7rT2PsvFvVBoZPeM09B0AFYK+XJt9tqnbJvzhlLw==",
       "requires": {
-        "@nomicfoundation/slang-darwin-arm64": "0.15.1",
-        "@nomicfoundation/slang-darwin-x64": "0.15.1",
-        "@nomicfoundation/slang-linux-arm64-gnu": "0.15.1",
-        "@nomicfoundation/slang-linux-arm64-musl": "0.15.1",
-        "@nomicfoundation/slang-linux-x64-gnu": "0.15.1",
-        "@nomicfoundation/slang-linux-x64-musl": "0.15.1",
-        "@nomicfoundation/slang-win32-arm64-msvc": "0.15.1",
-        "@nomicfoundation/slang-win32-ia32-msvc": "0.15.1",
-        "@nomicfoundation/slang-win32-x64-msvc": "0.15.1"
+        "@nomicfoundation/slang-darwin-arm64": "0.16.0",
+        "@nomicfoundation/slang-darwin-x64": "0.16.0",
+        "@nomicfoundation/slang-linux-arm64-gnu": "0.16.0",
+        "@nomicfoundation/slang-linux-arm64-musl": "0.16.0",
+        "@nomicfoundation/slang-linux-x64-gnu": "0.16.0",
+        "@nomicfoundation/slang-linux-x64-musl": "0.16.0",
+        "@nomicfoundation/slang-win32-arm64-msvc": "0.16.0",
+        "@nomicfoundation/slang-win32-ia32-msvc": "0.16.0",
+        "@nomicfoundation/slang-win32-x64-msvc": "0.16.0"
       }
     },
     "@nomicfoundation/slang-darwin-arm64": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-arm64/-/slang-darwin-arm64-0.15.1.tgz",
-      "integrity": "sha512-taPHlCUNNztQZJze9OlZFK9cZH8Ut4Ih4QJQo5CKebXx9vWOUtmSBfKv/M2P8hiV/iL7Q5sPwR7HY9uZYnb49Q=="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-arm64/-/slang-darwin-arm64-0.16.0.tgz",
+      "integrity": "sha512-tdrpV2/sEy9pWevl6pg2qdG8chV5R2lO80D0vgwP3FTd27vwLRgAdSMSUlhtVSb8NWKx6E1dagjjNfabUzmZpQ=="
     },
     "@nomicfoundation/slang-darwin-x64": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-x64/-/slang-darwin-x64-0.15.1.tgz",
-      "integrity": "sha512-kgZh5KQe/UcbFqn1EpyrvBuT8E6I1kWSgGPtO25t90zAqFv23sMUPdn7wLpMjngkD+quIIgrzQGUtupS5YYEig=="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-x64/-/slang-darwin-x64-0.16.0.tgz",
+      "integrity": "sha512-a4OsidbwzaKOR7693ImYUSRKnmOs1xvTJviln0bc9nr6fngSkzXF7ijlHL/9/FrBhCIR+jY2ozmncWNOmqrvjQ=="
     },
     "@nomicfoundation/slang-linux-arm64-gnu": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-gnu/-/slang-linux-arm64-gnu-0.15.1.tgz",
-      "integrity": "sha512-Iw8mepaccKRWllPU9l+hoe88LN9fScC0Px3nFeNQy26qk1ueO0tjovP1dhTvmGwHUxacOYPqhQTUn7Iu0oxNoQ=="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-gnu/-/slang-linux-arm64-gnu-0.16.0.tgz",
+      "integrity": "sha512-4kHqeVbJ6HvmhSIP3p/vS4SjiaC8/TRbeh+6jT77mr6fb6fVxUcVdNwCTVPocn7GRx1rYAsuYqjYZkeS72ubzg=="
     },
     "@nomicfoundation/slang-linux-arm64-musl": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-musl/-/slang-linux-arm64-musl-0.15.1.tgz",
-      "integrity": "sha512-zcesdQZwRgrT7ND+3TZUjRK/uGF20EfhEfCg8ZMhrb4Q7XaK1JvtHazIs03TV8Jcs30TPkEXks8Qi0Zdfy4RuA=="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-musl/-/slang-linux-arm64-musl-0.16.0.tgz",
+      "integrity": "sha512-seuEaQSEGa3yqBI6Y/HH4X10+f7BNkX5OzOTNjWejqSIFAVBj0mWNBNWetT2YWDHRqiOSm5khD3+8LaSvShDRQ=="
     },
     "@nomicfoundation/slang-linux-x64-gnu": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-gnu/-/slang-linux-x64-gnu-0.15.1.tgz",
-      "integrity": "sha512-FSmAnzKm58TFIwx4r/wOZtqfDx0nI6AfvnOh8kLDF5OxpWW3r0q9fq8lyaUReg9C/ZgCZRBn+m5WGrNKCZcvPQ=="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-gnu/-/slang-linux-x64-gnu-0.16.0.tgz",
+      "integrity": "sha512-DI8sIWhz1EsuAE2L4vlBM48WaSaWpRgUixG1ZHIlxpTwzn6s+DxmfAxmOcBeLpNdtfba9eSpqF+2539zllktPQ=="
     },
     "@nomicfoundation/slang-linux-x64-musl": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-musl/-/slang-linux-x64-musl-0.15.1.tgz",
-      "integrity": "sha512-hnoA/dgeHQ8aS0SReABYkxf0d/Q6DdaKsaYv6ev21wyQA7TROxT1X3nekECLGu1GYLML8pzvD9vyAMBRKOkkyg=="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-musl/-/slang-linux-x64-musl-0.16.0.tgz",
+      "integrity": "sha512-80obGwJ336r5wxQ/dLzEDp1nlAYtMWdnP5G5T2JmCnIkxxEVnyQIH62VcK6mc7RMSVeAlL1RGGx2LdNbk9V4QA=="
     },
     "@nomicfoundation/slang-win32-arm64-msvc": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-arm64-msvc/-/slang-win32-arm64-msvc-0.15.1.tgz",
-      "integrity": "sha512-2H0chHQ4uTh4l4UxN5fIVHR5mKaL5mfYTID6kxxxv2+KAh68EpYWwxLlkS5So90R2WcuPvFvTVKLm/uRo4h4dg=="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-arm64-msvc/-/slang-win32-arm64-msvc-0.16.0.tgz",
+      "integrity": "sha512-hcmsfXjRaCuy5/eUhrdDOnE5uqfJ0vVXvon5mTHaWzf6UE4REIx3vJwf/t4QQu1Q4mKKO5ZxzauBdzRtbhOKsw=="
     },
     "@nomicfoundation/slang-win32-ia32-msvc": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-ia32-msvc/-/slang-win32-ia32-msvc-0.15.1.tgz",
-      "integrity": "sha512-CVZWBnbpFlVBg/m7bsiw70jY3p9TGH9vxq0vLEEJ56yK+QPosxPrKMcADojtGjIOjWjPSZ+lCoo5ilnW0a249g=="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-ia32-msvc/-/slang-win32-ia32-msvc-0.16.0.tgz",
+      "integrity": "sha512-W9959+Tdq71kkE5EGxoQWBxhpe9bjxpY7ozDoPjz2lBzaGi8X24z4toS6us3W83URIf6Cve0VizAX4fz5MWjFw=="
     },
     "@nomicfoundation/slang-win32-x64-msvc": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-x64-msvc/-/slang-win32-x64-msvc-0.15.1.tgz",
-      "integrity": "sha512-cyER8M1fdBTzIfihy55d4LGGlN/eQxDqfRUTXgJf1VvNR98tRB0Q3nBfyh5PK2yP98B4lMt3RJYDqTQu+dOVDA=="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-x64-msvc/-/slang-win32-x64-msvc-0.16.0.tgz",
+      "integrity": "sha512-sOKuMtm3g62ugdhgpWqjF+o3clIR4eAIiAbx6oRPGB/9fPukgZnI5untsgTYJyVldAzby7jlIQ4R7df18aNraw=="
     },
     "@nomicfoundation/solidity-analyzer": {
       "version": "0.1.1",
@@ -14377,7 +14377,7 @@
       "version": "file:server",
       "requires": {
         "@istanbuljs/nyc-config-typescript": "1.0.2",
-        "@nomicfoundation/slang": "0.15.1",
+        "@nomicfoundation/slang": "0.16.0",
         "@nomicfoundation/solidity-analyzer": "0.1.1",
         "@sentry/node": "7.32.1",
         "@sentry/tracing": "7.32.1",

--- a/server/package.json
+++ b/server/package.json
@@ -87,7 +87,7 @@
     "yaml": "^2.2.1"
   },
   "dependencies": {
-    "@nomicfoundation/slang": "0.15.1",
+    "@nomicfoundation/slang": "0.16.0",
     "@nomicfoundation/solidity-analyzer": "0.1.1"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "name": "@nomicfoundation/solidity-language-server",
   "description": "Solidity language server by Nomic Foundation",
   "license": "MIT",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "author": "Nomic Foundation",
   "repository": {
     "type": "git",

--- a/server/src/parser/slangHelpers.ts
+++ b/server/src/parser/slangHelpers.ts
@@ -49,12 +49,10 @@ export function resolveVersion(
   } else {
     const latest = versions[versions.length - 1];
 
-    logger.error(
-      new Error(
-        `No Slang-supported version (latest: ${latest}) for Solidity found that satisfies the pragma directives: '${versionPragmas.join(
-          " "
-        )}'.`
-      )
+    logger.info(
+      `No Slang-supported version (latest: ${latest}) for Solidity found that satisfies the pragma directives: '${versionPragmas.join(
+        " "
+      )}'.`
     );
 
     return latest;

--- a/server/src/services/documentSymbol/finders/ConstantDefinition.ts
+++ b/server/src/services/documentSymbol/finders/ConstantDefinition.ts
@@ -7,9 +7,7 @@ export class ConstantDefinition extends SymbolFinder {
 
   public override readonly query = Query.parse(`
     @definition [ConstantDefinition
-      ...
       @identifier name: [_]
-      ...
     ]
   `);
 }

--- a/server/src/services/documentSymbol/finders/ConstructorDefinition.ts
+++ b/server/src/services/documentSymbol/finders/ConstructorDefinition.ts
@@ -7,9 +7,7 @@ export class ConstructorDefinition extends SymbolFinder {
 
   public override readonly query = Query.parse(`
     @definition [ConstructorDefinition
-      ...
       @identifier [ConstructorKeyword]
-      ...
     ]
   `);
 }

--- a/server/src/services/documentSymbol/finders/ContractDefinition.ts
+++ b/server/src/services/documentSymbol/finders/ContractDefinition.ts
@@ -7,9 +7,7 @@ export class ContractDefinition extends SymbolFinder {
 
   public override readonly query = Query.parse(`
     @definition [ContractDefinition
-      ...
       @identifier name: [_]
-      ...
     ]
   `);
 }

--- a/server/src/services/documentSymbol/finders/EnumDefinition.ts
+++ b/server/src/services/documentSymbol/finders/EnumDefinition.ts
@@ -7,9 +7,7 @@ export class EnumDefinition extends SymbolFinder {
 
   public override readonly query = Query.parse(`
     @definition [EnumDefinition
-      ...
       @identifier name: [_]
-      ...
     ]
   `);
 }

--- a/server/src/services/documentSymbol/finders/ErrorDefinition.ts
+++ b/server/src/services/documentSymbol/finders/ErrorDefinition.ts
@@ -7,9 +7,7 @@ export class ErrorDefinition extends SymbolFinder {
 
   public override readonly query = Query.parse(`
     @definition [ErrorDefinition
-      ...
       @identifier name: [_]
-      ...
     ]
   `);
 }

--- a/server/src/services/documentSymbol/finders/EventDefinition.ts
+++ b/server/src/services/documentSymbol/finders/EventDefinition.ts
@@ -7,9 +7,7 @@ export class EventDefinition extends SymbolFinder {
 
   public override readonly query = Query.parse(`
     @definition [EventDefinition
-      ...
       @identifier name: [_]
-      ...
     ]
   `);
 }

--- a/server/src/services/documentSymbol/finders/FallbackFunctionDefinition.ts
+++ b/server/src/services/documentSymbol/finders/FallbackFunctionDefinition.ts
@@ -7,9 +7,7 @@ export class FallbackFunctionDefinition extends SymbolFinder {
 
   public override readonly query = Query.parse(`
     @definition [FallbackFunctionDefinition
-      ...
       @identifier [FallbackKeyword]
-      ...
     ]
   `);
 }

--- a/server/src/services/documentSymbol/finders/FunctionDefinition.ts
+++ b/server/src/services/documentSymbol/finders/FunctionDefinition.ts
@@ -7,13 +7,9 @@ export class FunctionDefinition extends SymbolFinder {
 
   public override readonly query = Query.parse(`
     @definition [FunctionDefinition
-      ...
       [FunctionName
-        ...
         @identifier variant: [_]
-        ...
       ]
-      ...
     ]
   `);
 }

--- a/server/src/services/documentSymbol/finders/InterfaceDefinition.ts
+++ b/server/src/services/documentSymbol/finders/InterfaceDefinition.ts
@@ -7,9 +7,7 @@ export class InterfaceDefinition extends SymbolFinder {
 
   public override readonly query = Query.parse(`
     @definition [InterfaceDefinition
-      ...
       @identifier name: [_]
-      ...
     ]
   `);
 }

--- a/server/src/services/documentSymbol/finders/LibraryDefinition.ts
+++ b/server/src/services/documentSymbol/finders/LibraryDefinition.ts
@@ -7,9 +7,7 @@ export class LibraryDefinition extends SymbolFinder {
 
   public override readonly query = Query.parse(`
     @definition [LibraryDefinition
-      ...
       @identifier name: [_]
-      ...
     ]
   `);
 }

--- a/server/src/services/documentSymbol/finders/ModifierDefinition.ts
+++ b/server/src/services/documentSymbol/finders/ModifierDefinition.ts
@@ -7,9 +7,7 @@ export class ModifierDefinition extends SymbolFinder {
 
   public override readonly query = Query.parse(`
     @definition [ModifierDefinition
-      ...
       @identifier name: [_]
-      ...
     ]
   `);
 }

--- a/server/src/services/documentSymbol/finders/ReceiveFunctionDefinition.ts
+++ b/server/src/services/documentSymbol/finders/ReceiveFunctionDefinition.ts
@@ -7,9 +7,7 @@ export class ReceiveFunctionDefinition extends SymbolFinder {
 
   public override readonly query = Query.parse(`
     @definition [ReceiveFunctionDefinition
-      ...
       @identifier [ReceiveKeyword]
-      ...
     ]
   `);
 }

--- a/server/src/services/documentSymbol/finders/StateVariableDefinition.ts
+++ b/server/src/services/documentSymbol/finders/StateVariableDefinition.ts
@@ -7,9 +7,7 @@ export class StateVariableDefinition extends SymbolFinder {
 
   public override readonly query = Query.parse(`
     @definition [StateVariableDefinition
-      ...
       @identifier name: [_]
-      ...
     ]
   `);
 }

--- a/server/src/services/documentSymbol/finders/StructDefinition.ts
+++ b/server/src/services/documentSymbol/finders/StructDefinition.ts
@@ -7,9 +7,7 @@ export class StructDefinition extends SymbolFinder {
 
   public override readonly query = Query.parse(`
     @definition [StructDefinition
-      ...
       @identifier name: [_]
-      ...
     ]
   `);
 }

--- a/server/src/services/documentSymbol/finders/StructMember.ts
+++ b/server/src/services/documentSymbol/finders/StructMember.ts
@@ -7,9 +7,7 @@ export class StructMember extends SymbolFinder {
 
   public override readonly query = Query.parse(`
     @definition [StructMember
-      ...
       @identifier name: [_]
-      ...
     ]
   `);
 }

--- a/server/src/services/documentSymbol/finders/UnnamedFunctionDefinition.ts
+++ b/server/src/services/documentSymbol/finders/UnnamedFunctionDefinition.ts
@@ -7,9 +7,7 @@ export class UnnamedFunctionDefinition extends SymbolFinder {
 
   public override readonly query = Query.parse(`
     @definition [UnnamedFunctionDefinition
-      ...
       @identifier [FunctionKeyword]
-      ...
     ]
   `);
 }

--- a/server/src/services/documentSymbol/finders/UserDefinedValueTypeDefinition.ts
+++ b/server/src/services/documentSymbol/finders/UserDefinedValueTypeDefinition.ts
@@ -7,9 +7,7 @@ export class UserDefinedValueTypeDefinition extends SymbolFinder {
 
   public override readonly query = Query.parse(`
     @definition [UserDefinedValueTypeDefinition
-      ...
       @identifier name: [_]
-      ...
     ]
   `);
 }

--- a/server/src/services/documentSymbol/finders/VariableDeclarationStatement.ts
+++ b/server/src/services/documentSymbol/finders/VariableDeclarationStatement.ts
@@ -7,9 +7,7 @@ export class VariableDeclarationStatement extends SymbolFinder {
 
   public override readonly query = Query.parse(`
     @definition [VariableDeclarationStatement
-      ...
       @identifier name: [_]
-      ...
     ]
   `);
 }

--- a/server/src/services/documentSymbol/finders/YulFunctionDefinition.ts
+++ b/server/src/services/documentSymbol/finders/YulFunctionDefinition.ts
@@ -7,9 +7,7 @@ export class YulFunctionDefinition extends SymbolFinder {
 
   public override readonly query = Query.parse(`
     @definition [YulFunctionDefinition
-      ...
       @identifier name: [_]
-      ...
     ]
   `);
 }

--- a/server/src/services/semanticHighlight/highlighters/ContractDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/ContractDefinitionHighlighter.ts
@@ -8,9 +8,7 @@ export class ContractDefinitionHighlighter extends Highlighter {
 
   public override readonly query = Query.parse(`
     [ContractDefinition
-      ...
       @identifier name: [_]
-      ...
     ]
   `);
 }

--- a/server/src/services/semanticHighlight/highlighters/CustomTypeHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/CustomTypeHighlighter.ts
@@ -8,13 +8,9 @@ export class CustomTypeHighlighter extends Highlighter {
 
   public override readonly query = Query.parse(`
     [TypeName
-      ...
       [IdentifierPath
-        ...
         @identifier [Identifier]
-        ...
       ]
-      ...
     ]
   `);
 }

--- a/server/src/services/semanticHighlight/highlighters/EnumDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/EnumDefinitionHighlighter.ts
@@ -7,9 +7,7 @@ export class EnumDefinitionHighlighter extends Highlighter {
 
   public override readonly query = Query.parse(`
     [EnumDefinition
-      ...
       @identifier name: [_]
-      ...
     ]
   `);
 }

--- a/server/src/services/semanticHighlight/highlighters/ErrorDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/ErrorDefinitionHighlighter.ts
@@ -7,9 +7,7 @@ export class ErrorDefinitionHighlighter extends Highlighter {
 
   public override readonly query = Query.parse(`
     [ErrorDefinition
-      ...
       @identifier name: [_]
-      ...
     ]
   `);
 }

--- a/server/src/services/semanticHighlight/highlighters/EventDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/EventDefinitionHighlighter.ts
@@ -8,9 +8,7 @@ export class EventDefinitionHighlighter extends Highlighter {
 
   public override readonly query = Query.parse(`
     [EventDefinition
-      ...
       @identifier name: [_]
-      ...
     ]
   `);
 }

--- a/server/src/services/semanticHighlight/highlighters/EventEmissionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/EventEmissionHighlighter.ts
@@ -9,13 +9,9 @@ export class EventEmissionHighlighter extends Highlighter {
 
   public override readonly query = Query.parse(`
     [EmitStatement
-      ...
       [IdentifierPath
-        ...
         @identifier [Identifier]
-        ...
       ]
-      ...
     ]
   `);
 }

--- a/server/src/services/semanticHighlight/highlighters/FunctionCallHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/FunctionCallHighlighter.ts
@@ -8,13 +8,9 @@ export class FunctionCallHighlighter extends Highlighter {
 
   public override readonly query = Query.parse(`
     [FunctionCallExpression
-      ...
       [Expression
-        ...
         @identifier [Identifier]
-        ...
       ]
-      ...
     ]
   `);
 }

--- a/server/src/services/semanticHighlight/highlighters/FunctionDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/FunctionDefinitionHighlighter.ts
@@ -8,13 +8,9 @@ export class FunctionDefinitionHighlighter extends Highlighter {
 
   public override readonly query = Query.parse(`
     [FunctionDefinition
-      ...
       [FunctionName
-        ...
         @identifier [Identifier]
-        ...
       ]
-      ...
     ]
   `);
 }

--- a/server/src/services/semanticHighlight/highlighters/InterfaceDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/InterfaceDefinitionHighlighter.ts
@@ -8,9 +8,7 @@ export class InterfaceDefinitionHighlighter extends Highlighter {
 
   public override readonly query = Query.parse(`
     [InterfaceDefinition
-      ...
       @identifier name: [_]
-      ...
     ]
   `);
 }

--- a/server/src/services/semanticHighlight/highlighters/LibraryDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/LibraryDefinitionHighlighter.ts
@@ -7,9 +7,7 @@ export class LibraryDefinitionHighlighter extends Highlighter {
 
   public override readonly query = Query.parse(`
     [LibraryDefinition
-      ...
       @identifier name: [_]
-      ...
     ]
   `);
 }

--- a/server/src/services/semanticHighlight/highlighters/StructDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/StructDefinitionHighlighter.ts
@@ -8,9 +8,7 @@ export class StructDefinitionHighlighter extends Highlighter {
 
   public override readonly query = Query.parse(`
     [StructDefinition
-      ...
       @identifier name: [_]
-      ...
     ]
   `);
 }

--- a/server/src/services/semanticHighlight/highlighters/UserDefinedValueTypeDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/UserDefinedValueTypeDefinitionHighlighter.ts
@@ -7,9 +7,7 @@ export class UserDefinedValueTypeDefinitionHighlighter extends Highlighter {
 
   public override readonly query = Query.parse(`
     [UserDefinedValueTypeDefinition
-      ...
       @identifier name: [_]
-      ...
     ]
   `);
 }


### PR DESCRIPTION
Update the package version and changelog for the `0.8.5 - 2024-08-1` release.

### Added

- Bump Slang to 0.16.0 ([588](https://github.com/NomicFoundation/hardhat-vscode/pull/588))
