### PR TITLE
Upgrade to Sentry 9.6.1

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -56,7 +56,6 @@
     "postpackage": "rimraf ./tmp"
   },
   "devDependencies": {
-    "@sentry/types": "6.19.1",
     "@types/prettier": "2.6.0",
     "@types/vscode": "^1.86",
     "eslint": "^7.23.0",
@@ -65,7 +64,7 @@
   },
   "dependencies": {
     "@nomicfoundation/solidity-language-server": "0.6.16",
-    "@sentry/node": "6.19.1",
+    "@sentry/node": "9.6.1",
     "vscode-languageclient": "^7.0.0"
   },
   "contributes": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,15 +39,14 @@
     },
     "client": {
       "name": "hardhat-solidity",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "license": "MIT",
       "dependencies": {
         "@nomicfoundation/solidity-language-server": "0.6.16",
-        "@sentry/node": "6.19.1",
+        "@sentry/node": "9.6.1",
         "vscode-languageclient": "^7.0.0"
       },
       "devDependencies": {
-        "@sentry/types": "6.19.1",
         "@types/prettier": "2.6.0",
         "@types/vscode": "^1.86",
         "eslint": "^7.23.0",
@@ -142,10 +141,10 @@
     },
     "coc": {
       "name": "@nomicfoundation/coc-solidity",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/solidity-language-server": "0.8.10"
+        "@nomicfoundation/solidity-language-server": "0.8.11"
       },
       "devDependencies": {
         "coc.nvim": "^0.0.80",
@@ -2811,6 +2810,572 @@
       "resolved": "server",
       "link": true
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
+      "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+      "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.57.2",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-amqplib": {
+      "version": "0.46.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.46.1.tgz",
+      "integrity": "sha512-AyXVnlCf/xV3K/rNumzKxZqsULyITJH6OVLiW6730JPRqWA7Zc9bvYoVNpN6iOpTU8CasH34SU/ksVJmObFibQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-connect": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.43.1.tgz",
+      "integrity": "sha512-ht7YGWQuV5BopMcw5Q2hXn3I8eG8TH0J/kc/GMcW4CuNTgiP6wCu44BOnucJWL3CmFWaRHI//vWyAhaC8BwePw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/connect": "3.4.38"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-dataloader": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.16.1.tgz",
+      "integrity": "sha512-K/qU4CjnzOpNkkKO4DfCLSQshejRNAJtd4esgigo/50nxCB6XCyi1dhAblUHM9jG5dRm8eu0FB+t87nIo99LYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-express": {
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.47.1.tgz",
+      "integrity": "sha512-QNXPTWteDclR2B4pDFpz0TNghgB33UMjUt14B+BZPmtH1MwUFAfLHBaP5If0Z5NZC+jaH8oF2glgYjrmhZWmSw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fastify": {
+      "version": "0.44.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.44.2.tgz",
+      "integrity": "sha512-arSp97Y4D2NWogoXRb8CzFK3W2ooVdvqRRtQDljFt9uC3zI6OuShgey6CVFC0JxT1iGjkAr1r4PDz23mWrFULQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fs": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.19.1.tgz",
+      "integrity": "sha512-6g0FhB3B9UobAR60BGTcXg4IHZ6aaYJzp0Ki5FhnxyAPt8Ns+9SSvgcrnsN2eGmk3RWG5vYycUGOEApycQL24A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-generic-pool": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.43.1.tgz",
+      "integrity": "sha512-M6qGYsp1cURtvVLGDrPPZemMFEbuMmCXgQYTReC/IbimV5sGrLBjB+/hANUpRZjX67nGLdKSVLZuQQAiNz+sww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-graphql": {
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.47.1.tgz",
+      "integrity": "sha512-EGQRWMGqwiuVma8ZLAZnExQ7sBvbOx0N/AE/nlafISPs8S+QtXX+Viy6dcQwVWwYHQPAcuY3bFt3xgoAwb4ZNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-hapi": {
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.45.2.tgz",
+      "integrity": "sha512-7Ehow/7Wp3aoyCrZwQpU7a2CnoMq0XhIcioFuKjBb0PLYfBfmTsFTUyatlHu0fRxhwcRsSQRTvEhmZu8CppBpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.57.2.tgz",
+      "integrity": "sha512-1Uz5iJ9ZAlFOiPuwYg29Bf7bJJc/GeoeJIFKJYQf67nTVKFe8RHbEtxgkOmK4UGZNHKXcpW4P8cWBYzBn1USpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/instrumentation": "0.57.2",
+        "@opentelemetry/semantic-conventions": "1.28.0",
+        "forwarded-parse": "2.1.2",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-ioredis": {
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.47.1.tgz",
+      "integrity": "sha512-OtFGSN+kgk/aoKgdkKQnBsQFDiG8WdCxu+UrHr0bXScdAmtSzLSraLo7wFIb25RVHfRWvzI5kZomqJYEg/l1iA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/redis-common": "^0.36.2",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-kafkajs": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.7.1.tgz",
+      "integrity": "sha512-OtjaKs8H7oysfErajdYr1yuWSjMAectT7Dwr+axIoZqT9lmEOkD/H/3rgAs8h/NIuEi2imSXD+vL4MZtOuJfqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-knex": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.44.1.tgz",
+      "integrity": "sha512-U4dQxkNhvPexffjEmGwCq68FuftFK15JgUF05y/HlK3M6W/G2iEaACIfXdSnwVNe9Qh0sPfw8LbOPxrWzGWGMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-koa": {
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.47.1.tgz",
+      "integrity": "sha512-l/c+Z9F86cOiPJUllUCt09v+kICKvT+Vg1vOAJHtHPsJIzurGayucfCMq2acd/A/yxeNWunl9d9eqZ0G+XiI6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.44.1.tgz",
+      "integrity": "sha512-5MPkYCvG2yw7WONEjYj5lr5JFehTobW7wX+ZUFy81oF2lr9IPfZk9qO+FTaM0bGEiymwfLwKe6jE15nHn1nmHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongodb": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.52.0.tgz",
+      "integrity": "sha512-1xmAqOtRUQGR7QfJFfGV/M2kC7wmI2WgZdpru8hJl3S0r4hW0n3OQpEHlSGXJAaNFyvT+ilnwkT+g5L4ljHR6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongoose": {
+      "version": "0.46.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.46.1.tgz",
+      "integrity": "sha512-3kINtW1LUTPkiXFRSSBmva1SXzS/72we/jL22N+BnF3DFcoewkdkHPYOIdAAk9gSicJ4d5Ojtt1/HeibEc5OQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.45.1.tgz",
+      "integrity": "sha512-TKp4hQ8iKQsY7vnp/j0yJJ4ZsP109Ht6l4RHTj0lNEG1TfgTrIH5vJMbgmoYXWzNHAqBH2e7fncN12p3BP8LFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/mysql": "2.15.26"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql2": {
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.45.2.tgz",
+      "integrity": "sha512-h6Ad60FjCYdJZ5DTz1Lk2VmQsShiViKe0G7sYikb0GHI0NVvApp2XQNRHNjEMz87roFttGPLHOYVPlfy+yVIhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/sql-common": "^0.40.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pg": {
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.51.1.tgz",
+      "integrity": "sha512-QxgjSrxyWZc7Vk+qGSfsejPVFL1AgAJdSBMYZdDUbwg730D09ub3PXScB9d04vIqPriZ+0dqzjmQx0yWKiCi2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.26.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/sql-common": "^0.40.1",
+        "@types/pg": "8.6.1",
+        "@types/pg-pool": "2.0.6"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis-4": {
+      "version": "0.46.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.46.1.tgz",
+      "integrity": "sha512-UMqleEoabYMsWoTkqyt9WAzXwZ4BlFZHO40wr3d5ZvtjKCHlD4YXLm+6OLCeIi/HkX7EXvQaz8gtAwkwwSEvcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/redis-common": "^0.36.2",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-tedious": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.18.1.tgz",
+      "integrity": "sha512-5Cuy/nj0HBaH+ZJ4leuD7RjgvA844aY2WW+B5uLcWtxGjRZl3MNLuxnNg5DYWZNPO+NafSSnra0q49KWAHsKBg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/tedious": "^4.0.14"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-undici": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.10.1.tgz",
+      "integrity": "sha512-rkOGikPEyRpMCmNu9AQuV5dtRlDmJp2dK5sw8roVshAGoB6hH/3QjDtRhdwd75SsJwgynWUNRUYe0wAkTo16tQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0"
+      }
+    },
+    "node_modules/@opentelemetry/redis-common": {
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.36.2.tgz",
+      "integrity": "sha512-faYX1N0gpLhej/6nyp6bgRjzAKXn5GOEMYY7YhciSfCoITAktLUtQ36d24QEWNA1/WA1y6qQunCe0OhHRkVl9g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+      "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.30.0.tgz",
+      "integrity": "sha512-4VlGgo32k2EQ2wcCY3vEU28A0O13aOtHz3Xt2/2U5FAh9EfhD6t6DqL5Z6yAnRCntbTFDU4YfbpyzSlHNWycPw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sql-common": {
+      "version": "0.40.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.40.1.tgz",
+      "integrity": "sha512-nSDlnHSqzC3pXn/wZEZVLuAuJ1MYMXPBwtv2qAbCa3847SaHItdE7SzUq/Jtb0KZmh1zfAbNi3AAMjztTT4Ugg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-6.5.0.tgz",
+      "integrity": "sha512-morJDtFRoAp5d/KENEm+K6Y3PQcn5bCvpJ5a9y3V3DNMrNy/ZSn2zulPGj+ld+Xj2UYVoaMJ8DpBX/o6iF6OiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.8"
+      }
+    },
     "node_modules/@scure/base": {
       "version": "1.1.1",
       "dev": true,
@@ -2854,123 +3419,77 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "6.19.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/hub": "6.19.1",
-        "@sentry/minimal": "6.19.1",
-        "@sentry/types": "6.19.1",
-        "@sentry/utils": "6.19.1",
-        "tslib": "^1.9.3"
-      },
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.6.1.tgz",
+      "integrity": "sha512-BHaRxyFF3sNlKP6lNcB5cxFogvfMOtWw0Est6mK/Mbewnim0qEbmqKyuMj67ebfgo+pmUJJc2wgugdxkxvqGRQ==",
+      "license": "MIT",
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/hub": {
-      "version": "6.19.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/types": "6.19.1",
-        "@sentry/utils": "6.19.1",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/minimal": {
-      "version": "6.19.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/hub": "6.19.1",
-        "@sentry/types": "6.19.1",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/node": {
-      "version": "6.19.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/core": "6.19.1",
-        "@sentry/hub": "6.19.1",
-        "@sentry/types": "6.19.1",
-        "@sentry/utils": "6.19.1",
-        "cookie": "^0.4.1",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/tracing": {
-      "version": "7.32.1",
-      "dev": true,
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.6.1.tgz",
+      "integrity": "sha512-cS05ROvBvAFbooqIdyw+yvPyVJqJ89bcirf/QwtFJm+4REtbI7+UAn3D9l17Zd41G1FtpQynpebkCyMc22jO/Q==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "7.32.1",
-        "@sentry/types": "7.32.1",
-        "@sentry/utils": "7.32.1",
-        "tslib": "^1.9.3"
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.30.1",
+        "@opentelemetry/core": "^1.30.1",
+        "@opentelemetry/instrumentation": "^0.57.2",
+        "@opentelemetry/instrumentation-amqplib": "^0.46.1",
+        "@opentelemetry/instrumentation-connect": "0.43.1",
+        "@opentelemetry/instrumentation-dataloader": "0.16.1",
+        "@opentelemetry/instrumentation-express": "0.47.1",
+        "@opentelemetry/instrumentation-fastify": "0.44.2",
+        "@opentelemetry/instrumentation-fs": "0.19.1",
+        "@opentelemetry/instrumentation-generic-pool": "0.43.1",
+        "@opentelemetry/instrumentation-graphql": "0.47.1",
+        "@opentelemetry/instrumentation-hapi": "0.45.2",
+        "@opentelemetry/instrumentation-http": "0.57.2",
+        "@opentelemetry/instrumentation-ioredis": "0.47.1",
+        "@opentelemetry/instrumentation-kafkajs": "0.7.1",
+        "@opentelemetry/instrumentation-knex": "0.44.1",
+        "@opentelemetry/instrumentation-koa": "0.47.1",
+        "@opentelemetry/instrumentation-lru-memoizer": "0.44.1",
+        "@opentelemetry/instrumentation-mongodb": "0.52.0",
+        "@opentelemetry/instrumentation-mongoose": "0.46.1",
+        "@opentelemetry/instrumentation-mysql": "0.45.1",
+        "@opentelemetry/instrumentation-mysql2": "0.45.2",
+        "@opentelemetry/instrumentation-pg": "0.51.1",
+        "@opentelemetry/instrumentation-redis-4": "0.46.1",
+        "@opentelemetry/instrumentation-tedious": "0.18.1",
+        "@opentelemetry/instrumentation-undici": "0.10.1",
+        "@opentelemetry/resources": "^1.30.1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1",
+        "@opentelemetry/semantic-conventions": "^1.30.0",
+        "@prisma/instrumentation": "6.5.0",
+        "@sentry/core": "9.6.1",
+        "@sentry/opentelemetry": "9.6.1",
+        "import-in-the-middle": "^1.13.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       }
     },
-    "node_modules/@sentry/tracing/node_modules/@sentry/core": {
-      "version": "7.32.1",
-      "dev": true,
+    "node_modules/@sentry/opentelemetry": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.6.1.tgz",
+      "integrity": "sha512-KjWOcYEoRiwlHxfWTnEQKErpa4c1BubsJFCezqV64BOTV2vX09AjdJo33PrPjstGopDloLdkqJS60KBhVl49JQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/types": "7.32.1",
-        "@sentry/utils": "7.32.1",
-        "tslib": "^1.9.3"
+        "@sentry/core": "9.6.1"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/tracing/node_modules/@sentry/types": {
-      "version": "7.32.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/tracing/node_modules/@sentry/utils": {
-      "version": "7.32.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.32.1",
-        "tslib": "^1.9.3"
+        "node": ">=18"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/types": {
-      "version": "6.19.1",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/utils": {
-      "version": "6.19.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/types": "6.19.1",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.30.1",
+        "@opentelemetry/core": "^1.30.1",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1",
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -3078,6 +3597,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/fs-extra": {
       "version": "9.0.13",
       "dev": true,
@@ -3183,9 +3711,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mysql": {
+      "version": "2.15.26",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.26.tgz",
+      "integrity": "sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "18.14.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
@@ -3199,6 +3735,26 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
+      "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/pg-pool": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.6.tgz",
+      "integrity": "sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pg": "*"
       }
     },
     "node_modules/@types/prettier": {
@@ -3232,12 +3788,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/shimmer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
+      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
+      "license": "MIT"
+    },
     "node_modules/@types/sinon": {
       "version": "10.0.6",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sinonjs/fake-timers": "^7.1.0"
+      }
+    },
+    "node_modules/@types/tedious": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
+      "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/vscode": {
@@ -3606,6 +4177,7 @@
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -4350,6 +4922,12 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "license": "MIT"
+    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "dev": true,
@@ -4479,6 +5057,7 @@
     },
     "node_modules/cookie": {
       "version": "0.4.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4619,6 +5198,7 @@
     },
     "node_modules/debug": {
       "version": "4.3.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -5925,6 +6505,12 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/forwarded-parse": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+      "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
+      "license": "MIT"
+    },
     "node_modules/fp-ts": {
       "version": "1.19.3",
       "dev": true,
@@ -5974,9 +6560,13 @@
       "license": "ISC"
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
@@ -6893,6 +7483,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/he": {
       "version": "1.2.0",
       "dev": true,
@@ -7008,6 +7610,7 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -7093,6 +7696,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.13.1.tgz",
+      "integrity": "sha512-k2V9wNm9B+ysuelDTHjI9d5KPc4l8zAZTGqj+pcynvWkypZd857ryzN8jNC7Pg2YZXNMJcHRPpaDyCBbNyVRpA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
+    "node_modules/import-in-the-middle/node_modules/acorn": {
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/import-in-the-middle/node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/imurmurhash": {
@@ -7230,11 +7866,15 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.11.0",
-      "dev": true,
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "license": "MIT",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7942,6 +8582,7 @@
     },
     "node_modules/lru_map": {
       "version": "0.3.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -8386,8 +9027,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
+      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mute-stream": {
@@ -8952,7 +9600,6 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
@@ -8999,6 +9646,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.8.0.tgz",
+      "integrity": "sha512-jvuYlEkL03NRvOoyoRktBK7+qU5kOvlAwvmrH8sr3wbLrOdVWsRxQfz8mMy9sZFsqJ1hEWNfdWKI4SAmoL+j7g==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "dev": true,
@@ -9032,6 +9710,45 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prebuild-install": {
@@ -9501,22 +10218,63 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-in-the-middle": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/require-in-the-middle/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/require-in-the-middle/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/resolve": {
-      "version": "1.22.1",
-      "dev": true,
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -9778,6 +10536,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
@@ -10345,7 +11109,6 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10603,6 +11366,7 @@
     },
     "node_modules/tslib": {
       "version": "1.14.1",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsort": {
@@ -11372,6 +12136,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "dev": true,
@@ -11513,7 +12286,7 @@
     },
     "server": {
       "name": "@nomicfoundation/solidity-language-server",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "license": "MIT",
       "dependencies": {
         "@nomicfoundation/slang": "0.16.0",
@@ -11524,9 +12297,8 @@
       },
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "1.0.2",
-        "@sentry/node": "7.32.1",
-        "@sentry/tracing": "7.32.1",
-        "@sentry/types": "7.32.1",
+        "@sentry/core": "9.6.1",
+        "@sentry/node": "9.6.1",
         "@solidity-parser/parser": "^0.16.0",
         "@types/chai": "4.3.0",
         "@types/fs-extra": "^9.0.13",
@@ -11581,56 +12353,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "server/node_modules/@sentry/core": {
-      "version": "7.32.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.32.1",
-        "@sentry/utils": "7.32.1",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "server/node_modules/@sentry/node": {
-      "version": "7.32.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "7.32.1",
-        "@sentry/types": "7.32.1",
-        "@sentry/utils": "7.32.1",
-        "cookie": "^0.4.1",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "server/node_modules/@sentry/types": {
-      "version": "7.32.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "server/node_modules/@sentry/utils": {
-      "version": "7.32.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.32.1",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "server/node_modules/@solidity-parser/parser": {
@@ -13853,7 +14575,7 @@
     "@nomicfoundation/coc-solidity": {
       "version": "file:coc",
       "requires": {
-        "@nomicfoundation/solidity-language-server": "0.8.10",
+        "@nomicfoundation/solidity-language-server": "0.8.11",
         "coc.nvim": "^0.0.80",
         "esbuild": "^0.16.0",
         "eslint": "^7.23.0"
@@ -14246,9 +14968,8 @@
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@nomicfoundation/slang": "0.16.0",
         "@nomicfoundation/solidity-analyzer": "0.1.1",
-        "@sentry/node": "7.32.1",
-        "@sentry/tracing": "7.32.1",
-        "@sentry/types": "7.32.1",
+        "@sentry/core": "9.6.1",
+        "@sentry/node": "9.6.1",
         "@solidity-parser/parser": "^0.16.0",
         "@types/chai": "4.3.0",
         "@types/fs-extra": "^9.0.13",
@@ -14296,40 +15017,6 @@
           "dev": true,
           "requires": {
             "@cspotcode/source-map-consumer": "0.8.0"
-          }
-        },
-        "@sentry/core": {
-          "version": "7.32.1",
-          "dev": true,
-          "requires": {
-            "@sentry/types": "7.32.1",
-            "@sentry/utils": "7.32.1",
-            "tslib": "^1.9.3"
-          }
-        },
-        "@sentry/node": {
-          "version": "7.32.1",
-          "dev": true,
-          "requires": {
-            "@sentry/core": "7.32.1",
-            "@sentry/types": "7.32.1",
-            "@sentry/utils": "7.32.1",
-            "cookie": "^0.4.1",
-            "https-proxy-agent": "^5.0.0",
-            "lru_map": "^0.3.3",
-            "tslib": "^1.9.3"
-          }
-        },
-        "@sentry/types": {
-          "version": "7.32.1",
-          "dev": true
-        },
-        "@sentry/utils": {
-          "version": "7.32.1",
-          "dev": true,
-          "requires": {
-            "@sentry/types": "7.32.1",
-            "tslib": "^1.9.3"
           }
         },
         "@solidity-parser/parser": {
@@ -14588,6 +15275,342 @@
         }
       }
     },
+    "@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
+    },
+    "@opentelemetry/api-logs": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+      "requires": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "@opentelemetry/context-async-hooks": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
+      "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
+      "requires": {}
+    },
+    "@opentelemetry/core": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "requires": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        }
+      }
+    },
+    "@opentelemetry/instrumentation": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+      "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+      "requires": {
+        "@opentelemetry/api-logs": "0.57.2",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      }
+    },
+    "@opentelemetry/instrumentation-amqplib": {
+      "version": "0.46.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.46.1.tgz",
+      "integrity": "sha512-AyXVnlCf/xV3K/rNumzKxZqsULyITJH6OVLiW6730JPRqWA7Zc9bvYoVNpN6iOpTU8CasH34SU/ksVJmObFibQ==",
+      "requires": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation-connect": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.43.1.tgz",
+      "integrity": "sha512-ht7YGWQuV5BopMcw5Q2hXn3I8eG8TH0J/kc/GMcW4CuNTgiP6wCu44BOnucJWL3CmFWaRHI//vWyAhaC8BwePw==",
+      "requires": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/connect": "3.4.38"
+      }
+    },
+    "@opentelemetry/instrumentation-dataloader": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.16.1.tgz",
+      "integrity": "sha512-K/qU4CjnzOpNkkKO4DfCLSQshejRNAJtd4esgigo/50nxCB6XCyi1dhAblUHM9jG5dRm8eu0FB+t87nIo99LYQ==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.57.1"
+      }
+    },
+    "@opentelemetry/instrumentation-express": {
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.47.1.tgz",
+      "integrity": "sha512-QNXPTWteDclR2B4pDFpz0TNghgB33UMjUt14B+BZPmtH1MwUFAfLHBaP5If0Z5NZC+jaH8oF2glgYjrmhZWmSw==",
+      "requires": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation-fastify": {
+      "version": "0.44.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.44.2.tgz",
+      "integrity": "sha512-arSp97Y4D2NWogoXRb8CzFK3W2ooVdvqRRtQDljFt9uC3zI6OuShgey6CVFC0JxT1iGjkAr1r4PDz23mWrFULQ==",
+      "requires": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation-fs": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.19.1.tgz",
+      "integrity": "sha512-6g0FhB3B9UobAR60BGTcXg4IHZ6aaYJzp0Ki5FhnxyAPt8Ns+9SSvgcrnsN2eGmk3RWG5vYycUGOEApycQL24A==",
+      "requires": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1"
+      }
+    },
+    "@opentelemetry/instrumentation-generic-pool": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.43.1.tgz",
+      "integrity": "sha512-M6qGYsp1cURtvVLGDrPPZemMFEbuMmCXgQYTReC/IbimV5sGrLBjB+/hANUpRZjX67nGLdKSVLZuQQAiNz+sww==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.57.1"
+      }
+    },
+    "@opentelemetry/instrumentation-graphql": {
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.47.1.tgz",
+      "integrity": "sha512-EGQRWMGqwiuVma8ZLAZnExQ7sBvbOx0N/AE/nlafISPs8S+QtXX+Viy6dcQwVWwYHQPAcuY3bFt3xgoAwb4ZNQ==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.57.1"
+      }
+    },
+    "@opentelemetry/instrumentation-hapi": {
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.45.2.tgz",
+      "integrity": "sha512-7Ehow/7Wp3aoyCrZwQpU7a2CnoMq0XhIcioFuKjBb0PLYfBfmTsFTUyatlHu0fRxhwcRsSQRTvEhmZu8CppBpQ==",
+      "requires": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation-http": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.57.2.tgz",
+      "integrity": "sha512-1Uz5iJ9ZAlFOiPuwYg29Bf7bJJc/GeoeJIFKJYQf67nTVKFe8RHbEtxgkOmK4UGZNHKXcpW4P8cWBYzBn1USpg==",
+      "requires": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/instrumentation": "0.57.2",
+        "@opentelemetry/semantic-conventions": "1.28.0",
+        "forwarded-parse": "2.1.2",
+        "semver": "^7.5.2"
+      },
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        }
+      }
+    },
+    "@opentelemetry/instrumentation-ioredis": {
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.47.1.tgz",
+      "integrity": "sha512-OtFGSN+kgk/aoKgdkKQnBsQFDiG8WdCxu+UrHr0bXScdAmtSzLSraLo7wFIb25RVHfRWvzI5kZomqJYEg/l1iA==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/redis-common": "^0.36.2",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation-kafkajs": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.7.1.tgz",
+      "integrity": "sha512-OtjaKs8H7oysfErajdYr1yuWSjMAectT7Dwr+axIoZqT9lmEOkD/H/3rgAs8h/NIuEi2imSXD+vL4MZtOuJfqQ==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation-knex": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.44.1.tgz",
+      "integrity": "sha512-U4dQxkNhvPexffjEmGwCq68FuftFK15JgUF05y/HlK3M6W/G2iEaACIfXdSnwVNe9Qh0sPfw8LbOPxrWzGWGMQ==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation-koa": {
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.47.1.tgz",
+      "integrity": "sha512-l/c+Z9F86cOiPJUllUCt09v+kICKvT+Vg1vOAJHtHPsJIzurGayucfCMq2acd/A/yxeNWunl9d9eqZ0G+XiI6A==",
+      "requires": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation-lru-memoizer": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.44.1.tgz",
+      "integrity": "sha512-5MPkYCvG2yw7WONEjYj5lr5JFehTobW7wX+ZUFy81oF2lr9IPfZk9qO+FTaM0bGEiymwfLwKe6jE15nHn1nmHg==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.57.1"
+      }
+    },
+    "@opentelemetry/instrumentation-mongodb": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.52.0.tgz",
+      "integrity": "sha512-1xmAqOtRUQGR7QfJFfGV/M2kC7wmI2WgZdpru8hJl3S0r4hW0n3OQpEHlSGXJAaNFyvT+ilnwkT+g5L4ljHR6g==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation-mongoose": {
+      "version": "0.46.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.46.1.tgz",
+      "integrity": "sha512-3kINtW1LUTPkiXFRSSBmva1SXzS/72we/jL22N+BnF3DFcoewkdkHPYOIdAAk9gSicJ4d5Ojtt1/HeibEc5OQg==",
+      "requires": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation-mysql": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.45.1.tgz",
+      "integrity": "sha512-TKp4hQ8iKQsY7vnp/j0yJJ4ZsP109Ht6l4RHTj0lNEG1TfgTrIH5vJMbgmoYXWzNHAqBH2e7fncN12p3BP8LFg==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/mysql": "2.15.26"
+      }
+    },
+    "@opentelemetry/instrumentation-mysql2": {
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.45.2.tgz",
+      "integrity": "sha512-h6Ad60FjCYdJZ5DTz1Lk2VmQsShiViKe0G7sYikb0GHI0NVvApp2XQNRHNjEMz87roFttGPLHOYVPlfy+yVIhQ==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/sql-common": "^0.40.1"
+      }
+    },
+    "@opentelemetry/instrumentation-pg": {
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.51.1.tgz",
+      "integrity": "sha512-QxgjSrxyWZc7Vk+qGSfsejPVFL1AgAJdSBMYZdDUbwg730D09ub3PXScB9d04vIqPriZ+0dqzjmQx0yWKiCi2Q==",
+      "requires": {
+        "@opentelemetry/core": "^1.26.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/sql-common": "^0.40.1",
+        "@types/pg": "8.6.1",
+        "@types/pg-pool": "2.0.6"
+      }
+    },
+    "@opentelemetry/instrumentation-redis-4": {
+      "version": "0.46.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.46.1.tgz",
+      "integrity": "sha512-UMqleEoabYMsWoTkqyt9WAzXwZ4BlFZHO40wr3d5ZvtjKCHlD4YXLm+6OLCeIi/HkX7EXvQaz8gtAwkwwSEvcQ==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/redis-common": "^0.36.2",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      }
+    },
+    "@opentelemetry/instrumentation-tedious": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.18.1.tgz",
+      "integrity": "sha512-5Cuy/nj0HBaH+ZJ4leuD7RjgvA844aY2WW+B5uLcWtxGjRZl3MNLuxnNg5DYWZNPO+NafSSnra0q49KWAHsKBg==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/tedious": "^4.0.14"
+      }
+    },
+    "@opentelemetry/instrumentation-undici": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.10.1.tgz",
+      "integrity": "sha512-rkOGikPEyRpMCmNu9AQuV5dtRlDmJp2dK5sw8roVshAGoB6hH/3QjDtRhdwd75SsJwgynWUNRUYe0wAkTo16tQ==",
+      "requires": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1"
+      }
+    },
+    "@opentelemetry/redis-common": {
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.36.2.tgz",
+      "integrity": "sha512-faYX1N0gpLhej/6nyp6bgRjzAKXn5GOEMYY7YhciSfCoITAktLUtQ36d24QEWNA1/WA1y6qQunCe0OhHRkVl9g=="
+    },
+    "@opentelemetry/resources": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+      "requires": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        }
+      }
+    },
+    "@opentelemetry/sdk-trace-base": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+      "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+      "requires": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        }
+      }
+    },
+    "@opentelemetry/semantic-conventions": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.30.0.tgz",
+      "integrity": "sha512-4VlGgo32k2EQ2wcCY3vEU28A0O13aOtHz3Xt2/2U5FAh9EfhD6t6DqL5Z6yAnRCntbTFDU4YfbpyzSlHNWycPw=="
+    },
+    "@opentelemetry/sql-common": {
+      "version": "0.40.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.40.1.tgz",
+      "integrity": "sha512-nSDlnHSqzC3pXn/wZEZVLuAuJ1MYMXPBwtv2qAbCa3847SaHItdE7SzUq/Jtb0KZmh1zfAbNi3AAMjztTT4Ugg==",
+      "requires": {
+        "@opentelemetry/core": "^1.1.0"
+      }
+    },
+    "@prisma/instrumentation": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-6.5.0.tgz",
+      "integrity": "sha512-morJDtFRoAp5d/KENEm+K6Y3PQcn5bCvpJ5a9y3V3DNMrNy/ZSn2zulPGj+ld+Xj2UYVoaMJ8DpBX/o6iF6OiA==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0"
+      }
+    },
     "@scure/base": {
       "version": "1.1.1",
       "dev": true
@@ -14610,85 +15633,57 @@
       }
     },
     "@sentry/core": {
-      "version": "6.19.1",
-      "requires": {
-        "@sentry/hub": "6.19.1",
-        "@sentry/minimal": "6.19.1",
-        "@sentry/types": "6.19.1",
-        "@sentry/utils": "6.19.1",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/hub": {
-      "version": "6.19.1",
-      "requires": {
-        "@sentry/types": "6.19.1",
-        "@sentry/utils": "6.19.1",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/minimal": {
-      "version": "6.19.1",
-      "requires": {
-        "@sentry/hub": "6.19.1",
-        "@sentry/types": "6.19.1",
-        "tslib": "^1.9.3"
-      }
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.6.1.tgz",
+      "integrity": "sha512-BHaRxyFF3sNlKP6lNcB5cxFogvfMOtWw0Est6mK/Mbewnim0qEbmqKyuMj67ebfgo+pmUJJc2wgugdxkxvqGRQ=="
     },
     "@sentry/node": {
-      "version": "6.19.1",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.6.1.tgz",
+      "integrity": "sha512-cS05ROvBvAFbooqIdyw+yvPyVJqJ89bcirf/QwtFJm+4REtbI7+UAn3D9l17Zd41G1FtpQynpebkCyMc22jO/Q==",
       "requires": {
-        "@sentry/core": "6.19.1",
-        "@sentry/hub": "6.19.1",
-        "@sentry/types": "6.19.1",
-        "@sentry/utils": "6.19.1",
-        "cookie": "^0.4.1",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.30.1",
+        "@opentelemetry/core": "^1.30.1",
+        "@opentelemetry/instrumentation": "^0.57.2",
+        "@opentelemetry/instrumentation-amqplib": "^0.46.1",
+        "@opentelemetry/instrumentation-connect": "0.43.1",
+        "@opentelemetry/instrumentation-dataloader": "0.16.1",
+        "@opentelemetry/instrumentation-express": "0.47.1",
+        "@opentelemetry/instrumentation-fastify": "0.44.2",
+        "@opentelemetry/instrumentation-fs": "0.19.1",
+        "@opentelemetry/instrumentation-generic-pool": "0.43.1",
+        "@opentelemetry/instrumentation-graphql": "0.47.1",
+        "@opentelemetry/instrumentation-hapi": "0.45.2",
+        "@opentelemetry/instrumentation-http": "0.57.2",
+        "@opentelemetry/instrumentation-ioredis": "0.47.1",
+        "@opentelemetry/instrumentation-kafkajs": "0.7.1",
+        "@opentelemetry/instrumentation-knex": "0.44.1",
+        "@opentelemetry/instrumentation-koa": "0.47.1",
+        "@opentelemetry/instrumentation-lru-memoizer": "0.44.1",
+        "@opentelemetry/instrumentation-mongodb": "0.52.0",
+        "@opentelemetry/instrumentation-mongoose": "0.46.1",
+        "@opentelemetry/instrumentation-mysql": "0.45.1",
+        "@opentelemetry/instrumentation-mysql2": "0.45.2",
+        "@opentelemetry/instrumentation-pg": "0.51.1",
+        "@opentelemetry/instrumentation-redis-4": "0.46.1",
+        "@opentelemetry/instrumentation-tedious": "0.18.1",
+        "@opentelemetry/instrumentation-undici": "0.10.1",
+        "@opentelemetry/resources": "^1.30.1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1",
+        "@opentelemetry/semantic-conventions": "^1.30.0",
+        "@prisma/instrumentation": "6.5.0",
+        "@sentry/core": "9.6.1",
+        "@sentry/opentelemetry": "9.6.1",
+        "import-in-the-middle": "^1.13.0"
       }
     },
-    "@sentry/tracing": {
-      "version": "7.32.1",
-      "dev": true,
+    "@sentry/opentelemetry": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.6.1.tgz",
+      "integrity": "sha512-KjWOcYEoRiwlHxfWTnEQKErpa4c1BubsJFCezqV64BOTV2vX09AjdJo33PrPjstGopDloLdkqJS60KBhVl49JQ==",
       "requires": {
-        "@sentry/core": "7.32.1",
-        "@sentry/types": "7.32.1",
-        "@sentry/utils": "7.32.1",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "@sentry/core": {
-          "version": "7.32.1",
-          "dev": true,
-          "requires": {
-            "@sentry/types": "7.32.1",
-            "@sentry/utils": "7.32.1",
-            "tslib": "^1.9.3"
-          }
-        },
-        "@sentry/types": {
-          "version": "7.32.1",
-          "dev": true
-        },
-        "@sentry/utils": {
-          "version": "7.32.1",
-          "dev": true,
-          "requires": {
-            "@sentry/types": "7.32.1",
-            "tslib": "^1.9.3"
-          }
-        }
-      }
-    },
-    "@sentry/types": {
-      "version": "6.19.1"
-    },
-    "@sentry/utils": {
-      "version": "6.19.1",
-      "requires": {
-        "@sentry/types": "6.19.1",
-        "tslib": "^1.9.3"
+        "@sentry/core": "9.6.1"
       }
     },
     "@sindresorhus/is": {
@@ -14769,6 +15764,14 @@
     "@types/chai": {
       "version": "4.3.0",
       "dev": true
+    },
+    "@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/fs-extra": {
       "version": "9.0.13",
@@ -14858,9 +15861,16 @@
       "version": "2.0.1",
       "dev": true
     },
+    "@types/mysql": {
+      "version": "2.15.26",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.26.tgz",
+      "integrity": "sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
-      "version": "18.14.2",
-      "dev": true
+      "version": "18.14.2"
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -14871,6 +15881,24 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/pg": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
+      "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
+      "requires": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "@types/pg-pool": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.6.tgz",
+      "integrity": "sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==",
+      "requires": {
+        "@types/pg": "*"
       }
     },
     "@types/prettier": {
@@ -14899,11 +15927,24 @@
       "version": "7.3.13",
       "dev": true
     },
+    "@types/shimmer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
+      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="
+    },
     "@types/sinon": {
       "version": "10.0.6",
       "dev": true,
       "requires": {
         "@sinonjs/fake-timers": "^7.1.0"
+      }
+    },
+    "@types/tedious": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
+      "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/vscode": {
@@ -15122,6 +16163,7 @@
     },
     "agent-base": {
       "version": "6.0.2",
+      "dev": true,
       "requires": {
         "debug": "4"
       }
@@ -15587,6 +16629,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q=="
+    },
     "clean-stack": {
       "version": "2.2.0",
       "dev": true
@@ -15671,7 +16718,8 @@
       "dev": true
     },
     "cookie": {
-      "version": "0.4.2"
+      "version": "0.4.2",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -15765,6 +16813,7 @@
     },
     "debug": {
       "version": "4.3.4",
+      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -16637,6 +17686,11 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "forwarded-parse": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+      "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw=="
+    },
     "fp-ts": {
       "version": "1.19.3",
       "dev": true
@@ -16664,8 +17718,9 @@
       "dev": true
     },
     "function-bind": {
-      "version": "1.1.1",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
     "function.prototype.name": {
       "version": "1.1.5",
@@ -17178,8 +18233,7 @@
       "version": "file:client",
       "requires": {
         "@nomicfoundation/solidity-language-server": "0.6.16",
-        "@sentry/node": "6.19.1",
-        "@sentry/types": "6.19.1",
+        "@sentry/node": "9.6.1",
         "@types/prettier": "2.6.0",
         "@types/vscode": "^1.86",
         "eslint": "^7.23.0",
@@ -17325,6 +18379,14 @@
         }
       }
     },
+    "hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "requires": {
+        "function-bind": "^1.1.2"
+      }
+    },
     "he": {
       "version": "1.2.0",
       "dev": true
@@ -17406,6 +18468,7 @@
     },
     "https-proxy-agent": {
       "version": "5.0.1",
+      "dev": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -17452,6 +18515,30 @@
         "resolve-from": {
           "version": "4.0.0",
           "dev": true
+        }
+      }
+    },
+    "import-in-the-middle": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.13.1.tgz",
+      "integrity": "sha512-k2V9wNm9B+ysuelDTHjI9d5KPc4l8zAZTGqj+pcynvWkypZd857ryzN8jNC7Pg2YZXNMJcHRPpaDyCBbNyVRpA==",
+      "requires": {
+        "acorn": "^8.14.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.14.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+          "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg=="
+        },
+        "acorn-import-attributes": {
+          "version": "1.9.5",
+          "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+          "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+          "requires": {}
         }
       }
     },
