### PR TITLE
Hardhat 3 config reload support

### DIFF
--- a/server/src/services/validation/validate.ts
+++ b/server/src/services/validation/validate.ts
@@ -10,7 +10,11 @@ import { TextDocument, Range } from "vscode-languageserver-textdocument";
 import _ from "lodash";
 import path from "path";
 import { URI } from "vscode-uri";
-import { decodeUriAndRemoveFilePrefix, toUnixStyle } from "../../utils/index";
+import {
+  decodeUriAndRemoveFilePrefix,
+  isTestMode,
+  toUnixStyle,
+} from "../../utils/index";
 import {
   JobCompletionError,
   ServerState,
@@ -147,6 +151,13 @@ export async function validate(
           openDocuments,
           project
         );
+      }
+
+      // Notify that a file was successfully validated
+      if (isTestMode()) {
+        await serverState.connection.sendNotification("custom/validated", {
+          uri: change.document.uri,
+        });
       }
 
       return {

--- a/test/protocol/projects/hardhat3/contracts/workspace/onDidChangeWatchedFiles/ConfigReloadTest.sol
+++ b/test/protocol/projects/hardhat3/contracts/workspace/onDidChangeWatchedFiles/ConfigReloadTest.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.4;
+
+// This contract is used to test that the extension correctly reloads the
+// project when the hardhat.config.ts file changes.
+
+// It has an import to be resolved through remappings, so depending on the config
+// it would show a diagnostic or not
+
+import 'pkg_without_exports_2_through_remapping/B.sol';
+
+contract ConfigReloadTest {}

--- a/test/protocol/test/workspace/didChangeWatchedFiles/hardhat3.test.ts
+++ b/test/protocol/test/workspace/didChangeWatchedFiles/hardhat3.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync, writeFileSync } from 'fs'
+import { expect } from 'chai'
+import { getProjectPath, makeRange } from '../../helpers'
+import { TestLanguageClient } from '../../../src/TestLanguageClient'
+import { getInitializedClient } from '../../client'
+import { toUri } from '../../../src/helpers'
+
+let client!: TestLanguageClient
+
+describe('[hardhat3] onDidChangeWatchedFiles', () => {
+  describe('hardhat.config file change', () => {
+    const configPath = getProjectPath('hardhat3/hardhat.config.ts')
+    const originalConfigContents = readFileSync(configPath).toString()
+
+    beforeEach(async () => {
+      client = await getInitializedClient()
+    })
+
+    afterEach(async () => {
+      // After the test is done, restore the original config file
+      writeFileSync(configPath, originalConfigContents)
+    })
+
+    it('should reinitialize the project', async () => {
+      // Open the contract file that uses an import through remapping, there should be no diagnostics
+      const contractPath = getProjectPath('hardhat3/contracts/workspace/onDidChangeWatchedFiles/ConfigReloadTest.sol')
+      const document = await client.openDocument(contractPath)
+      expect(document.diagnostics).to.deep.equal([])
+
+      // Modify the config file, removing the required remapping
+      const modifiedConfigContents = originalConfigContents.replace(
+        'pkg_without_exports_2_through_remapping/',
+        'foobar/'
+      )
+      writeFileSync(configPath, modifiedConfigContents)
+
+      // Send the config change event
+      client.clear()
+      await client.changeWatchedFiles({ changes: [{ uri: toUri(configPath), type: 2 }] })
+
+      // Wait for the project to be reinitialized
+      await client.getOrWaitNotification('custom/projectInitialized', { configPath }, 2000)
+
+      // Trigger validation on the document
+      await client.changeDocument(contractPath, makeRange(0, 0, 0, 0), '')
+      await document.waitValidated
+
+      // Now there should be a diagnostic with invalid import
+      expect(document.diagnostics[0]).to.deep.include({
+        severity: 1,
+        source: 'hardhat',
+        code: 906,
+        range: {
+          start: {
+            line: 9,
+            character: 8,
+          },
+          end: {
+            line: 9,
+            character: 53,
+          },
+        },
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR introduces a change where events on the hardhat.config file are listened and the project is reinitialized accordingly (e.g. changes to paths, remappings, etc), without needing to restart the extension.

The main blocker for this was that ESM module imports are cached, so after the first initialization, when attempting to re-import the hardhat.config file (through `importUserConfig` helper from hardhat), it was returning the cached content. The workaround I chose for this was to create a copy of the config file whenever we want to load it, load the copy, and then delete it. A better solution would be possible if we were able to pass the URI of the config file to the `importUserConfig` helper, instead of path, because we could append a random query string to the URI and it would skip caching. Although I'm not sure if this would be allowed by tsx which we use for importing ts config files.

I wrote a full protocol test for the config reloading scenario, for which I had to add a few more custom notifications for server->client.