### PR TITLE
chore: add Sentry transaction monitoring to formatting

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 50%
+        base: development
+    patch:
+      default:
+        threshold: 50%
+    changes:
+      default:
+        threshold: 10%

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "latest"
+          node-version: "20"
 
       - name: Cache Node Modules
         id: cache-node-modules
@@ -84,5 +84,5 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          files: ./server/coverage/lcov.info     # __LCOV_RESULTS_INFO_FILE__ (keep in sync)
+          files: ./server/coverage/lcov.info # __LCOV_RESULTS_INFO_FILE__ (keep in sync)
           disable_search: true


### PR DESCRIPTION
Formatting has moved to the server side. We have added Sentry transaction monitoring to the top level `onDocumentFormatting` call.

There are separate subspans on the Sentry transaction for Forge and Prettier.

Resolves #622.
