### PR TITLE
Typo fix in Title Update SpecifyVisibility.ts

### DIFF
--- a/server/src/compilerDiagnostics/diagnostics/SpecifyVisibility.ts
+++ b/server/src/compilerDiagnostics/diagnostics/SpecifyVisibility.ts
@@ -92,7 +92,7 @@ export class SpecifyVisibility {
         : ` ${visibility} `;
 
     return {
-      title: `Add ${visibility} visibilty to function declaration`,
+      title: `Add ${visibility} visibility to function declaration`,
       kind: CodeActionKind.QuickFix,
       isPreferred: false,
       edit: {

--- a/server/test/services/codeactions/specifyVisibility.ts
+++ b/server/test/services/codeactions/specifyVisibility.ts
@@ -29,7 +29,7 @@ describe("Code Actions", () => {
 
       await assertCodeAction(specifyVisibility, fileText, diagnostic, [
         {
-          title: "Add public visibilty to function declaration",
+          title: "Add public visibility to function declaration",
           kind: "quickfix",
           isPreferred: false,
           edits: [
@@ -91,7 +91,7 @@ describe("Code Actions", () => {
 
       await assertCodeAction(specifyVisibility, fileText, diagnostic, [
         {
-          title: "Add public visibilty to function declaration",
+          title: "Add public visibility to function declaration",
           kind: "quickfix",
           isPreferred: false,
           edits: [

--- a/server/test/services/codeactions/specifyVisibility.ts
+++ b/server/test/services/codeactions/specifyVisibility.ts
@@ -49,7 +49,7 @@ describe("Code Actions", () => {
           ],
         },
         {
-          title: "Add private visibilty to function declaration",
+          title: "Add private visibility to function declaration",
           kind: "quickfix",
           isPreferred: false,
           edits: [
@@ -111,7 +111,7 @@ describe("Code Actions", () => {
           ],
         },
         {
-          title: "Add private visibilty to function declaration",
+          title: "Add private visibility to function declaration",
           kind: "quickfix",
           isPreferred: false,
           edits: [

--- a/test/protocol/test/textDocument/codeAction/hardhat/codeAction.test.ts
+++ b/test/protocol/test/textDocument/codeAction/hardhat/codeAction.test.ts
@@ -935,7 +935,7 @@ describe('[hardhat][codeAction]', () => {
 
     const expected = [
       {
-        title: 'Add public visibilty to function declaration',
+        title: 'Add public visibility to function declaration',
         kind: 'quickfix',
         isPreferred: false,
         edit: {

--- a/test/protocol/test/textDocument/codeAction/hardhat/codeAction.test.ts
+++ b/test/protocol/test/textDocument/codeAction/hardhat/codeAction.test.ts
@@ -959,7 +959,7 @@ describe('[hardhat][codeAction]', () => {
         },
       },
       {
-        title: 'Add private visibilty to function declaration',
+        title: 'Add private visibility to function declaration',
         kind: 'quickfix',
         isPreferred: false,
         edit: {


### PR DESCRIPTION
I fixed a typo in the SpecifyVisibility.ts file, correcting the word "visibilty" to "visibility" in the title property of an object.

Specific Change:
Before:
title: "Add ${visibility} visibilty to function declaration",
After:
title: "Add ${visibility} visibility to function declaration",
This change ensures proper spelling of "visibility," improving code clarity and reducing potential confusion.






