### PR TITLE
Fix typo in the link Update README.md

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -266,7 +266,7 @@ To set **Solidity by Nomic Foundation** as your default formatter for solidity f
 
 3. Select `Solidity` as the default formatter for solidity files
 
-![Format Document With](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/images/select_solidity_plus_hardhat.png "Confiure default formatter")
+![Format Document With](https://raw.githubusercontent.com/NomicFoundation/hardhat-vscode/main/docs/images/select_solidity_plus_hardhat.png "Configure default formatter")
 
 ### Formatting Configuration
 


### PR DESCRIPTION
I fixed a typo in the README.md file, specifically in the alt text of an image link.

Changes Made:
Before:
"Confiure default formatter"
After:
"Configure default formatter"
This involved one addition and one deletion, ensuring the alt text is now correctly spelled.