### PR TITLE
set Slang release flags to 100%

### DIFF
--- a/flags.json
+++ b/flags.json
@@ -1,9 +1,9 @@
 {
   "documentSymbol": {
-    "percent": 0.5
+    "percent": 1
   },
 
   "semanticHighlighting": {
-    "percent": 0.5
+    "percent": 1
   }
 }


### PR DESCRIPTION
No new issues or bug reports. Let's do it 🚀

Btw, I noticed that the terminology in the file is now a bit confusing. `percent: 1` reads like 1% rather than 100% 🤔 but I don't think it is worth the risk to change it now, considering the implications for existing/older versions still running.
