### PR TITLE
chore: update CI uploading of codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,5 +84,5 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          files: ./server/coverage/lcov.info
+          files: ./server/coverage/lcov.info     # __LCOV_RESULTS_INFO_FILE__ (keep in sync)
           disable_search: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,3 +78,11 @@ jobs:
           SOLIDITY_GOOGLE_TRACKING_ID: "dummy-value"
           SOLIDITY_SENTRY_DSN: "dummy-value"
         run: npm run package
+
+      - name: Publish code coverage
+        uses: codecov/codecov-action@v4.2.0
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: ./server/coverage/lcov.info
+          disable_search: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
     },
     "client": {
       "name": "hardhat-solidity",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "MIT",
       "dependencies": {
         "@nomicfoundation/solidity-language-server": "0.6.16",
@@ -142,10 +142,10 @@
     },
     "coc": {
       "name": "@nomicfoundation/coc-solidity",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/solidity-language-server": "0.8.5"
+        "@nomicfoundation/solidity-language-server": "0.8.6"
       },
       "devDependencies": {
         "coc.nvim": "^0.0.80",
@@ -3751,13 +3751,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/argv": {
-      "version": "0.0.2",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6.10"
-      }
-    },
     "node_modules/array-includes": {
       "version": "3.1.6",
       "dev": true,
@@ -4404,36 +4397,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/codecov": {
-      "version": "3.8.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argv": "0.0.2",
-        "ignore-walk": "3.0.4",
-        "js-yaml": "3.14.1",
-        "teeny-request": "7.1.1",
-        "urlgrey": "1.0.0"
-      },
-      "bin": {
-        "codecov": "bin/codecov"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/codecov/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/color-convert": {
@@ -5823,19 +5786,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-url-parser": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^1.3.2"
-      }
-    },
-    "node_modules/fast-url-parser/node_modules/punycode": {
-      "version": "1.4.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fastq": {
       "version": "1.15.0",
       "dev": true,
@@ -7109,14 +7059,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/ignore-walk": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minimatch": "^3.0.4"
       }
     },
     "node_modules/immediate": {
@@ -8524,25 +8466,6 @@
       "version": "2.0.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
     },
     "node_modules/node-gyp-build": {
       "version": "4.6.0",
@@ -10286,14 +10209,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/stream-events": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "stubs": "^3.0.0"
-      }
-    },
     "node_modules/stream-transform": {
       "version": "2.1.3",
       "dev": true,
@@ -10417,11 +10332,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/stubs": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "dev": true,
@@ -10507,21 +10417,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/teeny-request": {
-      "version": "7.1.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "http-proxy-agent": "^4.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.1",
-        "stream-events": "^1.0.5",
-        "uuid": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/term-size": {
       "version": "2.2.1",
       "dev": true,
@@ -10598,11 +10493,6 @@
       "engines": {
         "node": ">=0.6"
       }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -11006,14 +10896,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/urlgrey": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "fast-url-parser": "^1.1.3"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "dev": true,
@@ -11097,20 +10979,6 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -11645,7 +11513,7 @@
     },
     "server": {
       "name": "@nomicfoundation/solidity-language-server",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "MIT",
       "dependencies": {
         "@nomicfoundation/slang": "0.16.0",
@@ -11673,7 +11541,6 @@
         "@types/sinon": "10.0.6",
         "c3-linearization": "0.3.0",
         "chai": "4.3.4",
-        "codecov": "3.8.3",
         "cross-env": "7.0.3",
         "eslint": "^7.23.0",
         "fast-glob": "3.2.11",
@@ -13986,7 +13853,7 @@
     "@nomicfoundation/coc-solidity": {
       "version": "file:coc",
       "requires": {
-        "@nomicfoundation/solidity-language-server": "0.8.5",
+        "@nomicfoundation/solidity-language-server": "0.8.6",
         "coc.nvim": "^0.0.80",
         "esbuild": "^0.16.0",
         "eslint": "^7.23.0"
@@ -14396,7 +14263,6 @@
         "@types/sinon": "10.0.6",
         "c3-linearization": "0.3.0",
         "chai": "4.3.4",
-        "codecov": "3.8.3",
         "cross-env": "7.0.3",
         "eslint": "^7.23.0",
         "fast-glob": "3.2.11",
@@ -15349,10 +15215,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "argv": {
-      "version": "0.0.2",
-      "dev": true
-    },
     "array-includes": {
       "version": "3.1.6",
       "dev": true,
@@ -15753,27 +15615,6 @@
       "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
-      }
-    },
-    "codecov": {
-      "version": "3.8.3",
-      "dev": true,
-      "requires": {
-        "argv": "0.0.2",
-        "ignore-walk": "3.0.4",
-        "js-yaml": "3.14.1",
-        "teeny-request": "7.1.1",
-        "urlgrey": "1.0.0"
-      },
-      "dependencies": {
-        "js-yaml": {
-          "version": "3.14.1",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        }
       }
     },
     "color-convert": {
@@ -16708,19 +16549,6 @@
       "version": "2.0.6",
       "dev": true
     },
-    "fast-url-parser": {
-      "version": "1.1.3",
-      "dev": true,
-      "requires": {
-        "punycode": "^1.3.2"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "dev": true
-        }
-      }
-    },
     "fastq": {
       "version": "1.15.0",
       "dev": true,
@@ -17602,13 +17430,6 @@
     "ignore": {
       "version": "4.0.6",
       "dev": true
-    },
-    "ignore-walk": {
-      "version": "3.0.4",
-      "dev": true,
-      "requires": {
-        "minimatch": "^3.0.4"
-      }
     },
     "immediate": {
       "version": "3.0.6",
@@ -18543,13 +18364,6 @@
     "node-addon-api": {
       "version": "2.0.2",
       "dev": true
-    },
-    "node-fetch": {
-      "version": "2.6.9",
-      "dev": true,
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      }
     },
     "node-gyp-build": {
       "version": "4.6.0",
@@ -19971,13 +19785,6 @@
       "version": "2.0.1",
       "dev": true
     },
-    "stream-events": {
-      "version": "1.0.5",
-      "dev": true,
-      "requires": {
-        "stubs": "^3.0.0"
-      }
-    },
     "stream-transform": {
       "version": "2.1.3",
       "dev": true,
@@ -20056,10 +19863,6 @@
       "version": "3.1.1",
       "dev": true
     },
-    "stubs": {
-      "version": "3.0.0",
-      "dev": true
-    },
     "supports-color": {
       "version": "7.2.0",
       "dev": true,
@@ -20121,17 +19924,6 @@
         "readable-stream": "^3.1.1"
       }
     },
-    "teeny-request": {
-      "version": "7.1.1",
-      "dev": true,
-      "requires": {
-        "http-proxy-agent": "^4.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.1",
-        "stream-events": "^1.0.5",
-        "uuid": "^8.0.0"
-      }
-    },
     "term-size": {
       "version": "2.2.1",
       "dev": true
@@ -20177,10 +19969,6 @@
     },
     "toidentifier": {
       "version": "1.0.1",
-      "dev": true
-    },
-    "tr46": {
-      "version": "0.0.3",
       "dev": true
     },
     "tree-kill": {
@@ -20434,13 +20222,6 @@
       "version": "4.0.1",
       "dev": true
     },
-    "urlgrey": {
-      "version": "1.0.0",
-      "dev": true,
-      "requires": {
-        "fast-url-parser": "^1.1.3"
-      }
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "dev": true
@@ -20504,18 +20285,6 @@
       "dev": true,
       "requires": {
         "defaults": "^1.0.3"
-      }
-    },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "dev": true
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "dev": true,
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {

--- a/server/package.json
+++ b/server/package.json
@@ -37,7 +37,7 @@
     "eslint": "eslint --max-warnings 0 \"./src/**/*.ts\" \"./test/**/*.ts\"",
     "prettier": "prettier \"*.json\" \"src/**/*.{ts,js,md,json,yml}\" \"test/**/*.{ts,js,md,json,yml}\"",
     "clean": "rimraf out .nyc_output coverage *.tsbuildinfo",
-    "test:codecov": "cross-env TS_NODE_FILES=true nyc --reporter=lcov mocha && codecov"
+    "test:codecov": "cross-env TS_NODE_FILES=true nyc --reporter=lcov mocha"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "1.0.2",
@@ -58,7 +58,6 @@
     "@types/sinon": "10.0.6",
     "c3-linearization": "0.3.0",
     "chai": "4.3.4",
-    "codecov": "3.8.3",
     "cross-env": "7.0.3",
     "eslint": "^7.23.0",
     "fast-glob": "3.2.11",


### PR DESCRIPTION
Switch to an explicit github action for uploading code coverage files to codecov. We move away from the npm package inline with codecov docs: https://docs.codecov.com/docs/github-2-getting-a-codecov-account-and-uploading-coverage.