### PR TITLE
bump node language server and client

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "@nomicfoundation/solidity-language-server": "0.6.16",
     "@sentry/node": "6.19.1",
-    "vscode-languageclient": "^7.0.0"
+    "vscode-languageclient": "9.0.1"
   },
   "contributes": {
     "configuration": {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -25,7 +25,7 @@ export async function activate(context: ExtensionContext) {
 
   await indexHardhatProjects(extensionState);
 
-  setupLanguageServerHooks(extensionState);
+  await setupLanguageServerHooks(extensionState);
   setupTaskProvider(extensionState);
   await setupCommands(extensionState);
   setupWorkspaceHooks(extensionState);

--- a/client/src/setup/setupIndexingHooks.ts
+++ b/client/src/setup/setupIndexingHooks.ts
@@ -17,7 +17,7 @@ export function setupIndexingHooks(
   const indexingStatusItem = setupIndexingLanguageStatusItem();
 
   client
-    .onReady()
+    .start()
     .then(() => {
       // Hide spinner when initialization ends
       indexingStatusItem.dispose();

--- a/client/src/setup/setupValidationJobHooks.ts
+++ b/client/src/setup/setupValidationJobHooks.ts
@@ -29,14 +29,14 @@ export function setupValidationJobHooks(
   extensionState: ExtensionState,
   client: LanguageClient
 ) {
-  return client.onReady().then(() => {
+  return client.start().then(() => {
     // Trigger validation on newly focused documents
     window.onDidChangeActiveTextEditor((e) => {
       const uri = e?.document.uri.toString();
       const version = e?.document.version;
 
       if (uri !== undefined && version !== undefined && uri.endsWith(".sol")) {
-        client.sendNotification("textDocument/didChange", {
+        void client.sendNotification("textDocument/didChange", {
           textDocument: { uri, version },
           contentChanges: [
             {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
       "dependencies": {
         "@nomicfoundation/solidity-language-server": "0.6.16",
         "@sentry/node": "6.19.1",
-        "vscode-languageclient": "^7.0.0"
+        "vscode-languageclient": "9.0.1"
       },
       "devDependencies": {
         "@sentry/types": "6.19.1",
@@ -3455,13 +3455,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.15.tgz",
-      "integrity": "sha512-imAbQEEbVni6i6h6Bd5xkCRwLqFc8hihCsi2GbtDoAtUcAFQ6Zs4pFXTZUUbroTkXdImczWM9AI8eZUuybXE3w==",
+      "version": "22.14.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.0.tgz",
+      "integrity": "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -4477,7 +4477,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5088,6 +5087,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concurrently": {
@@ -13682,9 +13682,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -13792,92 +13792,80 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
-      "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
-      "dev": true,
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
-      "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
       "license": "MIT",
       "dependencies": {
-        "minimatch": "^3.0.4",
-        "semver": "^7.3.4",
-        "vscode-languageserver-protocol": "3.16.0"
+        "minimatch": "^5.1.0",
+        "semver": "^7.3.7",
+        "vscode-languageserver-protocol": "3.17.5"
       },
       "engines": {
-        "vscode": "^1.52.0"
-      }
-    },
-    "node_modules/vscode-languageclient/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "vscode": "^1.82.0"
       }
     },
     "node_modules/vscode-languageclient/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=10"
       }
     },
-    "node_modules/vscode-languageclient/node_modules/vscode-jsonrpc": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0 || >=10.0.0"
-      }
-    },
-    "node_modules/vscode-languageclient/node_modules/vscode-languageserver-protocol": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "vscode-jsonrpc": "6.0.0",
-        "vscode-languageserver-types": "3.16.0"
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
       }
-    },
-    "node_modules/vscode-languageclient/node_modules/vscode-languageserver-types": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==",
-      "license": "MIT"
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
-      "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
-      "dev": true,
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
       "license": "MIT",
       "dependencies": {
-        "vscode-jsonrpc": "8.1.0",
-        "vscode-languageserver-types": "3.17.3"
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
       }
     },
-    "node_modules/vscode-languageserver-types": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
-      "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==",
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
       "license": "MIT"
     },
     "node_modules/wcwidth": {
@@ -14635,11 +14623,11 @@
         "sinon": "12.0.1",
         "ts-node": "10.4.0",
         "typescript": "5.8.2",
-        "vscode-languageserver": "8.1.0",
-        "vscode-languageserver-protocol": "3.17.3",
-        "vscode-languageserver-textdocument": "1.0.8",
-        "vscode-languageserver-types": "3.17.3",
-        "vscode-uri": "3.0.7",
+        "vscode-languageserver": "9.0.1",
+        "vscode-languageserver-protocol": "3.17.5",
+        "vscode-languageserver-textdocument": "1.0.12",
+        "vscode-languageserver-types": "3.17.5",
+        "vscode-uri": "3.1.0",
         "yaml": "^2.2.1"
       },
       "engines": {
@@ -15073,33 +15061,6 @@
         "node": ">=0.3.1"
       }
     },
-    "server/node_modules/vscode-languageserver": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.1.0.tgz",
-      "integrity": "sha512-eUt8f1z2N2IEUDBsKaNapkz7jl5QpskN2Y0G01T/ItMxBxw1fJwvtySGB9QMecatne8jFIWJGWI61dWjyTLQsw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "vscode-languageserver-protocol": "3.17.3"
-      },
-      "bin": {
-        "installServerIntoExtension": "bin/installServerIntoExtension"
-      }
-    },
-    "server/node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
-      "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "server/node_modules/vscode-uri": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
-      "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "server/node_modules/workerpool": {
       "version": "6.1.5",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
@@ -15128,8 +15089,8 @@
       "license": "ISC",
       "dependencies": {
         "lodash": "^4.17.21",
-        "vscode-languageserver-protocol": "~3.16.0",
-        "vscode-uri": "3.0.7"
+        "vscode-languageserver-protocol": "3.17.5",
+        "vscode-uri": "3.1.0"
       },
       "devDependencies": {
         "@types/chai": "^4.3.4",
@@ -15460,37 +15421,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "test/protocol/node_modules/vscode-jsonrpc": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0 || >=10.0.0"
-      }
-    },
-    "test/protocol/node_modules/vscode-languageserver-protocol": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
-      "license": "MIT",
-      "dependencies": {
-        "vscode-jsonrpc": "6.0.0",
-        "vscode-languageserver-types": "3.16.0"
-      }
-    },
-    "test/protocol/node_modules/vscode-languageserver-types": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==",
-      "license": "MIT"
-    },
-    "test/protocol/node_modules/vscode-uri": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
-      "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA==",
-      "license": "MIT"
     },
     "test/protocol/node_modules/workerpool": {
       "version": "6.5.1",

--- a/server/package.json
+++ b/server/package.json
@@ -78,11 +78,11 @@
     "sinon": "12.0.1",
     "ts-node": "10.4.0",
     "typescript": "5.8.2",
-    "vscode-languageserver": "8.1.0",
-    "vscode-languageserver-protocol": "3.17.3",
-    "vscode-languageserver-textdocument": "1.0.8",
-    "vscode-languageserver-types": "3.17.3",
-    "vscode-uri": "3.0.7",
+    "vscode-languageserver": "9.0.1",
+    "vscode-languageserver-protocol": "3.17.5",
+    "vscode-languageserver-textdocument": "1.0.12",
+    "vscode-languageserver-types": "3.17.5",
+    "vscode-uri": "3.1.0",
     "yaml": "^2.2.1"
   },
   "dependencies": {

--- a/test/protocol/package.json
+++ b/test/protocol/package.json
@@ -16,8 +16,8 @@
   "license": "ISC",
   "dependencies": {
     "lodash": "^4.17.21",
-    "vscode-languageserver-protocol": "~3.16.0",
-    "vscode-uri": "3.0.7"
+    "vscode-languageserver-protocol": "3.17.5",
+    "vscode-uri": "3.1.0"
   },
   "devDependencies": {
     "@types/chai": "^4.3.4",

--- a/test/protocol/src/TestLanguageClient.ts
+++ b/test/protocol/src/TestLanguageClient.ts
@@ -96,7 +96,7 @@ export class TestLanguageClient {
     }
 
     const result = await this._initialize()
-    this._initialized()
+    await this._initialized()
     return result
   }
 
@@ -117,14 +117,15 @@ export class TestLanguageClient {
         text,
       },
     }
-    this.connection!.sendNotification(DidOpenTextDocumentNotification.type, documentParams)
+
+    await this.connection!.sendNotification(DidOpenTextDocumentNotification.type, documentParams)
 
     await document.waitAnalyzed
 
     return document
   }
 
-  public changeDocument(documentPath: string, range: Range, text: string) {
+  public async changeDocument(documentPath: string, range: Range, text: string) {
     const uri = toUri(documentPath)
     const document = this.documents[uri]
 
@@ -142,20 +143,20 @@ export class TestLanguageClient {
       contentChanges: [{ range, text }],
     }
 
-    this.connection!.sendNotification('textDocument/didChange', params)
+    await this.connection!.sendNotification('textDocument/didChange', params)
   }
 
-  public changeWatchedFiles(params: DidChangeWatchedFilesParams) {
-    this.connection!.sendNotification('workspace/didChangeWatchedFiles', params)
+  public async changeWatchedFiles(params: DidChangeWatchedFilesParams) {
+    await this.connection!.sendNotification('workspace/didChangeWatchedFiles', params)
   }
 
-  public closeAllDocuments() {
+  public async closeAllDocuments() {
     for (const [uri] of Object.entries(this.documents)) {
-      this.closeDocument(uri)
+      await this.closeDocument(uri)
     }
   }
 
-  public closeDocument(uri: string) {
+  public async closeDocument(uri: string) {
     this._checkConnection()
 
     const params: DidCloseTextDocumentParams = {
@@ -164,7 +165,7 @@ export class TestLanguageClient {
       },
     }
 
-    this.connection!.sendNotification(DidCloseTextDocumentNotification.type, params)
+    await this.connection!.sendNotification(DidCloseTextDocumentNotification.type, params)
 
     delete this.documents[uri]
   }
@@ -459,8 +460,8 @@ export class TestLanguageClient {
     return result
   }
 
-  private _initialized() {
-    this.connection!.sendNotification(InitializedNotification.type, {})
+  private async _initialized() {
+    await this.connection!.sendNotification(InitializedNotification.type, {})
     this.logger.trace('Sent Initialized')
   }
 

--- a/test/protocol/test/custom/validation-job-status/hardhat/invalidImport.test.ts
+++ b/test/protocol/test/custom/validation-job-status/hardhat/invalidImport.test.ts
@@ -12,7 +12,7 @@ describe('[hardhat] custom/validation-job-status', () => {
   })
 
   after(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   test('invalid import on hardhat dependency chain sends a custom notification with link to error file', async () => {

--- a/test/protocol/test/misc/fileRename.test.ts
+++ b/test/protocol/test/misc/fileRename.test.ts
@@ -17,7 +17,7 @@ describe('[misc] file rename', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
     try {
       renameSync(renamedPath, originalPath)
     } catch (error) {
@@ -36,7 +36,7 @@ describe('[misc] file rename', () => {
     renameSync(originalPath, renamedPath)
     await client.openDocument(renamedPath)
 
-    client.changeWatchedFiles({
+    await client.changeWatchedFiles({
       changes: [
         { type: FileChangeType.Deleted, uri: originalUri },
         { type: FileChangeType.Created, uri: renamedUri },

--- a/test/protocol/test/misc/formatting.test.ts
+++ b/test/protocol/test/misc/formatting.test.ts
@@ -15,7 +15,7 @@ describe('[misc] server document formatting', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   it('can use prettier as formatter', async () => {
@@ -23,7 +23,7 @@ describe('[misc] server document formatting', () => {
     expect(doc.text).to.eq('contract Formatting {\nuint256 counter;\n}\n')
 
     // Set prettier as the formatter
-    client.changeExtensionConfig({ formatter: 'prettier' })
+    await client.changeExtensionConfig({ formatter: 'prettier' })
 
     // Trigger formatting. Prettier is set to use 4 tabs on prettierrc.json
     const edits = await client.formatDocument(fileUri)
@@ -40,7 +40,7 @@ describe('[misc] server document formatting', () => {
     expect(doc.text).to.eq('contract Formatting {\nuint256 counter;\n}\n')
 
     // Set forge as the formatter
-    client.changeExtensionConfig({ formatter: 'forge' })
+    await client.changeExtensionConfig({ formatter: 'forge' })
 
     // Trigger formatting. Forge is set to use 2 tabs in foundry.toml
     const edits = await client.formatDocument(fileUri)
@@ -53,7 +53,7 @@ describe('[misc] server document formatting', () => {
     expect(doc.text).to.eq('contract Formatting {\nuint256 counter;\n}\n')
 
     // Set formatter to none
-    client.changeExtensionConfig({ formatter: 'none' })
+    await client.changeExtensionConfig({ formatter: 'none' })
 
     // Trigger formatting
     const edits = await client.formatDocument(fileUri)
@@ -66,7 +66,7 @@ describe('[misc] server document formatting', () => {
     expect(doc.text).to.eq('contract Formatting {\nuint256 counter;\n}\n')
 
     // Set empty extension config
-    client.changeExtensionConfig({})
+    await client.changeExtensionConfig({})
 
     // Trigger formatting. Prettier should be used (4 tabs)
     const edits = await client.formatDocument(fileUri)

--- a/test/protocol/test/textDocument/codeAction/ape/codeAction.test.ts
+++ b/test/protocol/test/textDocument/codeAction/ape/codeAction.test.ts
@@ -13,7 +13,7 @@ describe('[ape][codeAction]', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   test('add license identifier', async () => {

--- a/test/protocol/test/textDocument/codeAction/foundry/codeAction.test.ts
+++ b/test/protocol/test/textDocument/codeAction/foundry/codeAction.test.ts
@@ -16,7 +16,7 @@ describe('[foundry][codeAction]', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   test('add license identifier', async () => {

--- a/test/protocol/test/textDocument/codeAction/hardhat/codeAction.test.ts
+++ b/test/protocol/test/textDocument/codeAction/hardhat/codeAction.test.ts
@@ -13,7 +13,7 @@ describe('[hardhat][codeAction]', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   test('add license identifier', async () => {

--- a/test/protocol/test/textDocument/codeAction/projectless/codeAction.test.ts
+++ b/test/protocol/test/textDocument/codeAction/projectless/codeAction.test.ts
@@ -13,7 +13,7 @@ describe('[projectless][codeAction]', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   test('add license identifier', async () => {

--- a/test/protocol/test/textDocument/codeAction/truffle/codeAction.test.ts
+++ b/test/protocol/test/textDocument/codeAction/truffle/codeAction.test.ts
@@ -13,7 +13,7 @@ describe('[truffle][codeAction]', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   test('add license identifier', async () => {

--- a/test/protocol/test/textDocument/completion/ape/completion.test.ts
+++ b/test/protocol/test/textDocument/completion/ape/completion.test.ts
@@ -13,7 +13,7 @@ describe('[ape][completion]', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('imports', function () {

--- a/test/protocol/test/textDocument/completion/foundry/completion.test.ts
+++ b/test/protocol/test/textDocument/completion/foundry/completion.test.ts
@@ -17,7 +17,7 @@ describe('[foundry][completion]', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('imports', function () {

--- a/test/protocol/test/textDocument/completion/hardhat/completion.test.ts
+++ b/test/protocol/test/textDocument/completion/hardhat/completion.test.ts
@@ -15,7 +15,7 @@ describe('[hardhat][completion]', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('imports', function () {

--- a/test/protocol/test/textDocument/completion/projectless/completion.test.ts
+++ b/test/protocol/test/textDocument/completion/projectless/completion.test.ts
@@ -13,7 +13,7 @@ describe('[projectless][completion]', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('imports', function () {

--- a/test/protocol/test/textDocument/completion/truffle/completion.test.ts
+++ b/test/protocol/test/textDocument/completion/truffle/completion.test.ts
@@ -13,7 +13,7 @@ describe('[truffle][completion]', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('imports', function () {

--- a/test/protocol/test/textDocument/definition/ape/definition.test.ts
+++ b/test/protocol/test/textDocument/definition/ape/definition.test.ts
@@ -12,7 +12,7 @@ describe('[ape] definition', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('[versioned dependency] - go to definition', function () {

--- a/test/protocol/test/textDocument/definition/foundry/definition.test.ts
+++ b/test/protocol/test/textDocument/definition/foundry/definition.test.ts
@@ -30,7 +30,7 @@ describe('[foundry] definition', () => {
   })
 
   after(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   test('[single-file] - go to definition', async function () {

--- a/test/protocol/test/textDocument/definition/hardhat/definition.test.ts
+++ b/test/protocol/test/textDocument/definition/hardhat/definition.test.ts
@@ -28,7 +28,7 @@ describe('[hardhat] definition', () => {
   })
 
   after(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   test('[single-file] - go to definition', async () => {

--- a/test/protocol/test/textDocument/definition/projectless/definition.test.ts
+++ b/test/protocol/test/textDocument/definition/projectless/definition.test.ts
@@ -12,7 +12,7 @@ describe('[projectless] definition', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('[single-file] - go to definition', function () {

--- a/test/protocol/test/textDocument/definition/truffle/definition.test.ts
+++ b/test/protocol/test/textDocument/definition/truffle/definition.test.ts
@@ -12,7 +12,7 @@ describe('[truffle] definition', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('[single-file] - go to definition', function () {

--- a/test/protocol/test/textDocument/documentSymbol/documentSymbol.test.ts
+++ b/test/protocol/test/textDocument/documentSymbol/documentSymbol.test.ts
@@ -19,7 +19,7 @@ describe('[hardhat] documentSymbol', () => {
   })
 
   after(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   test('provides all the document symbols', async function () {
@@ -898,7 +898,7 @@ describe('[projectless] documentSymbol', () => {
   })
 
   after(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   test('supports unnamed function definition', async function () {

--- a/test/protocol/test/textDocument/implementation/ape/implementation.test.ts
+++ b/test/protocol/test/textDocument/implementation/ape/implementation.test.ts
@@ -12,7 +12,7 @@ describe('[ape] implementation', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('[single-file] - find all implementations', function () {

--- a/test/protocol/test/textDocument/implementation/foundry/implementation.test.ts
+++ b/test/protocol/test/textDocument/implementation/foundry/implementation.test.ts
@@ -16,7 +16,7 @@ describe('[foundry] implementation', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('[single-file] - find all implementations', function () {

--- a/test/protocol/test/textDocument/implementation/hardhat/implementation.test.ts
+++ b/test/protocol/test/textDocument/implementation/hardhat/implementation.test.ts
@@ -12,7 +12,7 @@ describe('[hardhat] implementation', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('[single-file] - find all implementations', function () {

--- a/test/protocol/test/textDocument/implementation/projectless/implementation.test.ts
+++ b/test/protocol/test/textDocument/implementation/projectless/implementation.test.ts
@@ -12,7 +12,7 @@ describe('[projectless] implementation', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('[single-file] - find all implementations', function () {

--- a/test/protocol/test/textDocument/implementation/truffle/implementation.test.ts
+++ b/test/protocol/test/textDocument/implementation/truffle/implementation.test.ts
@@ -12,7 +12,7 @@ describe('[truffle] implementation', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('[single-file] - find all implementations', function () {

--- a/test/protocol/test/textDocument/publishDiagnostics/ape/publishDiagnostics.test.ts
+++ b/test/protocol/test/textDocument/publishDiagnostics/ape/publishDiagnostics.test.ts
@@ -12,7 +12,7 @@ describe('[ape] publishDiagnostics', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('missing semicolon', function () {

--- a/test/protocol/test/textDocument/publishDiagnostics/foundry/publishDiagnostics.test.ts
+++ b/test/protocol/test/textDocument/publishDiagnostics/foundry/publishDiagnostics.test.ts
@@ -17,7 +17,7 @@ describe('[foundry] publishDiagnostics', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('missing semicolon', function () {

--- a/test/protocol/test/textDocument/publishDiagnostics/hardhat/publishDiagnostics.test.ts
+++ b/test/protocol/test/textDocument/publishDiagnostics/hardhat/publishDiagnostics.test.ts
@@ -15,7 +15,7 @@ describe('[hardhat] publishDiagnostics', () => {
 
   afterEach(async () => {
     client.clear()
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   test('missing semicolon', async function () {
@@ -154,7 +154,7 @@ describe('[hardhat] publishDiagnostics', () => {
     expect(client.documents[toUri(documentPath)].diagnostics.length).to.eq(1)
 
     // Edit the file to make it correct
-    client.changeDocument(documentPath, makeRange(0, 0, 0, 0), '// SPDX-License-Identifier: MIT\n')
+    await client.changeDocument(documentPath, makeRange(0, 0, 0, 0), '// SPDX-License-Identifier: MIT\n')
 
     // Assert diagnostics are gone
     await sleep(300) // TODO: change this to proper event listening for diagnostics

--- a/test/protocol/test/textDocument/publishDiagnostics/projectless/publishDiagnostics.test.ts
+++ b/test/protocol/test/textDocument/publishDiagnostics/projectless/publishDiagnostics.test.ts
@@ -13,7 +13,7 @@ describe('[projectless] publishDiagnostics', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   test('missing semicolon', async function () {

--- a/test/protocol/test/textDocument/publishDiagnostics/truffle/publishDiagnostics.test.ts
+++ b/test/protocol/test/textDocument/publishDiagnostics/truffle/publishDiagnostics.test.ts
@@ -13,7 +13,7 @@ describe('[truffle] publishDiagnostics', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   test('missing semicolon', async function () {

--- a/test/protocol/test/textDocument/references/ape/references.test.ts
+++ b/test/protocol/test/textDocument/references/ape/references.test.ts
@@ -12,7 +12,7 @@ describe('[ape] references', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('[single-file] - find all references', function () {

--- a/test/protocol/test/textDocument/references/foundry/references.test.ts
+++ b/test/protocol/test/textDocument/references/foundry/references.test.ts
@@ -16,7 +16,7 @@ describe('[foundry] references', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('[single-file] - find all references', function () {

--- a/test/protocol/test/textDocument/references/hardhat/references.test.ts
+++ b/test/protocol/test/textDocument/references/hardhat/references.test.ts
@@ -18,7 +18,7 @@ describe('[hardhat] references', () => {
   })
 
   after(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   before(async () => {

--- a/test/protocol/test/textDocument/references/projectless/references.test.ts
+++ b/test/protocol/test/textDocument/references/projectless/references.test.ts
@@ -12,7 +12,7 @@ describe('[projectless] references', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('[single-file] - find all references', function () {

--- a/test/protocol/test/textDocument/references/truffle/references.test.ts
+++ b/test/protocol/test/textDocument/references/truffle/references.test.ts
@@ -12,7 +12,7 @@ describe('[truffle] references', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('[single-file] - find all references', function () {

--- a/test/protocol/test/textDocument/rename/ape/rename.test.ts
+++ b/test/protocol/test/textDocument/rename/ape/rename.test.ts
@@ -12,7 +12,7 @@ describe('[ape] rename', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('[single-file][identifier] - rename', function () {

--- a/test/protocol/test/textDocument/rename/foundry/rename.test.ts
+++ b/test/protocol/test/textDocument/rename/foundry/rename.test.ts
@@ -16,7 +16,7 @@ describe('[foundry] rename', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('[single-file][identifier] - rename', function () {

--- a/test/protocol/test/textDocument/rename/hardhat/rename.test.ts
+++ b/test/protocol/test/textDocument/rename/hardhat/rename.test.ts
@@ -22,7 +22,7 @@ describe('[hardhat] rename', () => {
   })
 
   after(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   test('[single-file][identifier] - rename', async function () {

--- a/test/protocol/test/textDocument/rename/projectless/rename.test.ts
+++ b/test/protocol/test/textDocument/rename/projectless/rename.test.ts
@@ -12,7 +12,7 @@ describe('[projectless] rename', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('[single-file][identifier] - rename', function () {

--- a/test/protocol/test/textDocument/rename/truffle/rename.test.ts
+++ b/test/protocol/test/textDocument/rename/truffle/rename.test.ts
@@ -12,7 +12,7 @@ describe('[truffle] rename', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('[single-file][identifier] - rename', function () {

--- a/test/protocol/test/textDocument/semanticTokens/full.test.ts
+++ b/test/protocol/test/textDocument/semanticTokens/full.test.ts
@@ -19,7 +19,7 @@ describe('[hardhat] semanticTokens/full', () => {
   })
 
   after(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   test('provides highlighting for types, keywords, functions, numbers and strings', async function () {

--- a/test/protocol/test/textDocument/typeDefinition/ape/typeDefinition.test.ts
+++ b/test/protocol/test/textDocument/typeDefinition/ape/typeDefinition.test.ts
@@ -12,7 +12,7 @@ describe('[ape] type definition', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('[single-file] - go to type definition', function () {

--- a/test/protocol/test/textDocument/typeDefinition/foundry/typeDefinition.test.ts
+++ b/test/protocol/test/textDocument/typeDefinition/foundry/typeDefinition.test.ts
@@ -16,7 +16,7 @@ describe('[foundry] type definition', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('[single-file] - go to type definition', function () {

--- a/test/protocol/test/textDocument/typeDefinition/hardhat/typeDefinition.test.ts
+++ b/test/protocol/test/textDocument/typeDefinition/hardhat/typeDefinition.test.ts
@@ -22,7 +22,7 @@ describe('[hardhat] type definition', () => {
   })
 
   after(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   test('[single-file] - go to type definition', async function () {

--- a/test/protocol/test/textDocument/typeDefinition/projectless/typeDefinition.test.ts
+++ b/test/protocol/test/textDocument/typeDefinition/projectless/typeDefinition.test.ts
@@ -12,7 +12,7 @@ describe('[projectless] type definition', () => {
   })
 
   afterEach(async () => {
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   describe('[single-file] - go to type definition', function () {

--- a/test/protocol/test/window/showMessage/ape/testInitializeError.test.ts
+++ b/test/protocol/test/window/showMessage/ape/testInitializeError.test.ts
@@ -14,7 +14,7 @@ describe('[ape] show notification', () => {
 
   afterEach(async () => {
     client.clear()
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   test('on failed initialization', async () => {

--- a/test/protocol/test/window/showMessage/foundry/testInitializeError.test.ts
+++ b/test/protocol/test/window/showMessage/foundry/testInitializeError.test.ts
@@ -19,7 +19,7 @@ describe('[foundry] show notification', () => {
 
   afterEach(async () => {
     client.clear()
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   test('on failed initialization', async () => {

--- a/test/protocol/test/window/showMessage/hardhat/testInitializeError.test.ts
+++ b/test/protocol/test/window/showMessage/hardhat/testInitializeError.test.ts
@@ -14,7 +14,7 @@ describe('[hardhat] show notification', () => {
 
   afterEach(async () => {
     client.clear()
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   test('on failed initialization', async () => {

--- a/test/protocol/test/window/showMessage/truffle/testInitializeError.test.ts
+++ b/test/protocol/test/window/showMessage/truffle/testInitializeError.test.ts
@@ -14,7 +14,7 @@ describe('[truffle] show notification', () => {
 
   afterEach(async () => {
     client.clear()
-    client.closeAllDocuments()
+    await client.closeAllDocuments()
   })
 
   test('on failed initialization', async () => {


### PR DESCRIPTION
To deal with EPIPE errors we want to update to the latest versions of the vscode language server libraries that underlie our Language Server.
We have previously updated the language server side, this PR updates the client as well.

The client saw breaking changes around v8: https://github.com/Microsoft/vscode-languageserver-node?tab=readme-ov-file#3170-protocol-800-json-rpc-800-client-and-800-server.

In this PR we:

1. Update the library versions
2. Swap in the client code to using `.start()` instead of `.onReady()` - this needs to be analyzed to ensure we are not changing initialization order with multiple starts
3. Update the tests to match the new async apis

## Manual Testing

I have done a quick test round with the smoke test repo and a bundled version of these changes.

## Reviewer Suggestions

Take this one commit at a time. The main changes are commit 2 which swaps `.start()` for `.onReady()` and wires through the relevant awaits (or voids if that is appropriate).

A read through the changelog for the client is necessary as a check: https://github.com/microsoft/vscode-languageserver-node?tab=readme-ov-file#3170-protocol-800-json-rpc-800-client-and-800-server

I have not changed deactive in `extension.ts` but believe we are returning an appropriate promise that meets this requirement:

> Extensions should now implement a deactivate function in their extension main file and correctly return the stop promise from the deactivate call

