### PR TITLE
Upgrade to slang 1.0.0 and use prettier 3 on the codebase

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -64,7 +64,7 @@
     "prettier": "2.5.1"
   },
   "dependencies": {
-    "@nomicfoundation/solidity-language-server": "0.6.16",
+    "@nomicfoundation/solidity-language-server": "0.8.18",
     "@sentry/node": "6.19.1",
     "vscode-languageclient": "9.0.1"
   },

--- a/client/scripts/bundle.js
+++ b/client/scripts/bundle.js
@@ -207,15 +207,6 @@ async function main() {
           solidityAnalyzerVersion,
 
         "@nomicfoundation/slang": slangVersion,
-        "@nomicfoundation/slang-darwin-arm64": slangVersion,
-        "@nomicfoundation/slang-win32-arm64-msvc": slangVersion,
-        "@nomicfoundation/slang-linux-arm64-gnu": slangVersion,
-        "@nomicfoundation/slang-linux-arm64-musl": slangVersion,
-        "@nomicfoundation/slang-win32-ia32-msvc": slangVersion,
-        "@nomicfoundation/slang-darwin-x64": slangVersion,
-        "@nomicfoundation/slang-win32-x64-msvc": slangVersion,
-        "@nomicfoundation/slang-linux-x64-gnu": slangVersion,
-        "@nomicfoundation/slang-linux-x64-musl": slangVersion,
       },
     })
   );

--- a/docs/publish-extension.md
+++ b/docs/publish-extension.md
@@ -17,6 +17,7 @@ To publish `hardhat-solidity` you need to do next steps:
 6. Update the version based on semver, ensure it is updated in:
 
    - The client package version in `./client/package.json`
+     - Its `@nomicfoundation/solidity-language-server` dependency version.
    - The language server package version in `./server/package.json`
    - The coc extension package version in `./coc/package.json`
      - Its `@nomicfoundation/solidity-language-server` dependency version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -439,6 +439,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bytecodealliance/preview2-shim": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.17.1.tgz",
+      "integrity": "sha512-h1qLL0TN5KXk/zagY2BtbZuDX6xYjz4Br9RZXEa0ID4UpiPc0agUMhTdz9r89G4vX5SU/tqBg1A6UNv2+DJ5pg==",
+      "license": "(Apache-2.0 WITH LLVM-exception)"
+    },
     "node_modules/@changesets/apply-release-plan": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-5.0.5.tgz",
@@ -2613,104 +2619,12 @@
       }
     },
     "node_modules/@nomicfoundation/slang": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang/-/slang-0.16.0.tgz",
-      "integrity": "sha512-JBI+X+6/1WnaVNvnWp7o9PRbIFpgxKDmEKzYnMUfrBGFmm7rT2PsvFvVBoZPeM09B0AFYK+XJt9tqnbJvzhlLw==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang/-/slang-0.19.0.tgz",
+      "integrity": "sha512-bOKJnc5/Q4Fbkm9OkaPItri81DGjZbzPeeGKbqUefPftEgGsFMtAqj+vSfT0fwGGuhoGXkGXk7SZ5oTpNE7xGg==",
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/slang-darwin-arm64": "0.16.0",
-        "@nomicfoundation/slang-darwin-x64": "0.16.0",
-        "@nomicfoundation/slang-linux-arm64-gnu": "0.16.0",
-        "@nomicfoundation/slang-linux-arm64-musl": "0.16.0",
-        "@nomicfoundation/slang-linux-x64-gnu": "0.16.0",
-        "@nomicfoundation/slang-linux-x64-musl": "0.16.0",
-        "@nomicfoundation/slang-win32-arm64-msvc": "0.16.0",
-        "@nomicfoundation/slang-win32-ia32-msvc": "0.16.0",
-        "@nomicfoundation/slang-win32-x64-msvc": "0.16.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nomicfoundation/slang-darwin-arm64": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-arm64/-/slang-darwin-arm64-0.16.0.tgz",
-      "integrity": "sha512-tdrpV2/sEy9pWevl6pg2qdG8chV5R2lO80D0vgwP3FTd27vwLRgAdSMSUlhtVSb8NWKx6E1dagjjNfabUzmZpQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nomicfoundation/slang-darwin-x64": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-darwin-x64/-/slang-darwin-x64-0.16.0.tgz",
-      "integrity": "sha512-a4OsidbwzaKOR7693ImYUSRKnmOs1xvTJviln0bc9nr6fngSkzXF7ijlHL/9/FrBhCIR+jY2ozmncWNOmqrvjQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nomicfoundation/slang-linux-arm64-gnu": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-gnu/-/slang-linux-arm64-gnu-0.16.0.tgz",
-      "integrity": "sha512-4kHqeVbJ6HvmhSIP3p/vS4SjiaC8/TRbeh+6jT77mr6fb6fVxUcVdNwCTVPocn7GRx1rYAsuYqjYZkeS72ubzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nomicfoundation/slang-linux-arm64-musl": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-arm64-musl/-/slang-linux-arm64-musl-0.16.0.tgz",
-      "integrity": "sha512-seuEaQSEGa3yqBI6Y/HH4X10+f7BNkX5OzOTNjWejqSIFAVBj0mWNBNWetT2YWDHRqiOSm5khD3+8LaSvShDRQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nomicfoundation/slang-linux-x64-gnu": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-gnu/-/slang-linux-x64-gnu-0.16.0.tgz",
-      "integrity": "sha512-DI8sIWhz1EsuAE2L4vlBM48WaSaWpRgUixG1ZHIlxpTwzn6s+DxmfAxmOcBeLpNdtfba9eSpqF+2539zllktPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nomicfoundation/slang-linux-x64-musl": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-linux-x64-musl/-/slang-linux-x64-musl-0.16.0.tgz",
-      "integrity": "sha512-80obGwJ336r5wxQ/dLzEDp1nlAYtMWdnP5G5T2JmCnIkxxEVnyQIH62VcK6mc7RMSVeAlL1RGGx2LdNbk9V4QA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nomicfoundation/slang-win32-arm64-msvc": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-arm64-msvc/-/slang-win32-arm64-msvc-0.16.0.tgz",
-      "integrity": "sha512-hcmsfXjRaCuy5/eUhrdDOnE5uqfJ0vVXvon5mTHaWzf6UE4REIx3vJwf/t4QQu1Q4mKKO5ZxzauBdzRtbhOKsw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nomicfoundation/slang-win32-ia32-msvc": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-ia32-msvc/-/slang-win32-ia32-msvc-0.16.0.tgz",
-      "integrity": "sha512-W9959+Tdq71kkE5EGxoQWBxhpe9bjxpY7ozDoPjz2lBzaGi8X24z4toS6us3W83URIf6Cve0VizAX4fz5MWjFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nomicfoundation/slang-win32-x64-msvc": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang-win32-x64-msvc/-/slang-win32-x64-msvc-0.16.0.tgz",
-      "integrity": "sha512-sOKuMtm3g62ugdhgpWqjF+o3clIR4eAIiAbx6oRPGB/9fPukgZnI5untsgTYJyVldAzby7jlIQ4R7df18aNraw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
+        "@bytecodealliance/preview2-shim": "0.17.1"
       }
     },
     "node_modules/@nomicfoundation/solidity-analyzer": {
@@ -10723,6 +10637,23 @@
         "antlr4ts": "^0.5.0-alpha.4"
       }
     },
