### PR TITLE
set Slang release flags to 50%

### DIFF
--- a/flags.json
+++ b/flags.json
@@ -1,9 +1,9 @@
 {
   "documentSymbol": {
-    "percent": 0.2
+    "percent": 0.5
   },
 
   "semanticHighlighting": {
-    "percent": 0.2
+    "percent": 0.5
   }
 }


### PR DESCRIPTION
After the https://github.com/NomicFoundation/hardhat-vscode/releases/tag/v0.8.5 release with the latest Slang fixes, we can now bump up the release flags to 50%.
