### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -311,4 +311,4 @@ We currently distribute a [vim.coc](https://www.npmjs.com/package/@nomicfoundati
 
 [Hardhat Support Discord server](https://hardhat.org/discord): for questions and feedback.
 
-[Follow Hardhat on Twitter.](https://twitter.com/HardhatHQ)
+[Follow Hardhat on Twitter.](https://x.com/HardhatHQ)

--- a/client/README.template.md
+++ b/client/README.template.md
@@ -130,4 +130,4 @@ We currently distribute a [vim.coc](https://www.npmjs.com/package/@nomicfoundati
 
 [Hardhat Support Discord server](https://hardhat.org/discord): for questions and feedback.
 
-[Follow Hardhat on Twitter.](https://twitter.com/HardhatHQ)
+[Follow Hardhat on Twitter.](https://x.com/HardhatHQ)

--- a/coc/README.md
+++ b/coc/README.md
@@ -226,4 +226,4 @@ Go to [CONTRIBUTING.md](https://github.com/nomicfoundation/hardhat-vscode/blob/m
 
 [Hardhat Support Discord server](https://hardhat.org/discord): for questions and feedback.
 
-[Follow Hardhat on Twitter.](https://twitter.com/HardhatHQ)
+[Follow Hardhat on Twitter.](https://x.com/HardhatHQ)

--- a/coc/README.template.md
+++ b/coc/README.template.md
@@ -45,4 +45,4 @@ Go to [CONTRIBUTING.md](https://github.com/nomicfoundation/hardhat-vscode/blob/m
 
 [Hardhat Support Discord server](https://hardhat.org/discord): for questions and feedback.
 
-[Follow Hardhat on Twitter.](https://twitter.com/HardhatHQ)
+[Follow Hardhat on Twitter.](https://x.com/HardhatHQ)

--- a/server/README.md
+++ b/server/README.md
@@ -242,4 +242,4 @@ Go to [CONTRIBUTING.md](https://github.com/nomicfoundation/hardhat-vscode/blob/m
 
 [Hardhat Support Discord server](https://hardhat.org/discord): for questions and feedback.
 
-[Follow Hardhat on Twitter.](https://twitter.com/HardhatHQ)
+[Follow Hardhat on Twitter.](https://x.com/HardhatHQ)

--- a/server/README.template.md
+++ b/server/README.template.md
@@ -61,4 +61,4 @@ Go to [CONTRIBUTING.md](https://github.com/nomicfoundation/hardhat-vscode/blob/m
 
 [Hardhat Support Discord server](https://hardhat.org/discord): for questions and feedback.
 
-[Follow Hardhat on Twitter.](https://twitter.com/HardhatHQ)
+[Follow Hardhat on Twitter.](https://x.com/HardhatHQ)


### PR DESCRIPTION
Updated the Twitter URL from https://twitter.com to https://x.com to reflect the platform's rebranding.