+    "node_modules/prettier3": {
+      "name": "prettier",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -13850,7 +13781,7 @@
       "version": "0.8.18",
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/slang": "0.16.0",
+        "@nomicfoundation/slang": "0.19.0",
         "@nomicfoundation/solidity-analyzer": "0.1.1"
       },
       "bin": {
@@ -13887,6 +13818,7 @@
         "nyc": "15.1.0",
         "prettier": "2.5.1",
         "prettier-plugin-solidity": "1.1.2",
+        "prettier3": "npm:prettier@3.4.2",
         "qs": "^6.10.1",
         "rimraf": "3.0.2",
         "semver": "^7.3.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
       "version": "0.8.18",
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/solidity-language-server": "0.6.16",
+        "@nomicfoundation/solidity-language-server": "0.8.18",
         "@sentry/node": "6.19.1",
         "vscode-languageclient": "9.0.1"
       },
@@ -55,21 +55,6 @@
       },
       "engines": {
         "vscode": "^1.90.0"
-      }
-    },
-    "client/node_modules/@nomicfoundation/solidity-language-server": {
-      "version": "0.6.16",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-language-server/-/solidity-language-server-0.6.16.tgz",
-      "integrity": "sha512-ARoRC1m3HqG8u00uTcxNWWoY2Qmx83QydQN8UYXHmBSRpjggu8uPZikRHkVpassoiago1QmJQJtfAWQBIHLXPA==",
-      "license": "MIT",
-      "dependencies": {
-        "@nomicfoundation/solidity-analyzer": "0.1.1"
-      },
-      "bin": {
-        "nomicfoundation-solidity-language-server": "out/index.js"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "coc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -440,9 +440,9 @@
       }
     },
     "node_modules/@bytecodealliance/preview2-shim": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.17.1.tgz",
-      "integrity": "sha512-h1qLL0TN5KXk/zagY2BtbZuDX6xYjz4Br9RZXEa0ID4UpiPc0agUMhTdz9r89G4vX5SU/tqBg1A6UNv2+DJ5pg==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.17.2.tgz",
+      "integrity": "sha512-mNm/lblgES8UkVle8rGImXOz4TtL3eU3inHay/7TVchkKrb/lgcVvTK0+VAw8p5zQ0rgQsXm1j5dOlAAd+MeoA==",
       "license": "(Apache-2.0 WITH LLVM-exception)"
     },
     "node_modules/@changesets/apply-release-plan": {
@@ -2619,12 +2619,12 @@
       }
     },
     "node_modules/@nomicfoundation/slang": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang/-/slang-0.19.0.tgz",
