### PR TITLE
chore: add breadcrumbs to sentry events on uncaught error events

### DIFF
--- a/client/src/telemetry/SentryClientTelemetry.ts
+++ b/client/src/telemetry/SentryClientTelemetry.ts
@@ -29,13 +29,6 @@ export class SentryClientTelemetry implements Telemetry {
           component: "ext",
         },
       },
-      integrations: (defaults) =>
-        defaults.filter((integration) => {
-          return (
-            integration.name !== "OnUncaughtException" &&
-            integration.name !== "OnUnhandledRejection"
-          );
-        }),
       beforeSend: (event) => (isTelemetryEnabled() ? event : null),
     });
   }

--- a/server/scripts/bundle.js
+++ b/server/scripts/bundle.js
@@ -65,9 +65,9 @@ async function main() {
       "./out/ConfigLoader": "./src/frameworks/Truffle/ConfigLoader.ts",
     },
     bundle: true,
-    minifyWhitespace: true,
+    minifyWhitespace: false,
     minifyIdentifiers: false,
-    minifySyntax: true,
+    minifySyntax: false,
     external: [
       "@nomicfoundation/solidity-analyzer",
       "@nomicfoundation/slang",

--- a/server/src/eventEmitterPatch.ts
+++ b/server/src/eventEmitterPatch.ts
@@ -1,0 +1,73 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { EventEmitter } from "node:events";
+import * as Sentry from "@sentry/node";
+
+const eventEmiterCreationStack: WeakMap<EventEmitter, string> = new WeakMap();
+
+const errorEventEmitters: WeakMap<Error, EventEmitter> = new WeakMap();
+
+const errorEventToEmittionStack: WeakMap<Error, string> = new WeakMap();
+
+const EventEmitterAsAny: any = EventEmitter;
+
+const originalInit = EventEmitterAsAny.init;
+
+EventEmitterAsAny.init = function init(...args: any[]) {
+  eventEmiterCreationStack.set(
+    this,
+    new Error().stack ?? "<No stack available>"
+  );
+
+  return originalInit.apply(this, args);
+};
+
+const originalEmit: typeof EventEmitter.prototype.emit =
+  EventEmitter.prototype.emit;
+
+EventEmitter.prototype.emit = function emit(eventName, ...otherArgs) {
+  // This if is more complex than needed to make ts happy
+  if (eventName === "error" && Array.isArray(otherArgs) && "0" in otherArgs) {
+    const error: Error = otherArgs[0];
+
+    errorEventToEmittionStack.set(
+      error,
+      new Error().stack ?? "<No stack available>"
+    );
+    errorEventEmitters.set(otherArgs[0], this);
+  }
+
+  return originalEmit.apply(this, [eventName, ...otherArgs]);
+};
+
+function processUncaughtException(error: Error) {
+  const eventEmittionStack = errorEventToEmittionStack.get(error);
+  const eventEmitter = errorEventEmitters.get(error);
+
+  const eventEmitterCreationStack =
+    eventEmitter !== undefined
+      ? eventEmiterCreationStack.get(eventEmitter)
+      : undefined;
+
+  if (eventEmitterCreationStack !== undefined) {
+    Sentry.addBreadcrumb({
+      message: "eventEmitterCreationStack",
+      data: {
+        stack: eventEmitterCreationStack,
+      },
+    });
+  }
+
+  if (eventEmittionStack !== undefined) {
+    Sentry.addBreadcrumb({
+      message: "eventEmittionStack",
+      data: {
+        stack: eventEmittionStack,
+      },
+    });
+  }
+}
+
+process.on("uncaughtException", function (error) {
+  processUncaughtException(error);
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -24,6 +24,9 @@ import setupServer from "./server";
 import { SentryServerTelemetry } from "./telemetry/SentryServerTelemetry";
 import { GoogleAnalytics } from "./analytics/GoogleAnalytics";
 
+// TODO: Remove this once we finished debugging event emitters
+import "./eventEmitterPatch";
+
 // Create a connection for the server, using Node's IPC as a transport.
 // Also include all preview / proposed LSP features.
 const connection = createConnection(ProposedFeatures.all);


### PR DESCRIPTION
Patch `EventEmitter` `init` and `emit` functions to pick up stack traces and append them as breadcrumbs on process' uncaught exceptions. This is an effort to have more context on unhandled EPIPE errors