@@ -17543,10 +18630,11 @@
       }
     },
     "is-core-module": {
-      "version": "2.11.0",
-      "dev": true,
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "requires": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.2"
       }
     },
     "is-date-object": {
@@ -18019,7 +19107,8 @@
       "dev": true
     },
     "lru_map": {
-      "version": "0.3.3"
+      "version": "0.3.3",
+      "dev": true
     },
     "lru-cache": {
       "version": "5.1.1",
@@ -18302,8 +19391,14 @@
       "version": "2.2.2",
       "dev": true
     },
+    "module-details-from-path": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
+      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
+    },
     "ms": {
-      "version": "2.1.2"
+      "version": "2.1.2",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.8",
@@ -18687,8 +19782,7 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.7",
-      "dev": true
+      "version": "1.0.7"
     },
     "path-to-regexp": {
       "version": "1.8.0",
@@ -18720,6 +19814,28 @@
       "version": "1.2.0",
       "dev": true
     },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
+    "pg-protocol": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.8.0.tgz",
+      "integrity": "sha512-jvuYlEkL03NRvOoyoRktBK7+qU5kOvlAwvmrH8sr3wbLrOdVWsRxQfz8mMy9sZFsqJ1hEWNfdWKI4SAmoL+j7g=="
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
     "picocolors": {
       "version": "1.0.0",
       "dev": true
@@ -18737,6 +19853,29 @@
       "dev": true,
       "requires": {
         "find-up": "^4.0.0"
+      }
+    },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w=="
+    },
+    "postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "requires": {
+        "xtend": "^4.0.0"
       }
     },
     "prebuild-install": {
@@ -19315,15 +20454,41 @@
       "version": "2.0.2",
       "dev": true
     },