-      "integrity": "sha512-bOKJnc5/Q4Fbkm9OkaPItri81DGjZbzPeeGKbqUefPftEgGsFMtAqj+vSfT0fwGGuhoGXkGXk7SZ5oTpNE7xGg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/slang/-/slang-1.0.0.tgz",
+      "integrity": "sha512-dnfv/+84/+iTSLBvqNQDA4/OZuq0tvJgFFwvnMwIdnMvn8QDcdouPTgF/nOwEuDtcIw5KWFzEf++UqpfwXCRpw==",
       "license": "MIT",
       "dependencies": {
-        "@bytecodealliance/preview2-shim": "0.17.1"
+        "@bytecodealliance/preview2-shim": "0.17.2"
       }
     },
     "node_modules/@nomicfoundation/solidity-analyzer": {
@@ -13781,7 +13781,7 @@
       "version": "0.8.18",
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/slang": "0.19.0",
+        "@nomicfoundation/slang": "1.0.0",
         "@nomicfoundation/solidity-analyzer": "0.1.1"
       },
       "bin": {

--- a/server/package.json
+++ b/server/package.json
@@ -35,8 +35,8 @@
     "test:coverage": "cross-env TS_NODE_FILES=true nyc mocha",
     "lint": "npm run prettier -- --check && npm run eslint",
     "lint:fix": "npm run prettier -- --write && npm run eslint -- --fix",
+    "prettier": "node scripts/prettier3.js",
     "eslint": "eslint --max-warnings 0 \"./src/**/*.ts\" \"./test/**/*.ts\"",
-    "prettier": "prettier \"*.json\" \"src/**/*.{ts,js,md,json,yml}\" \"test/**/*.{ts,js,md,json,yml}\"",
     "clean": "rimraf out .nyc_output coverage *.tsbuildinfo",
     "test:codecov": "cross-env TS_NODE_FILES=true nyc --reporter=lcov mocha"
   },
@@ -69,8 +69,9 @@
     "mocha": "9.1.3",
     "module-alias": "^2.2.2",
     "nyc": "15.1.0",
-    "prettier": "2.5.1",
     "prettier-plugin-solidity": "1.1.2",
+    "prettier": "2.5.1",
+    "prettier3": "npm:prettier@3.4.2",
     "qs": "^6.10.1",
     "rimraf": "3.0.2",
     "semver": "^7.3.7",
@@ -86,7 +87,7 @@
     "yaml": "^2.2.1"
   },
   "dependencies": {
-    "@nomicfoundation/slang": "0.16.0",
+    "@nomicfoundation/slang": "0.19.0",
     "@nomicfoundation/solidity-analyzer": "0.1.1"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -87,7 +87,7 @@
     "yaml": "^2.2.1"
   },
   "dependencies": {
-    "@nomicfoundation/slang": "0.19.0",
+    "@nomicfoundation/slang": "1.0.0",
     "@nomicfoundation/solidity-analyzer": "0.1.1"
   }
 }

--- a/server/scripts/prettier3.js
+++ b/server/scripts/prettier3.js
@@ -1,0 +1,31 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+try {
+  // Get extra flags e.g. --check, --write
+  const prettierFlags = process.argv.slice(2);
+
+  // Find prettier3 (aliased) package path
+  const lsOutput = execSync("npm ls prettier3 --parseable").toString().trim();
+  const packageRoot = lsOutput.split("\n")[0];
+
+  console.log(`Found prettier at ${packageRoot}`);
+
+  const binaryPath = path.join(packageRoot, "bin", "prettier.cjs");
+
+  const spawnArgs = [
+    binaryPath,
+    ...prettierFlags,
+    "*.json",
+    "src/**/*.{ts,js,md,json,yml}",
+    "test/**/*.{ts,js,md,json,yml}",
+  ];
+
+  // Execute the prettier3 binary
+  require("child_process").spawn("node", spawnArgs, {
+    stdio: "inherit",
+  });
+} catch (error) {
+  console.error("Error running prettier:", error.message);
+  process.exit(1);
+}

