### PR TITLE
Rework forge command invocation (broken EPIPE issue)

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,9 +4,11 @@ coverage:
       default:
         threshold: 50%
         base: development
+        informational: true
     patch:
       default:
         threshold: 50%
+        informational: false
     changes:
       default:
         threshold: 10%

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,11 +4,9 @@ coverage:
       default:
         threshold: 50%
         base: development
-        informational: true
     patch:
       default:
         threshold: 50%
-        informational: false
     changes:
       default:
         threshold: 10%

--- a/server/src/frameworks/Foundry/resolveForgeCommand.ts
+++ b/server/src/frameworks/Foundry/resolveForgeCommand.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { ForgeResolveError } from "../../utils/errors";
 import { runCmd, runningOnWindows } from "../../utils/operatingSystem";
 
 let resolvedForgeCommand: string;
@@ -41,12 +42,12 @@ export async function resolveForgeCommand() {
         continue;
       } else {
         // command found but execution failed
-        throw error;
+        throw new ForgeResolveError(error.message);
       }
     }
   }
 
-  throw new Error(
+  throw new ForgeResolveError(
     `Couldn't find forge binary. Performed lookup: ${JSON.stringify(
       potentialForgeCommands
     )}`

--- a/server/src/services/formatting/forgeFormat.ts
+++ b/server/src/services/formatting/forgeFormat.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { TextEdit } from "vscode-languageserver-types";
 import { URI } from "vscode-uri";
+import type { ExecException } from "node:child_process";
 import { resolveForgeCommand } from "../../frameworks/Foundry/resolveForgeCommand";
 import { Logger } from "../../utils/Logger";
 import { execWithInput } from "../../utils/operatingSystem";
@@ -44,10 +45,14 @@ export async function forgeFormat(
 
     return [textEdit];
   } catch (error: unknown) {
-    if (error instanceof Error && "killed" in error && error.killed) {
+    if (isKilledDefinedExecException(error) && error.killed === true) {
       throw new TimeoutError(FORMAT_TIMEOUT);
     } else {
       throw error;
     }
   }
+}
+
+function isKilledDefinedExecException(error: unknown): error is ExecException {
+  return error instanceof Error && "killed" in error;
 }

--- a/server/src/services/formatting/forgeFormat.ts
+++ b/server/src/services/formatting/forgeFormat.ts
@@ -1,11 +1,10 @@
-import * as cp from "child_process";
 import path from "path";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { TextEdit } from "vscode-languageserver-types";
 import { URI } from "vscode-uri";
-import { promisify } from "util";
 import { resolveForgeCommand } from "../../frameworks/Foundry/resolveForgeCommand";
 import { Logger } from "../../utils/Logger";
+import { execWithInput } from "../../utils/operatingSystem";
 
 export async function forgeFormat(
   text: string,
@@ -19,25 +18,14 @@ export async function forgeFormat(
   logger.trace(`Forge command: ${forgeCommand}`);
   logger.trace(`CWD: ${cwd}`);
 
-  // Spawn and promisify the forge fmt process
-  const execPromise = promisify(cp.exec)(`${forgeCommand} fmt --raw -`, {
-    cwd,
-  });
-
-  // Write the file contents to the process
-  const { child } = execPromise;
-  child.stdin?.write(text);
-  child.stdin?.end();
-
-  // Set a time limit
-  const timeout = setTimeout(() => {
-    child.kill("SIGKILL");
-  }, 2000);
-
   // Wait for the formatted output
-  const formattedText = (await execPromise).stdout;
-
-  clearTimeout(timeout);
+  const execPromise = await execWithInput(
+    `${forgeCommand} fmt --raw -`,
+    text,
+    { cwd },
+    2000
+  );
+  const formattedText = execPromise.stdout;
 
   // Build and return a text edit with the entire file content
   const textEdit: TextEdit = {

--- a/server/src/services/formatting/forgeFormat.ts
+++ b/server/src/services/formatting/forgeFormat.ts
@@ -43,8 +43,8 @@ export async function forgeFormat(
     };
 
     return [textEdit];
-  } catch (error: any) {
-    if (error.killed) {
+  } catch (error: unknown) {
+    if (error instanceof Error && "killed" in error && error.killed) {
       throw new TimeoutError(FORMAT_TIMEOUT);
     } else {
       throw error;

--- a/server/src/services/formatting/onDocumentFormatting.ts
+++ b/server/src/services/formatting/onDocumentFormatting.ts
@@ -5,7 +5,7 @@ import { Logger } from "@utils/Logger";
 import { Transaction } from "@sentry/types";
 import { ServerState } from "../../types";
 import { TrackingResult } from "../../telemetry/types";
-import { TimeoutError } from "../../utils/errors";
+import { ForgeResolveError, TimeoutError } from "../../utils/errors";
 import { prettierFormat } from "./prettierFormat";
 import { forgeFormat } from "./forgeFormat";
 
@@ -47,12 +47,14 @@ export function onDocumentFormatting(serverState: ServerState) {
               return { status: "invalid_argument", result: null };
           }
         } catch (error) {
-          serverState.logger.trace(
+          serverState.logger.info(
             `Error formatting document ${uri} with ${formatter}: ${error}`
           );
 
           if (error instanceof TimeoutError) {
             return { status: "deadline_exceeded", result: null };
+          } else if (error instanceof ForgeResolveError) {
+            return { status: "failed_precondition", result: null };
           } else {
             return { status: "internal_error", result: null };
           }

--- a/server/src/services/formatting/onDocumentFormatting.ts
+++ b/server/src/services/formatting/onDocumentFormatting.ts
@@ -5,6 +5,7 @@ import { Logger } from "@utils/Logger";
 import { Transaction } from "@sentry/types";
 import { ServerState } from "../../types";
 import { TrackingResult } from "../../telemetry/types";
+import { TimeoutError } from "../../utils/errors";
 import { prettierFormat } from "./prettierFormat";
 import { forgeFormat } from "./forgeFormat";
 
@@ -50,7 +51,11 @@ export function onDocumentFormatting(serverState: ServerState) {
             `Error formatting document ${uri} with ${formatter}: ${error}`
           );
 
-          return { status: "internal_error", result: null };
+          if (error instanceof TimeoutError) {
+            return { status: "deadline_exceeded", result: null };
+          } else {
+            return { status: "internal_error", result: null };
+          }
         }
       }
     );

--- a/server/src/utils/errors.ts
+++ b/server/src/utils/errors.ts
@@ -1,0 +1,6 @@
+export class TimeoutError extends Error {
+  constructor(ms: number) {
+    super(`Timed out: ${ms}ms`);
+    this.name = "TimeoutError";
+  }
+}

--- a/server/src/utils/errors.ts
+++ b/server/src/utils/errors.ts
@@ -4,3 +4,6 @@ export class TimeoutError extends Error {
     this.name = "TimeoutError";
   }
 }
+
+// When we can't find the forge binary
+export class ForgeResolveError extends Error {}

--- a/server/src/utils/operatingSystem.ts
+++ b/server/src/utils/operatingSystem.ts
@@ -57,6 +57,10 @@ export async function execWithInput(
       });
 
       child.once("spawn", () => {
+        if (!stdin.writable || child.killed) {
+          return reject(new Error("Failed to write to unwritable stdin"));
+        }
+
         stdin.write(input, (error) => {
           if (error) {
             reject(error);

--- a/server/src/utils/operatingSystem.ts
+++ b/server/src/utils/operatingSystem.ts
@@ -1,4 +1,4 @@
-import { exec } from "child_process";
+import { exec, ExecOptions } from "child_process";
 import os from "os";
 
 export function runningOnWindows() {
@@ -14,6 +14,61 @@ export async function runCmd(cmd: string, cwd?: string): Promise<string> {
 
       resolve(stdout);
     });
+  });
+}
+
+/**
+ * Executes a command using exec, writes provided input to stdin,
+ * and returns a Promise that resolves with stdout and stderr.
+ *
+ * @param {string} command - The command to execute.
+ * @param {string} input - The input string to write to the child process's stdin.
+ * @param {ExecOptions} options - The options to pass to the exec function.
+ * @param {number} timeout - The timeout in milliseconds.
+ * @returns {Promise<{stdout: string, stderr: string}>}
+ */
+export async function execWithInput(
+  command: string,
+  input: string,
+  options: ExecOptions,
+  timeout?: number
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    // Set a timeout if provided
+    if (timeout !== undefined) {
+      setTimeout(() => {
+        reject("Timed out");
+      }, timeout);
+    }
+
+    // Start the child process
+    const child = exec(command, options, (error, stdout, stderr) => {
+      if (error) {
+        reject(error);
+      }
+      resolve({ stdout, stderr });
+    });
+
+    // Check that we have a writable stdin stream
+    if (child.stdin && child.stdin.writable && child.killed === false) {
+      // Handle errors on the stdin stream
+      child.stdin.on("error", (err) => {
+        reject(`Error on child.stdin: ${err}`);
+      });
+
+      // Write the input, then close the stream.
+      child.stdin.write(input, (writeErr) => {
+        if (writeErr) {
+          reject(`Error writing to stdin: ${writeErr}}`);
+          // Even on error, end the stream to avoid hanging.
+          child.stdin?.end();
+        } else {
+          child.stdin?.end();
+        }
+      });
+    } else {
+      reject("Child process has no writable stdin stream");
+    }
   });
 }
 


### PR DESCRIPTION
This PR changes the handling of the child process spawned when running `forge`, currently only used for formatting. The broken EPIPE error happens when a process tries to write to the stdin of a dead process. 