+    "require-in-the-middle": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+      "requires": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.8"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+          "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
     "require-main-filename": {
       "version": "2.0.0",
       "dev": true
     },
     "resolve": {
-      "version": "1.22.1",
-      "dev": true,
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
       "requires": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -19480,6 +20645,11 @@
     "shebang-regex": {
       "version": "3.0.0",
       "dev": true
+    },
+    "shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "side-channel": {
       "version": "1.0.4",
@@ -19871,8 +21041,7 @@
       }
     },
     "supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "table": {
       "version": "6.8.1",
@@ -20032,7 +21201,8 @@
       }
     },
     "tslib": {
-      "version": "1.14.1"
+      "version": "1.14.1",
+      "dev": true
     },
     "tsort": {
       "version": "0.0.1",
@@ -20548,6 +21718,11 @@
     "xmlbuilder": {
       "version": "11.0.1",
       "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/server/package.json
+++ b/server/package.json
@@ -41,9 +41,8 @@
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "1.0.2",
-    "@sentry/node": "7.32.1",
-    "@sentry/tracing": "7.32.1",
-    "@sentry/types": "7.32.1",
+    "@sentry/node": "9.6.1",
+    "@sentry/core": "9.6.1",
     "@solidity-parser/parser": "^0.16.0",
     "@types/chai": "4.3.0",
     "@types/fs-extra": "^9.0.13",

--- a/server/src/services/codeactions/onCodeAction.ts
+++ b/server/src/services/codeactions/onCodeAction.ts
@@ -1,5 +1,6 @@
 import { CodeActionParams, CodeAction } from "vscode-languageserver/node";
 import { ServerState } from "../../types";
+import { FAILED_PRECONDITION, OK } from "../../telemetry/TelemetryStatus";
 import { resolveQuickFixes } from "./QuickFixResolver";
 
 export function onCodeAction(serverState: ServerState) {
@@ -13,7 +14,7 @@ export function onCodeAction(serverState: ServerState) {
         const document = documents.get(params.textDocument.uri);
 
         if (!document) {
-          return { status: "failed_precondition", result: [] };
+          return { status: FAILED_PRECONDITION, result: [] };
         }
 
         const quickfixes = resolveQuickFixes(
@@ -23,7 +24,7 @@ export function onCodeAction(serverState: ServerState) {
           params.context.diagnostics
         );
 
-        return { status: "ok", result: quickfixes };
+        return { status: OK, result: quickfixes };
       }) ?? []
     );
   };

--- a/server/src/services/documentSymbol/onDocumentSymbol.ts
+++ b/server/src/services/documentSymbol/onDocumentSymbol.ts
@@ -6,8 +6,10 @@ import { DocumentSymbol, SymbolInformation } from "vscode-languageserver-types";
 import { analyze } from "@nomicfoundation/solidity-analyzer";
 import _ from "lodash";
 import { Language } from "@nomicfoundation/slang/language";
+import * as Sentry from "@sentry/node";
 import { ServerState } from "../../types";
 import { resolveVersion, slangToVSCodeRange } from "../../parser/slangHelpers";
+import { INTERNAL_ERROR, OK } from "../../telemetry/TelemetryStatus";
 import { SymbolTreeBuilder } from "./SymbolTreeBuilder";
 import { SymbolFinder } from "./SymbolFinder";
 import { StructDefinition } from "./finders/StructDefinition";
@@ -62,7 +64,7 @@ export function onDocumentSymbol(serverState: ServerState) {
     params: DocumentSymbolParams
   ): Promise<DocumentSymbol[] | SymbolInformation[] | null> => {
     const { telemetry, logger } = serverState;
-    return telemetry.trackTimingSync("onDocumentSymbol", (transaction) => {
+    return telemetry.trackTimingSync("onDocumentSymbol", () => {
       const { uri } = params.textDocument;
 
       // Find the file in the documents collection
@@ -75,9 +77,10 @@ export function onDocumentSymbol(serverState: ServerState) {
       const text = document.getText();
 
       // Get the document's solidity version
-      let span = transaction.startChild({ op: "solidity-analyzer" });
-      const { versionPragmas } = analyze(text);
-      span.finish();
+      const { versionPragmas } = Sentry.startSpan(
+        { name: "solidity-analyzer" },
+        () => analyze(text)
+      );
 
       const resolvedVersion = resolveVersion(logger, versionPragmas);
 
@@ -85,14 +88,9 @@ export function onDocumentSymbol(serverState: ServerState) {
         const language = new Language(resolvedVersion);
 
         // Parse using slang
-        span = transaction.startChild({ op: "slang-parsing" });
-
-        const parseOutput = language.parse(
-          Language.rootKind(),
-          document.getText()
+        const parseOutput = Sentry.startSpan({ name: "slang-parsing" }, () =>
+          language.parse(Language.rootKind(), document.getText())
         );
-
-        span.finish();
 
         const builder = new SymbolTreeBuilder();
 
@@ -113,58 +111,56 @@ export function onDocumentSymbol(serverState: ServerState) {
         //   );
         // } while (kursor.goToNext());
 
-        span = transaction.startChild({ op: "run-query" });
-
         // Execute a single call with all the queries
-        const matches = cursor.query(finders.map((f) => f.query));
-
-        span.finish();
-
-        span = transaction.startChild({ op: "build-symbols" });
+        const matches = Sentry.startSpan({ name: "run-query" }, () =>
+          cursor.query(finders.map((f) => f.query))
+        );
 
         // Transform the query results into symbols
-        let match;
-        const symbols = [];
+        Sentry.startSpan({ name: "build-symbols" }, () => {
+          let match;
+          const symbols = [];
 
-        while ((match = matches.next())) {
-          const finder = finders[match.queryNumber];
-          const symbol = finder.findSymbol(match);
+          while ((match = matches.next())) {
+            const finder = finders[match.queryNumber];
+            const symbol = finder.findSymbol(match);
 
-          symbols.push(symbol);
-        }
-
-        // Build the symbol tree
-        for (const symbol of symbols) {
-          const symbolRange = slangToVSCodeRange(symbol.range);
-
-          let lastOpenSymbol;
-
-          // Insert the symbol in the tree with the correct hierarchy
-          while ((lastOpenSymbol = builder.lastOpenSymbol())) {
-            const lastEndOffset = document.offsetAt(lastOpenSymbol.range!.end);
-            const currentEndOffset = document.offsetAt(symbolRange.end);
-
-            if (lastEndOffset < currentEndOffset) {
-              builder.closeSymbol();
-            } else {
-              break;
-            }
+            symbols.push(symbol);
           }
 
-          builder.openSymbol({
-            kind: symbol.symbolKind,
-            name: symbol.name,
-            range: symbolRange,
-            selectionRange: symbolRange,
-          });
-        }
+          // Build the symbol tree
+          for (const symbol of symbols) {
+            const symbolRange = slangToVSCodeRange(symbol.range);
 
-        span.finish();
+            let lastOpenSymbol;
 
-        return { status: "ok", result: builder.getSymbols() };
+            // Insert the symbol in the tree with the correct hierarchy
+            while ((lastOpenSymbol = builder.lastOpenSymbol())) {
+              const lastEndOffset = document.offsetAt(
+                lastOpenSymbol.range!.end
+              );
+              const currentEndOffset = document.offsetAt(symbolRange.end);
+
+              if (lastEndOffset < currentEndOffset) {
+                builder.closeSymbol();
+              } else {
+                break;
+              }
+            }
+
+            builder.openSymbol({
+              kind: symbol.symbolKind,
+              name: symbol.name,
+              range: symbolRange,
+              selectionRange: symbolRange,
+            });
+          }
+        });
+
+        return { status: OK, result: builder.getSymbols() };
       } catch (error) {
         logger.error(`Document Symbol Error: ${error}`);
-        return { status: "internal_error", result: null };
+        return { status: INTERNAL_ERROR, result: null };
       }
     });
   };

--- a/server/src/services/initialization/indexWorkspaceFolders.ts
+++ b/server/src/services/initialization/indexWorkspaceFolders.ts
@@ -3,7 +3,7 @@ import { WorkspaceFileRetriever } from "@utils/WorkspaceFileRetriever";
 import { SolFileEntry } from "@analyzer/SolFileEntry";
 import _ from "lodash";
 import path from "path";
-import { Transaction } from "@sentry/types";
+import { startSpan } from "@sentry/core";
 import { decodeUriAndRemoveFilePrefix, toUnixStyle } from "../../utils/index";
 import { ServerState } from "../../types";
 import { HardhatIndexer } from "../../frameworks/Hardhat/HardhatIndexer";
@@ -21,8 +21,7 @@ import { resolveTopLevelWorkspaceFolders } from "./resolveTopLevelWorkspaceFolde
 export async function indexWorkspaceFolders(
   serverState: ServerState,
   workspaceFileRetriever: WorkspaceFileRetriever,
-  workspaceFolders: WorkspaceFolder[],
-  sentryTransaction?: Transaction
+  workspaceFolders: WorkspaceFolder[]
 ) {
   const logger = _.clone(serverState.logger);
   logger.tag = "indexing";
@@ -76,17 +75,15 @@ export async function indexWorkspaceFolders(
 
       serverState.projects[foundProject.id()] = foundProject;
       logger.info(`Initializing ${foundProject.id()}`);
-      const span = sentryTransaction?.startChild({
-        op: "initializeProject",
-        tags: frameworkTag(foundProject),
-      });
       try {
-        await foundProject.initialize();
+        await startSpan(
+          { name: "initializeProject", attributes: frameworkTag(foundProject) },
+          async () => foundProject.initialize()
+        );
       } catch (error) {
         logger.error(error);
       }
 
-      span?.finish();
       logger.info(`Done ${foundProject.id()}`);
     }
   });
@@ -94,16 +91,16 @@ export async function indexWorkspaceFolders(
   // Find all sol files
   let solFileUris: string[];
   await logger.trackTime("Indexing solidity files", async () => {
-    const span = sentryTransaction?.startChild({ op: "findSolidityFiles" });
-    solFileUris = await scanForSolFiles(
-      logger,
-      workspaceFileRetriever,
-      topLevelWorkspaceFolders
-    );
+    await startSpan({ name: "findSolidityFiles" }, async () => {
+      solFileUris = await scanForSolFiles(
+        logger,
+        workspaceFileRetriever,
+        topLevelWorkspaceFolders
+      );
 
-    // Index sol files, and associate the matching project
-    await indexSolidityFiles(serverState, solFileUris);
-    span?.finish();
+      // Index sol files, and associate the matching project
+      await indexSolidityFiles(serverState, solFileUris);
+    });
   });
 
   // Store workspace folders to mark them as indexed
@@ -113,13 +110,13 @@ export async function indexWorkspaceFolders(
 
   // Analyze local files
   await logger.trackTime("Analyzing solidity files", async () => {
-    const span = sentryTransaction?.startChild({ op: "analyzeSolidityFiles" });
-    const localSolFileUris = solFileUris.filter(
-      (uri) => serverState.solFileIndex[uri]?.isLocal === true
-    );
-    logger.info(`Analyzing ${localSolFileUris.length} solidity files`);
-    await analyzeSolFiles(serverState, logger, localSolFileUris);
-    span?.finish();
+    await startSpan({ name: "analyzeSolidityFiles" }, async () => {
+      const localSolFileUris = solFileUris.filter(
+        (uri) => serverState.solFileIndex[uri]?.isLocal === true
+      );
+      logger.info(`Analyzing ${localSolFileUris.length} solidity files`);
+      await analyzeSolFiles(serverState, logger, localSolFileUris);
+    });
   });
 }
 

--- a/server/src/services/initialization/onInitialize.ts
+++ b/server/src/services/initialization/onInitialize.ts
@@ -7,6 +7,7 @@ import {
 import { ServerState } from "../../types";
 import { tokensTypes } from "../semanticHighlight/tokenTypes";
 import { isSlangSupported } from "../../parser/slangHelpers";
+import { OK } from "../../telemetry/TelemetryStatus";
 import { indexWorkspaceFolders } from "./indexWorkspaceFolders";
 import { updateAvailableSolcVersions } from "./updateAvailableSolcVersions";
 
@@ -49,15 +50,14 @@ export const onInitialize = (serverState: ServerState) => {
     const slangSupported = isSlangSupported();
 
     // Index and analysis
-    await serverState.telemetry.trackTiming("indexing", async (transaction) => {
+    await serverState.telemetry.trackTiming("indexing", async () => {
       await indexWorkspaceFolders(
         serverState,
         serverState.workspaceFileRetriever,
-        workspaceFolders,
-        transaction
+        workspaceFolders
       );
 
-      return { status: "ok", result: null };
+      return { status: OK, result: null };
     });
 
     // Build and return InitializeResult

--- a/server/src/services/semanticHighlight/onSemanticTokensFull.ts
+++ b/server/src/services/semanticHighlight/onSemanticTokensFull.ts
@@ -8,8 +8,10 @@ import {
 import _ from "lodash";
 import { analyze } from "@nomicfoundation/solidity-analyzer";
 import { Language } from "@nomicfoundation/slang/language";
+import { startSpan } from "@sentry/core";
 import { ServerState } from "../../types";
 import { resolveVersion } from "../../parser/slangHelpers";
+import { INTERNAL_ERROR, OK } from "../../telemetry/TelemetryStatus";
 import { SemanticTokensBuilder } from "./SemanticTokensBuilder";
 import { ContractDefinitionHighlighter } from "./highlighters/ContractDefinitionHighlighter";
 import { CustomTypeHighlighter } from "./highlighters/CustomTypeHighlighter";
@@ -52,7 +54,7 @@ export function onSemanticTokensFull(serverState: ServerState) {
     const { telemetry, logger } = serverState;
 
     return (
-      telemetry.trackTimingSync("onSemanticTokensFull", (transaction) => {
+      telemetry.trackTimingSync("onSemanticTokensFull", () => {
         const { uri } = params.textDocument;
 
         // Find the file in the documents collection
@@ -61,7 +63,7 @@ export function onSemanticTokensFull(serverState: ServerState) {
         if (document === undefined) {
           logger.error("document not found in collection");
           return {
-            status: "internal_error",
+            status: INTERNAL_ERROR,
             result: emptyResponse,
           };
         }
@@ -69,23 +71,19 @@ export function onSemanticTokensFull(serverState: ServerState) {
         const text = document.getText();
 
         // Get the document's solidity version
-        let span = transaction.startChild({ op: "solidity-analyzer" });
-        const { versionPragmas } = analyze(text);
-        span.finish();
+        const { versionPragmas } = startSpan(
+          { name: "solidity-analyzer" },
+          () => analyze(text)
+        );
 
         const resolvedVersion = resolveVersion(logger, versionPragmas);
 
         try {
           const language = new Language(resolvedVersion);
           // Parse using slang
-          span = transaction.startChild({ op: "slang-parsing" });
-
-          const parseOutput = language.parse(
-            Language.rootKind(),
-            document.getText()
+          const parseOutput = startSpan({ name: "slang-parsing" }, () =>
+            language.parse(Language.rootKind(), document.getText())
           );
-
-          span.finish();
 
           // Register highlighters
           const builder = new SemanticTokensBuilder(document);
@@ -103,10 +101,10 @@ export function onSemanticTokensFull(serverState: ServerState) {
             highlighter.onResult(builder, match);
           }
 
-          return { status: "ok", result: { data: builder.getTokenData() } };
+          return { status: OK, result: { data: builder.getTokenData() } };
         } catch (error) {
           logger.error(`Semantic Highlighting Error: ${error}`);
-          return { status: "internal_error", result: emptyResponse };
+          return { status: INTERNAL_ERROR, result: emptyResponse };
         }
       }) || emptyResponse
     );

--- a/server/src/services/validation/analyse.ts
+++ b/server/src/services/validation/analyse.ts
@@ -5,6 +5,11 @@ import { decodeUriAndRemoveFilePrefix, isTestMode } from "../../utils/index";
 import { ServerState } from "../../types";
 import { addFrameworkTag } from "../../telemetry/tags";
 import { indexSolidityFile } from "../initialization/indexWorkspaceFolders";
+import {
+  FAILED_PRECONDITION,
+  INTERNAL_ERROR,
+  OK,
+} from "../../telemetry/TelemetryStatus";
 
 export async function analyse(
   serverState: ServerState,
@@ -12,7 +17,7 @@ export async function analyse(
 ) {
   serverState.logger.trace("analyse");
 
-  return serverState.telemetry.trackTiming("analysis", async (transaction) => {
+  return serverState.telemetry.trackTiming("analysis", async () => {
     try {
       const internalUri = decodeUriAndRemoveFilePrefix(changeDoc.uri);
 
@@ -25,7 +30,7 @@ export async function analyse(
           new Error(`Could not analyze, uri is not indexed: ${internalUri}`)
         );
 
-        return { status: "failed_precondition", result: false };
+        return { status: FAILED_PRECONDITION, result: false };
       }
 
       await analyzeSolFile(serverState, solFileEntry, changeDoc.getText());
@@ -37,11 +42,11 @@ export async function analyse(
         });
       }
 
-      addFrameworkTag(transaction, solFileEntry.project);
-      return { status: "ok", result: true };
+      addFrameworkTag(solFileEntry.project);
+      return { status: OK, result: true };
     } catch (err) {
       serverState.logger.error(err);
-      return { status: "internal_error", result: false };
+      return { status: INTERNAL_ERROR, result: false };
     }
   });
 }

--- a/server/src/services/validation/validate.ts
+++ b/server/src/services/validation/validate.ts
@@ -28,6 +28,7 @@ import { CompilationDetails } from "../../frameworks/base/CompilationDetails";
 import { addFrameworkTag } from "../../telemetry/tags";
 import { Project } from "../../frameworks/base/Project";
 import { indexSolidityFile } from "../initialization/indexWorkspaceFolders";
+import { FAILED_PRECONDITION, OK } from "../../telemetry/TelemetryStatus";
 import { DiagnosticConverter } from "./DiagnosticConverter";
 import { CompilationService } from "./CompilationService";
 import { OutputConverter } from "./OutputConverter";
@@ -36,123 +37,120 @@ export async function validate(
   serverState: ServerState,
   change: TextDocumentChangeEvent<TextDocument>
 ): Promise<boolean | null> {
-  return serverState.telemetry.trackTiming(
-    "validation",
-    async (transaction) => {
-      // Ensure file is analyzed
-      const sourceUri = decodeUriAndRemoveFilePrefix(change.document.uri);
-      const solFileEntry =
-        serverState.solFileIndex[sourceUri] ??
-        (await indexSolidityFile(serverState, sourceUri));
+  return serverState.telemetry.trackTiming("validation", async () => {
+    // Ensure file is analyzed
+    const sourceUri = decodeUriAndRemoveFilePrefix(change.document.uri);
+    const solFileEntry =
+      serverState.solFileIndex[sourceUri] ??
+      (await indexSolidityFile(serverState, sourceUri));
 
-      if (solFileEntry === undefined) {
-        serverState.logger.error(
-          new Error(
-            `Could not send to validation process, uri is not indexed: ${sourceUri}`
-          )
-        );
+    if (solFileEntry === undefined) {
+      serverState.logger.error(
+        new Error(
+          `Could not send to validation process, uri is not indexed: ${sourceUri}`
+        )
+      );
 
-        return { status: "failed_precondition", result: false };
-      }
-
-      addFrameworkTag(transaction, solFileEntry.project);
-
-      // Get the file project's open documents
-      const openDocuments = getOpenDocumentsInProject(
-        serverState,
-        solFileEntry.project
-      ).map((openDoc) => ({
-        uri: decodeUriAndRemoveFilePrefix(openDoc.uri),
-        documentText: openDoc.getText(),
-      }));
-
-      // Ensure sourceUri is included in open documents
-      if (!openDocuments.some((doc) => doc.uri === sourceUri)) {
-        return { status: "failed_precondition", result: false };
-      }
-
-      // Associate validation request id to this file
-      const validationId = ++serverState.validationCount;
-      serverState.lastValidationId[sourceUri] = validationId;
-
-      const { project } = solFileEntry;
-      let validationResult: ValidationResult;
-
-      const logger = _.clone(serverState.logger);
-      logger.tag = `${path.basename(project.basePath)}:${validationId}`;
-
-      try {
-        let compilationDetails: CompilationDetails;
-        let compilerOutput: any;
-
-        // Get solc input from framework provider
-        await logger.trackTime(
-          `Building compilation (${project.frameworkName()} - ${path.basename(
-            sourceUri
-          )})`,
-          async () => {
-            compilationDetails = await project.buildCompilation(
-              sourceUri,
-              openDocuments
-            );
-          }
-        );
-
-        // Use bundled hardhat to compile
-        await logger.trackTime("Compiling", async () => {
-          compilerOutput = await CompilationService.compile(
-            serverState,
-            compilationDetails!
-          );
-        });
-
-        validationResult = OutputConverter.getValidationResults(
-          compilationDetails!,
-          compilerOutput,
-          project.basePath
-        );
-      } catch (error: any) {
-        logger.trace(error);
-
-        if (error._isBuildInputError) {
-          // Framework provider detailed error on why buildInput failed
-          validationResult = {
-            status: "BUILD_INPUT_ERROR",
-            error,
-          };
-        } else if (error._isInitializationFailedError) {
-          // Project could not be initialized correctly
-          validationResult = {
-            status: "INITIALIZATION_FAILED_ERROR",
-            error,
-          };
-        } else {
-          // Generic catch-all error
-          validationResult = {
-            status: "JOB_COMPLETION_ERROR",
-            projectBasePath: project.basePath,
-            reason: error?.message ?? error,
-          };
-        }
-      }
-
-      // Only show validation result if this is the latest validation request for this file
-      if (serverState.lastValidationId[sourceUri] === validationId) {
-        await sendResults(
-          serverState,
-          change,
-          validationResult,
-          openDocuments,
-          project
-        );
-      }
-
-      return {
-        status: "ok",
-        result: validationResult.status === "VALIDATION_PASS",
-      };
+      return { status: FAILED_PRECONDITION, result: false };
     }
-  );
+
+    addFrameworkTag(solFileEntry.project);
+
+    // Get the file project's open documents
+    const openDocuments = getOpenDocumentsInProject(
+      serverState,
+      solFileEntry.project
+    ).map((openDoc) => ({
+      uri: decodeUriAndRemoveFilePrefix(openDoc.uri),
+      documentText: openDoc.getText(),
+    }));
+
+    // Ensure sourceUri is included in open documents
+    if (!openDocuments.some((doc) => doc.uri === sourceUri)) {
+      return { status: FAILED_PRECONDITION, result: false };
+    }
+
+    // Associate validation request id to this file
+    const validationId = ++serverState.validationCount;
+    serverState.lastValidationId[sourceUri] = validationId;
+
+    const { project } = solFileEntry;
+    let validationResult: ValidationResult;
+
+    const logger = _.clone(serverState.logger);
+    logger.tag = `${path.basename(project.basePath)}:${validationId}`;
+
+    try {
+      let compilationDetails: CompilationDetails;
+      let compilerOutput: any;
+
+      // Get solc input from framework provider
+      await logger.trackTime(
+        `Building compilation (${project.frameworkName()} - ${path.basename(
+          sourceUri
+        )})`,
+        async () => {
+          compilationDetails = await project.buildCompilation(
+            sourceUri,
+            openDocuments
+          );
+        }
+      );
+
+      // Use bundled hardhat to compile
+      await logger.trackTime("Compiling", async () => {
+        compilerOutput = await CompilationService.compile(
+          serverState,
+          compilationDetails!
+        );
+      });
+
+      validationResult = OutputConverter.getValidationResults(
+        compilationDetails!,
+        compilerOutput,
+        project.basePath
+      );
+    } catch (error: any) {
+      logger.trace(error);
+
+      if (error._isBuildInputError) {
+        // Framework provider detailed error on why buildInput failed
+        validationResult = {
+          status: "BUILD_INPUT_ERROR",
+          error,
+        };
+      } else if (error._isInitializationFailedError) {
+        // Project could not be initialized correctly
+        validationResult = {
+          status: "INITIALIZATION_FAILED_ERROR",
+          error,
+        };
+      } else {
+        // Generic catch-all error
+        validationResult = {
+          status: "JOB_COMPLETION_ERROR",
+          projectBasePath: project.basePath,
+          reason: error?.message ?? error,
+        };
+      }
+    }
+
+    // Only show validation result if this is the latest validation request for this file
+    if (serverState.lastValidationId[sourceUri] === validationId) {
+      await sendResults(
+        serverState,
+        change,
+        validationResult,
+        openDocuments,
+        project
+      );
+    }
+
+    return {
+      status: OK,
+      result: validationResult.status === "VALIDATION_PASS",
+    };
+  });
 }
 
 async function sendResults(

--- a/server/src/telemetry/SentryServerTelemetry.ts
+++ b/server/src/telemetry/SentryServerTelemetry.ts
@@ -1,12 +1,11 @@
 /* istanbul ignore file: external system */
 import * as Sentry from "@sentry/node";
-import type { Primitive, Transaction } from "@sentry/types";
-import * as tracing from "@sentry/tracing";
 import { ServerState } from "../types";
 import { Analytics } from "../analytics/types";
 import { Telemetry, TrackingResult } from "./types";
 
 import { sentryEventFilter } from "./sentryEventFilter";
+import { INTERNAL_ERROR } from "./TelemetryStatus";
 
 const SENTRY_CLOSE_TIMEOUT = 2000;
 
@@ -42,11 +41,6 @@ export class SentryServerTelemetry implements Telemetry {
   ) {
     this.serverState = serverState;
 
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-    if (!tracing) {
-      throw new Error("Tracing not loaded");
-    }
-
     Sentry.init({
       dsn: this.dsn,
       tracesSampleRate: serverState.env === "development" ? 1 : 0.001,
@@ -81,78 +75,56 @@ export class SentryServerTelemetry implements Telemetry {
 
   public async trackTiming<T>(
     taskName: string,
-    action: (transaction: Transaction) => Promise<TrackingResult<T>>,
-    tags?: Record<string, Primitive>
+    action: (span: Sentry.Span) => Promise<TrackingResult<T>>
   ): Promise<T | null> {
-    const transaction = this.startTransaction({
-      op: "task",
-      name: taskName,
-      tags,
-    });
+    let returnValue: T | null = null;
     this.actionTaken = true;
 
-    try {
-      const trackingResult = await action(transaction);
+    await Sentry.startSpan(
+      {
+        op: taskName,
+        name: taskName,
+      },
+      async (span) => {
+        try {
+          const trackingResult = await action(span);
+          span.setStatus(trackingResult.status);
+          returnValue = trackingResult.result;
+        } catch (err) {
+          this.serverState?.logger.error(err);
+          span.setStatus(INTERNAL_ERROR);
+        }
+      }
+    );
 
-      transaction.setStatus(trackingResult.status);
-
-      return trackingResult.result;
-    } catch (err) {
-      this.serverState?.logger.error(err);
-      transaction.setStatus("internal_error");
-      return null;
-    } finally {
-      transaction.finish();
-    }
+    return returnValue;
   }
 
   public trackTimingSync<T>(
     taskName: string,
-    action: (transaction: Transaction) => TrackingResult<T>,
-    tags?: Record<string, Primitive>
+    action: (span: Sentry.Span) => TrackingResult<T>
   ): T | null {
-    const transaction = this.startTransaction({
-      op: "task",
-      name: taskName,
-      tags,
-    });
+    let returnValue: T | null = null;
     this.actionTaken = true;
 
-    try {
-      const trackingResult = action(transaction);
-
-      transaction.setStatus(trackingResult.status);
-
-      return trackingResult.result;
-    } catch (err) {
-      this.serverState?.logger.error(err);
-      transaction.setStatus("internal_error");
-      return null;
-    } finally {
-      transaction.finish();
-    }
-  }
-
-  public startTransaction({
-    op,
-    name,
-    tags,
-  }: {
-    op: string;
-    name: string;
-    tags?: Record<string, Primitive>;
-  }): Transaction {
-    const transaction = Sentry.startTransaction({
-      op,
-      name,
-      tags,
-    });
-
-    Sentry.getCurrentHub().configureScope((scope) =>
-      scope.setSpan(transaction)
+    Sentry.startSpan(
+      {
+        op: taskName,
+        name: taskName,
+      },
+      (span) => {
+        try {
+          const trackingResult = action(span);
+          span.setStatus(trackingResult.status);
+          returnValue = trackingResult.result;
+        } catch (err) {
+          this.serverState?.logger.error(err);
+          span.setStatus(INTERNAL_ERROR);
+        }
+      }
     );
 
-    return transaction;
+    return returnValue;
   }
 
   public enableHeartbeat(): void {

--- a/server/src/telemetry/TelemetryStatus.ts
+++ b/server/src/telemetry/TelemetryStatus.ts
@@ -1,0 +1,20 @@
+import { SPAN_STATUS_OK, SPAN_STATUS_ERROR } from "@sentry/core";
+import { SpanStatusCode } from "@sentry/core/build/types/types-hoist/spanStatus";
+
+export const OK = { code: SPAN_STATUS_OK as SpanStatusCode, message: "ok" };
+export const INTERNAL_ERROR = {
+  code: SPAN_STATUS_ERROR as SpanStatusCode,
+  message: "internal_error",
+};
+export const DEADLINE_EXCEEDED = {
+  code: SPAN_STATUS_ERROR as SpanStatusCode,
+  message: "deadline_exceeded",
+};
+export const FAILED_PRECONDITION = {
+  code: SPAN_STATUS_ERROR as SpanStatusCode,
+  message: "failed_precondition",
+};
+export const INVALID_ARGUMENT = {
+  code: SPAN_STATUS_ERROR as SpanStatusCode,
+  message: "invalid_argument",
+};

--- a/server/src/telemetry/tags.ts
+++ b/server/src/telemetry/tags.ts
@@ -1,11 +1,14 @@
-import { Transaction } from "@sentry/types";
+import { setTag, Span } from "@sentry/core";
 import { Project } from "../frameworks/base/Project";
 
-export function addFrameworkTag(transaction: Transaction, project: Project) {
-  transaction.tags = {
-    ...(transaction.tags ?? {}),
-    ...frameworkTag(project),
-  };
+export function addFrameworkTag(project: Project, span?: Span) {
+  if (span !== undefined) {
+    span.setAttributes({
+      ...frameworkTag(project),
+    });
+  } else {
+    setTag("framework", project.frameworkName());
+  }
 }
 
 export function frameworkTag(project: Project) {

--- a/server/src/telemetry/types.ts
+++ b/server/src/telemetry/types.ts
@@ -1,9 +1,8 @@
-import { SpanStatusType } from "@sentry/tracing";
-import type { Primitive, Transaction } from "@sentry/types";
+import { Primitive, Span, SpanStatus } from "@sentry/core";
 import { ServerState } from "../types";
 
 export interface TrackingResult<T> {
-  status: SpanStatusType;
+  status: SpanStatus;
   result: T | null;
 }
 
@@ -18,15 +17,14 @@ export interface Telemetry {
   captureException(err: unknown): void;
   trackTiming<T>(
     taskName: string,
-    action: (transaction: Transaction) => Promise<TrackingResult<T>>,
+    action: (span: Span) => Promise<TrackingResult<T>>,
     tags?: Record<string, Primitive>
   ): Promise<T | null>;
   trackTimingSync<T>(
     taskName: string,
-    action: (transaction: Transaction) => TrackingResult<T>,
+    action: (span: Span) => TrackingResult<T>,
     tags?: Record<string, Primitive>
   ): T | null;
-  startTransaction({ op, name }: { op: string; name: string }): Transaction;
   enableHeartbeat(): void;
   close(): Promise<boolean>;
 }

--- a/server/src/utils/onCommand.ts
+++ b/server/src/utils/onCommand.ts
@@ -1,8 +1,9 @@
 import { ISolFileEntry } from "@common/types";
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { Transaction } from "@sentry/types";
+import { Span } from "@sentry/core";
 import { addFrameworkTag } from "../telemetry/tags";
 import { ServerState } from "../types";
+import { FAILED_PRECONDITION, OK } from "../telemetry/TelemetryStatus";
 import { lookupEntryForUri } from "./lookupEntryForUri";
 
 export function onCommand<T>(
@@ -12,14 +13,14 @@ export function onCommand<T>(
   action: (
     documentAnalyzer: ISolFileEntry,
     document: TextDocument,
-    transaction: Transaction
+    span: Span
   ) => T
 ) {
   const { logger, telemetry } = serverState;
 
   logger.trace(commandName);
 
-  return telemetry.trackTimingSync(commandName, (transaction) => {
+  return telemetry.trackTimingSync(commandName, (span) => {
     const { found, errorMessage, documentAnalyzer, document } =
       lookupEntryForUri(serverState, uri);
 
@@ -28,14 +29,14 @@ export function onCommand<T>(
         logger.trace(errorMessage);
       }
 
-      return { status: "failed_precondition", result: null };
+      return { status: FAILED_PRECONDITION, result: null };
     }
 
-    addFrameworkTag(transaction, documentAnalyzer.project);
+    addFrameworkTag(documentAnalyzer.project);
 
     return {
-      status: "ok",
-      result: action(documentAnalyzer, document, transaction),
+      status: OK,
+      result: action(documentAnalyzer, document, span),
     };
   });
 }

--- a/server/test/helpers/setupMockTelemetry.ts
+++ b/server/test/helpers/setupMockTelemetry.ts
@@ -1,4 +1,3 @@
-import { Transaction } from "@sentry/types";
 import * as sinon from "sinon";
 import { Telemetry } from "../../src/telemetry/types";
 
@@ -23,19 +22,6 @@ export function setupMockTelemetry(): Telemetry {
       } catch {
         return null;
       }
-    },
-    startTransaction: (): Transaction => {
-      return {
-        startChild: () => {
-          return {
-            setStatus: sinon.spy(),
-            finish: sinon.spy(),
-          };
-        },
-        setStatus: sinon.spy(),
-        finish: sinon.spy(),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any;
     },
     enableHeartbeat: sinon.spy(),
     close: sinon.spy(),


### PR DESCRIPTION
- Removed deprecated packages: `sentry/tracing` and `sentry/types`
- Updated sentry/node to latest version, 9.6.1
- Added sentry/core, which is a transient dependency of sentry/node since some functions and types are not re-exported by sentry/node
- Some concepts ceased to exist, for instance Transactions. So I migrated to the new approach which is to use only spans (top level spans are what transactions used to be)
- Some methods e.g. `setTag` now should be invoked directly from Sentry, so our application is a bit more coupled to sentry instead of the abstract Telemetry class. I think it's unnecesary to have such abstraction, and would get rid of it. If we wanted to completely decouple from Sentry it'd be too much overhead for little benefit