--- a/server/src/frameworks/Hardhat/worker/WorkerProcess.ts
+++ b/server/src/frameworks/Hardhat/worker/WorkerProcess.ts
@@ -106,7 +106,9 @@ export class WorkerProcess {
     this.hre = require(`${hardhatBase}/internal/lib/hardhat-lib.js`);
 
     // Load local cache through require
-    const cacheModule = require(`${hardhatBase}/builtin-tasks/utils/solidity-files-cache`);
+    const cacheModule = require(
+      `${hardhatBase}/builtin-tasks/utils/solidity-files-cache`
+    );
 
     this.solidityFilesCachePath = cacheModule.getSolidityFilesCachePath(
       this.hre.config.paths

--- a/server/src/frameworks/Hardhat/worker/WorkerProtocol.ts
+++ b/server/src/frameworks/Hardhat/worker/WorkerProtocol.ts
@@ -37,7 +37,10 @@ export abstract class ResponseMessage extends Message {
 export class ErrorResponseMessage extends ResponseMessage {
   public type = MessageType.ERROR_RESPONSE;
 
-  constructor(requestId: number, public error: any) {
+  constructor(
+    requestId: number,
+    public error: any
+  ) {
     super(requestId);
   }
 }
@@ -49,7 +52,10 @@ export class InitializedMessage extends Message {
 export class LogMessage extends Message {
   public type = MessageType.LOG;
 
-  constructor(public logMessage: string, public level: LogLevel) {
+  constructor(
+    public logMessage: string,
+    public level: LogLevel
+  ) {
     super();
   }
 }
@@ -57,14 +63,20 @@ export class LogMessage extends Message {
 export class FileBelongsRequest extends RequestMessage {
   public type = MessageType.FILE_BELONGS_REQUEST;
 
-  constructor(requestId: number, public uri: string) {
+  constructor(
+    requestId: number,
+    public uri: string
+  ) {
     super(requestId);
   }
 }
 
 export class FileBelongsResponse extends ResponseMessage {
   public type = MessageType.FILE_BELONGS_RESPONSE;
-  constructor(requestId: number, public result: FileBelongsResult) {
+  constructor(
+    requestId: number,
+    public result: FileBelongsResult
+  ) {
     super(requestId);
   }
 }
@@ -84,7 +96,10 @@ export class ResolveImportRequest extends RequestMessage {
 
 export class ResolveImportResponse extends ResponseMessage {
   public type = MessageType.RESOLVE_IMPORT_RESPONSE;
-  constructor(requestId: number, public path: string | undefined) {
+  constructor(
+    requestId: number,
+    public path: string | undefined
+  ) {
     super(requestId);
   }
 }

--- a/server/src/frameworks/base/Project.ts
+++ b/server/src/frameworks/base/Project.ts
@@ -15,7 +15,10 @@ export interface FileBelongsResult {
 }
 
 export abstract class Project {
-  constructor(public serverState: ServerState, public basePath: string) {}
+  constructor(
+    public serverState: ServerState,
+    public basePath: string
+  ) {}
 
   public abstract configPath?: string;
 

--- a/server/src/parser/slangHelpers.ts
+++ b/server/src/parser/slangHelpers.ts
@@ -1,10 +1,11 @@
-import { TextIndex, TextRange } from "@nomicfoundation/slang/text_index";
 import _ from "lodash";
 import { Range, Position } from "vscode-languageserver-types";
-import { Language } from "@nomicfoundation/slang/language";
 import semver from "semver";
+import type {
+  TextIndex,
+  TextRange,
+} from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { Logger } from "../utils/Logger";
-import { getPlatform } from "../utils/operatingSystem";
 
 export function slangToVSCodeRange(range: TextRange): Range {
   return {
@@ -20,27 +21,12 @@ export function slangToVSCodePosition(position: TextIndex): Position {
   };
 }
 
-const SUPPORTED_PLATFORMS = [
-  "darwin-arm64",
-  "darwin-x64",
-  "linux-arm64",
-  "linux-x64",
-  "win32-arm64",
-  "win32-ia32",
-  "win32-x64",
-];
-
-export function isSlangSupported() {
-  const currentPlatform = getPlatform();
-
-  return SUPPORTED_PLATFORMS.includes(currentPlatform);
-}
-
-export function resolveVersion(
+export async function resolveVersion(
   logger: Logger,
   versionPragmas: string[]
-): string {
-  const versions = Language.supportedVersions();
+): Promise<string> {
+  const { LanguageFacts } = await import("@nomicfoundation/slang/utils");
+  const versions = LanguageFacts.allVersions();
 
   const slangVersion = semver.maxSatisfying(versions, versionPragmas.join(" "));
 

--- a/server/src/services/documentSymbol/SymbolFinder.ts
+++ b/server/src/services/documentSymbol/SymbolFinder.ts
@@ -1,9 +1,12 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { SymbolKind } from "vscode-languageserver-types";
 import _ from "lodash";
-import { TerminalNode } from "@nomicfoundation/slang/cst";
-import { TextRange } from "@nomicfoundation/slang/text_index";
-import { Query, QueryMatch } from "@nomicfoundation/slang/query";
+import type {
+  TerminalNode,
+  Query,
+  QueryMatch,
+  TextRange,
+} from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 
 export interface SymbolData {
   range: TextRange;
@@ -13,7 +16,6 @@ export interface SymbolData {
 
 export abstract class SymbolFinder {
   public abstract readonly symbolKind: SymbolKind;
-  public abstract readonly query: Query;
 
   public findSymbol(match: QueryMatch): SymbolData {
     // Ensure definition rule and name identifier are present
@@ -22,18 +24,20 @@ export abstract class SymbolFinder {
     if (definition === undefined || identifier === undefined) {
       throw new Error(
         `Captures @definition or @identifier not present in query match.
-         Query: '${this.query}'
+         Query: '${this.getQuery()}'
          Captures: ${JSON.stringify(match, undefined, 2)}`
       );
     }
 
     const definitionCursor = definition[0];
-    const identifierNode = identifier[0].node() as TerminalNode;
+    const identifierNode = identifier[0].node as TerminalNode;
 
     return {
       range: definitionCursor.textRange,
       symbolKind: this.symbolKind,
-      name: identifierNode.text,
+      name: identifierNode.unparse(),
     };
   }
+
+  public abstract getQuery(): Promise<Query>;
 }

--- a/server/src/services/documentSymbol/finders/ConstantDefinition.ts
+++ b/server/src/services/documentSymbol/finders/ConstantDefinition.ts
@@ -1,13 +1,16 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { SymbolFinder } from "../SymbolFinder";
 
 export class ConstantDefinition extends SymbolFinder {
   public override readonly symbolKind = SymbolKind.Constant;
 
-  public override readonly query = Query.parse(`
-    @definition [ConstantDefinition
-      @identifier name: [_]
-    ]
-  `);
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
+      @definition [ConstantDefinition
+        @identifier name: [_]
+      ]
+    `);
+  }
 }

--- a/server/src/services/documentSymbol/finders/ConstructorDefinition.ts
+++ b/server/src/services/documentSymbol/finders/ConstructorDefinition.ts
@@ -1,13 +1,16 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { SymbolFinder } from "../SymbolFinder";
 
 export class ConstructorDefinition extends SymbolFinder {
   public override readonly symbolKind = SymbolKind.Constructor;
 
-  public override readonly query = Query.parse(`
-    @definition [ConstructorDefinition
-      @identifier [ConstructorKeyword]
-    ]
-  `);
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
+      @definition [ConstructorDefinition
+        @identifier [ConstructorKeyword]
+      ]
+    `);
+  }
 }

--- a/server/src/services/documentSymbol/finders/ContractDefinition.ts
+++ b/server/src/services/documentSymbol/finders/ContractDefinition.ts
@@ -1,13 +1,16 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { SymbolFinder } from "../SymbolFinder";
 
 export class ContractDefinition extends SymbolFinder {
   public override readonly symbolKind = SymbolKind.Class;
 
-  public override readonly query = Query.parse(`
-    @definition [ContractDefinition
-      @identifier name: [_]
-    ]
-  `);
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
+      @definition [ContractDefinition
+        @identifier name: [_]
+      ]
+    `);
+  }
 }

--- a/server/src/services/documentSymbol/finders/EnumDefinition.ts
+++ b/server/src/services/documentSymbol/finders/EnumDefinition.ts
@@ -1,13 +1,16 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { SymbolFinder } from "../SymbolFinder";
 
 export class EnumDefinition extends SymbolFinder {
   public override readonly symbolKind = SymbolKind.Enum;
 
-  public override readonly query = Query.parse(`
-    @definition [EnumDefinition
-      @identifier name: [_]
-    ]
-  `);
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
+      @definition [EnumDefinition
+        @identifier name: [_]
+      ]
+    `);
+  }
 }

--- a/server/src/services/documentSymbol/finders/ErrorDefinition.ts
+++ b/server/src/services/documentSymbol/finders/ErrorDefinition.ts
@@ -1,13 +1,16 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { SymbolFinder } from "../SymbolFinder";
 
 export class ErrorDefinition extends SymbolFinder {
   public override readonly symbolKind = SymbolKind.Event;
 
-  public override readonly query = Query.parse(`
-    @definition [ErrorDefinition
-      @identifier name: [_]
-    ]
-  `);
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
+      @definition [ErrorDefinition
+        @identifier name: [_]
+      ]
+    `);
+  }
 }

--- a/server/src/services/documentSymbol/finders/EventDefinition.ts
+++ b/server/src/services/documentSymbol/finders/EventDefinition.ts
@@ -1,13 +1,16 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { SymbolFinder } from "../SymbolFinder";
 
 export class EventDefinition extends SymbolFinder {
   public override readonly symbolKind = SymbolKind.Event;
 
-  public override readonly query = Query.parse(`
-    @definition [EventDefinition
-      @identifier name: [_]
-    ]
-  `);
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
+      @definition [EventDefinition
+        @identifier name: [_]
+      ]
+    `);
+  }
 }

--- a/server/src/services/documentSymbol/finders/FallbackFunctionDefinition.ts
+++ b/server/src/services/documentSymbol/finders/FallbackFunctionDefinition.ts
@@ -1,13 +1,16 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { SymbolFinder } from "../SymbolFinder";
 
 export class FallbackFunctionDefinition extends SymbolFinder {
   public override readonly symbolKind = SymbolKind.Function;
 
-  public override readonly query = Query.parse(`
-    @definition [FallbackFunctionDefinition
-      @identifier [FallbackKeyword]
-    ]
-  `);
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
+      @definition [FallbackFunctionDefinition
+        @identifier [FallbackKeyword]
+      ]
+    `);
+  }
 }

--- a/server/src/services/documentSymbol/finders/FunctionDefinition.ts
+++ b/server/src/services/documentSymbol/finders/FunctionDefinition.ts
@@ -1,15 +1,18 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { SymbolFinder } from "../SymbolFinder";
 
 export class FunctionDefinition extends SymbolFinder {
   public override readonly symbolKind = SymbolKind.Function;
 
-  public override readonly query = Query.parse(`
-    @definition [FunctionDefinition
-      [FunctionName
-        @identifier variant: [_]
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
+      @definition [FunctionDefinition
+        [FunctionName
+          @identifier variant: [_]
+        ]
       ]
-    ]
-  `);
+    `);
+  }
 }

--- a/server/src/services/documentSymbol/finders/InterfaceDefinition.ts
+++ b/server/src/services/documentSymbol/finders/InterfaceDefinition.ts
@@ -1,13 +1,16 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { SymbolFinder } from "../SymbolFinder";
 
 export class InterfaceDefinition extends SymbolFinder {
   public override readonly symbolKind = SymbolKind.Interface;
 
-  public override readonly query = Query.parse(`
-    @definition [InterfaceDefinition
-      @identifier name: [_]
-    ]
-  `);
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
+      @definition [InterfaceDefinition
+        @identifier name: [_]
+      ]
+    `);
+  }
 }

--- a/server/src/services/documentSymbol/finders/LibraryDefinition.ts
+++ b/server/src/services/documentSymbol/finders/LibraryDefinition.ts
@@ -1,13 +1,16 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { SymbolFinder } from "../SymbolFinder";
 
 export class LibraryDefinition extends SymbolFinder {
   public override readonly symbolKind = SymbolKind.Class;
 
-  public override readonly query = Query.parse(`
-    @definition [LibraryDefinition
-      @identifier name: [_]
-    ]
-  `);
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
+      @definition [LibraryDefinition
+        @identifier name: [_]
+      ]
+    `);
+  }
 }

--- a/server/src/services/documentSymbol/finders/ModifierDefinition.ts
+++ b/server/src/services/documentSymbol/finders/ModifierDefinition.ts
@@ -1,13 +1,16 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { SymbolFinder } from "../SymbolFinder";
 
 export class ModifierDefinition extends SymbolFinder {
   public override readonly symbolKind = SymbolKind.Function;
 
-  public override readonly query = Query.parse(`
-    @definition [ModifierDefinition
-      @identifier name: [_]
-    ]
-  `);
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
+      @definition [ModifierDefinition
+        @identifier name: [_]
+      ]
+    `);
+  }
 }

--- a/server/src/services/documentSymbol/finders/ReceiveFunctionDefinition.ts
+++ b/server/src/services/documentSymbol/finders/ReceiveFunctionDefinition.ts
@@ -1,13 +1,16 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { SymbolFinder } from "../SymbolFinder";
 
 export class ReceiveFunctionDefinition extends SymbolFinder {
   public override readonly symbolKind = SymbolKind.Function;
 
-  public override readonly query = Query.parse(`
-    @definition [ReceiveFunctionDefinition
-      @identifier [ReceiveKeyword]
-    ]
-  `);
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
+      @definition [ReceiveFunctionDefinition
+        @identifier [ReceiveKeyword]
+      ]
+    `);
+  }
 }

--- a/server/src/services/documentSymbol/finders/StateVariableDefinition.ts
+++ b/server/src/services/documentSymbol/finders/StateVariableDefinition.ts
@@ -1,13 +1,16 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { SymbolFinder } from "../SymbolFinder";
 
 export class StateVariableDefinition extends SymbolFinder {
   public override readonly symbolKind = SymbolKind.Property;
 
-  public override readonly query = Query.parse(`
-    @definition [StateVariableDefinition
-      @identifier name: [_]
-    ]
-  `);
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
+      @definition [StateVariableDefinition
+        @identifier name: [_]
+      ]
+    `);
+  }
 }

--- a/server/src/services/documentSymbol/finders/StructDefinition.ts
+++ b/server/src/services/documentSymbol/finders/StructDefinition.ts
@@ -1,13 +1,16 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { SymbolFinder } from "../SymbolFinder";
 
 export class StructDefinition extends SymbolFinder {
   public override readonly symbolKind = SymbolKind.Struct;
 
-  public override readonly query = Query.parse(`
-    @definition [StructDefinition
-      @identifier name: [_]
-    ]
-  `);
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
+      @definition [StructDefinition
+        @identifier name: [_]
+      ]
+    `);
+  }
 }

--- a/server/src/services/documentSymbol/finders/StructMember.ts
+++ b/server/src/services/documentSymbol/finders/StructMember.ts
@@ -1,13 +1,16 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { SymbolFinder } from "../SymbolFinder";
 
 export class StructMember extends SymbolFinder {
   public override readonly symbolKind = SymbolKind.Property;
 
-  public override readonly query = Query.parse(`
-    @definition [StructMember
-      @identifier name: [_]
-    ]
-  `);
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
+      @definition [StructMember
+        @identifier name: [_]
+      ]
+    `);
+  }
 }

--- a/server/src/services/documentSymbol/finders/UnnamedFunctionDefinition.ts
+++ b/server/src/services/documentSymbol/finders/UnnamedFunctionDefinition.ts
@@ -1,13 +1,16 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { SymbolFinder } from "../SymbolFinder";
 
 export class UnnamedFunctionDefinition extends SymbolFinder {
   public override readonly symbolKind = SymbolKind.Function;
 
-  public override readonly query = Query.parse(`
-    @definition [UnnamedFunctionDefinition
-      @identifier [FunctionKeyword]
-    ]
-  `);
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
+      @definition [UnnamedFunctionDefinition
+        @identifier [FunctionKeyword]
+      ]
+    `);
+  }
 }

--- a/server/src/services/documentSymbol/finders/UserDefinedValueTypeDefinition.ts
+++ b/server/src/services/documentSymbol/finders/UserDefinedValueTypeDefinition.ts
@@ -1,13 +1,16 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { SymbolFinder } from "../SymbolFinder";
 
 export class UserDefinedValueTypeDefinition extends SymbolFinder {
   public override readonly symbolKind = SymbolKind.TypeParameter;
 
-  public override readonly query = Query.parse(`
-    @definition [UserDefinedValueTypeDefinition
-      @identifier name: [_]
-    ]
-  `);
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
+      @definition [UserDefinedValueTypeDefinition
+        @identifier name: [_]
+      ]
+    `);
+  }
 }

--- a/server/src/services/documentSymbol/finders/VariableDeclarationStatement.ts
+++ b/server/src/services/documentSymbol/finders/VariableDeclarationStatement.ts
@@ -1,13 +1,16 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { SymbolFinder } from "../SymbolFinder";
 
 export class VariableDeclarationStatement extends SymbolFinder {
   public override readonly symbolKind = SymbolKind.Variable;
 
-  public override readonly query = Query.parse(`
-    @definition [VariableDeclarationStatement
-      @identifier name: [_]
-    ]
-  `);
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
+      @definition [VariableDeclarationStatement
+        @identifier name: [_]
+      ]
+    `);
+  }
 }

--- a/server/src/services/documentSymbol/finders/YulFunctionDefinition.ts
+++ b/server/src/services/documentSymbol/finders/YulFunctionDefinition.ts
@@ -1,13 +1,16 @@
 import { SymbolKind } from "vscode-languageserver-types";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { SymbolFinder } from "../SymbolFinder";
 
 export class YulFunctionDefinition extends SymbolFinder {
   public override readonly symbolKind = SymbolKind.Function;
 
-  public override readonly query = Query.parse(`
-    @definition [YulFunctionDefinition
-      @identifier name: [_]
-    ]
-  `);
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
+      @definition [YulFunctionDefinition
+        @identifier name: [_]
+      ]
+    `);
+  }
 }

--- a/server/src/services/initialization/onInitialize.ts
+++ b/server/src/services/initialization/onInitialize.ts
@@ -6,7 +6,6 @@ import {
 } from "vscode-languageserver/node";
 import { ServerState } from "../../types";
 import { tokensTypes } from "../semanticHighlight/tokenTypes";
-import { isSlangSupported } from "../../parser/slangHelpers";
 import { indexWorkspaceFolders } from "./indexWorkspaceFolders";
 import { updateAvailableSolcVersions } from "./updateAvailableSolcVersions";
 
@@ -45,8 +44,6 @@ export const onInitialize = (serverState: ServerState) => {
     await updateAvailableSolcVersions(serverState);
 
     logger.info("Language server ready");
-
-    const slangSupported = isSlangSupported();
 
     // Index and analysis
     await serverState.telemetry.trackTiming("indexing", async (transaction) => {
@@ -88,9 +85,9 @@ export const onInitialize = (serverState: ServerState) => {
             tokenModifiers: [],
           },
           range: false,
-          full: slangSupported,
+          full: true,
         },
-        documentSymbolProvider: slangSupported,
+        documentSymbolProvider: true,
         workspace: {
           workspaceFolders: {
             supported: false,

--- a/server/src/services/semanticHighlight/Highlighter.ts
+++ b/server/src/services/semanticHighlight/Highlighter.ts
@@ -1,20 +1,25 @@
 import { SemanticTokenTypes } from "vscode-languageserver-types";
-import { Query, QueryMatch } from "@nomicfoundation/slang/query";
+import type {
+  Query,
+  QueryMatch,
+} from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { SemanticTokensBuilder } from "./SemanticTokensBuilder";
 
 // Abstraction for a visitor that wants to highlight tokens
 export abstract class Highlighter {
   public abstract readonly semanticTokenType: SemanticTokenTypes;
-  public abstract readonly query: Query;
 
-  public onResult(tokenBuilder: SemanticTokensBuilder, match: QueryMatch) {
+  public async onResult(
+    tokenBuilder: SemanticTokensBuilder,
+    match: QueryMatch
+  ) {
     // Ensure definition rule and name identifier are present
     const { identifier } = match.captures;
 
     if (identifier === undefined) {
       throw new Error(
         `Capture @identifier not present in query match.
-         Query: '${this.query}'
+         Query: '${await this.getQuery()}'
          Captures: ${JSON.stringify(match, undefined, 2)}`
       );
     }
@@ -24,4 +29,6 @@ export abstract class Highlighter {
 
     tokenBuilder.addToken(identifierCursor.textRange, this.semanticTokenType);
   }
+
+  public abstract getQuery(): Promise<Query>;
 }

--- a/server/src/services/semanticHighlight/SemanticTokensBuilder.ts
+++ b/server/src/services/semanticHighlight/SemanticTokensBuilder.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { TextRange } from "@nomicfoundation/slang/text_index";
+import type { TextRange } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { getTokenTypeIndex } from "./tokenTypes";
 
 // Helps building a SemanticTokens response by providing slang nodes and supported token types

--- a/server/src/services/semanticHighlight/highlighters/ContractDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/ContractDefinitionHighlighter.ts
@@ -1,14 +1,17 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { Highlighter } from "../Highlighter";
 
 // Highlights contract definitions
 export class ContractDefinitionHighlighter extends Highlighter {
   public override readonly semanticTokenType = SemanticTokenTypes.type;
 
-  public override readonly query = Query.parse(`
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
     [ContractDefinition
       @identifier name: [_]
     ]
   `);
+  }
 }

--- a/server/src/services/semanticHighlight/highlighters/CustomTypeHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/CustomTypeHighlighter.ts
@@ -1,16 +1,18 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { Highlighter } from "../Highlighter";
 
-// Highlights custom type names
 export class CustomTypeHighlighter extends Highlighter {
   public override readonly semanticTokenType = SemanticTokenTypes.type;
 
-  public override readonly query = Query.parse(`
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
     [TypeName
       [IdentifierPath
         @identifier [Identifier]
       ]
     ]
   `);
+  }
 }

--- a/server/src/services/semanticHighlight/highlighters/EnumDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/EnumDefinitionHighlighter.ts
@@ -1,13 +1,16 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { Highlighter } from "../Highlighter";
 
 export class EnumDefinitionHighlighter extends Highlighter {
   public override readonly semanticTokenType = SemanticTokenTypes.type;
 
-  public override readonly query = Query.parse(`
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
     [EnumDefinition
       @identifier name: [_]
     ]
   `);
+  }
 }

--- a/server/src/services/semanticHighlight/highlighters/ErrorDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/ErrorDefinitionHighlighter.ts
@@ -1,13 +1,16 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { Highlighter } from "../Highlighter";
 
 export class ErrorDefinitionHighlighter extends Highlighter {
   public override readonly semanticTokenType = SemanticTokenTypes.type;
 
-  public override readonly query = Query.parse(`
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
     [ErrorDefinition
       @identifier name: [_]
     ]
   `);
+  }
 }

--- a/server/src/services/semanticHighlight/highlighters/EventDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/EventDefinitionHighlighter.ts
@@ -1,14 +1,16 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { Highlighter } from "../Highlighter";
 
-// Highlights event definitions
 export class EventDefinitionHighlighter extends Highlighter {
   public override readonly semanticTokenType = SemanticTokenTypes.type;
 
-  public override readonly query = Query.parse(`
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
     [EventDefinition
       @identifier name: [_]
     ]
   `);
+  }
 }

--- a/server/src/services/semanticHighlight/highlighters/EventEmissionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/EventEmissionHighlighter.ts
@@ -1,17 +1,18 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { Highlighter } from "../Highlighter";
-import {} from "../../../parser/slangHelpers";
 
-// Highlights event emissions
 export class EventEmissionHighlighter extends Highlighter {
   public override readonly semanticTokenType = SemanticTokenTypes.type;
 
-  public override readonly query = Query.parse(`
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
     [EmitStatement
       [IdentifierPath
         @identifier [Identifier]
       ]
     ]
   `);
+  }
 }

--- a/server/src/services/semanticHighlight/highlighters/FunctionCallHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/FunctionCallHighlighter.ts
@@ -1,16 +1,18 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { Highlighter } from "../Highlighter";
 
-// Highlights function calls
 export class FunctionCallHighlighter extends Highlighter {
   public override readonly semanticTokenType = SemanticTokenTypes.function;
 
-  public override readonly query = Query.parse(`
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
     [FunctionCallExpression
       [Expression
         @identifier [Identifier]
       ]
     ]
   `);
+  }
 }

--- a/server/src/services/semanticHighlight/highlighters/FunctionDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/FunctionDefinitionHighlighter.ts
@@ -1,16 +1,18 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { Highlighter } from "../Highlighter";
 
-// Highlights function definitions
 export class FunctionDefinitionHighlighter extends Highlighter {
   public override readonly semanticTokenType = SemanticTokenTypes.function;
 
-  public override readonly query = Query.parse(`
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
     [FunctionDefinition
       [FunctionName
         @identifier [Identifier]
       ]
     ]
   `);
+  }
 }

--- a/server/src/services/semanticHighlight/highlighters/InterfaceDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/InterfaceDefinitionHighlighter.ts
@@ -1,14 +1,16 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { Highlighter } from "../Highlighter";
 
-// Highlights interface definitions
 export class InterfaceDefinitionHighlighter extends Highlighter {
   public override readonly semanticTokenType = SemanticTokenTypes.type;
 
-  public override readonly query = Query.parse(`
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
     [InterfaceDefinition
       @identifier name: [_]
     ]
   `);
+  }
 }

--- a/server/src/services/semanticHighlight/highlighters/LibraryDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/LibraryDefinitionHighlighter.ts
@@ -1,13 +1,16 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { Highlighter } from "../Highlighter";
 
 export class LibraryDefinitionHighlighter extends Highlighter {
   public override readonly semanticTokenType = SemanticTokenTypes.type;
 
-  public override readonly query = Query.parse(`
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
     [LibraryDefinition
       @identifier name: [_]
     ]
   `);
+  }
 }

--- a/server/src/services/semanticHighlight/highlighters/StructDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/StructDefinitionHighlighter.ts
@@ -1,14 +1,16 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { Highlighter } from "../Highlighter";
 
-// Highlights struct definitions
 export class StructDefinitionHighlighter extends Highlighter {
   public override readonly semanticTokenType = SemanticTokenTypes.type;
 
-  public override readonly query = Query.parse(`
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
     [StructDefinition
       @identifier name: [_]
     ]
   `);
+  }
 }

--- a/server/src/services/semanticHighlight/highlighters/UserDefinedValueTypeDefinitionHighlighter.ts
+++ b/server/src/services/semanticHighlight/highlighters/UserDefinedValueTypeDefinitionHighlighter.ts
@@ -1,13 +1,16 @@
 import { SemanticTokenTypes } from "vscode-languageserver-protocol";
-import { Query } from "@nomicfoundation/slang/query";
+import type { Query } from "@nomicfoundation/slang/cst" with { "resolution-mode": "import" };
 import { Highlighter } from "../Highlighter";
 
 export class UserDefinedValueTypeDefinitionHighlighter extends Highlighter {
   public override readonly semanticTokenType = SemanticTokenTypes.type;
 
-  public override readonly query = Query.parse(`
+  public override async getQuery(): Promise<Query> {
+    const { Query } = await import("@nomicfoundation/slang/cst");
+    return Query.create(`
     [UserDefinedValueTypeDefinition
       @identifier name: [_]
     ]
   `);
+  }
 }


### PR DESCRIPTION
- Upgraded slang to 1.0.0, which doesnt have native bindings nor optional packages
- Replaced all static imports for dynamic imports. This means many sync functions are now  async.
- Updated all calls to slang with the new apis
- Updated documentSymbols and semanticTokens features
- Installed prettier 3 with an alias (prettier3), to be used on our codebase. Wrote a small script to access it binary. This is necessary to support TS 5.3+ syntax (import attributes in our case).


Closes #632