### PR TITLE
Sentry event anonymization

### DIFF
--- a/server/src/telemetry/SentryServerTelemetry.ts
+++ b/server/src/telemetry/SentryServerTelemetry.ts
@@ -62,13 +62,11 @@ export class SentryServerTelemetry implements Telemetry {
 
       beforeSend: (event) =>
         serverState.telemetryEnabled && this.eventFilter(event)
-          ? (anonymizeEvent(event) as ErrorEvent)
+          ? anonymizeEvent(event)
           : null,
 
       beforeSendTransaction: (transactionEvent) =>
-        serverState.telemetryEnabled
-          ? (anonymizeEvent(transactionEvent) as TransactionEvent)
-          : null,
+        serverState.telemetryEnabled ? anonymizeEvent(transactionEvent) : null,
     });
 
     this.analytics.init(machineId, extensionVersion, serverState, clientName);

--- a/server/src/telemetry/SentryServerTelemetry.ts
+++ b/server/src/telemetry/SentryServerTelemetry.ts
@@ -1,7 +1,6 @@
 /* istanbul ignore file: external system */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 import * as Sentry from "@sentry/node";
-import { ErrorEvent, TransactionEvent } from "@sentry/core";
 import { ServerState } from "../types";
 import { Analytics } from "../analytics/types";
 import { Telemetry, TrackingResult } from "./types";

--- a/server/src/telemetry/anonymization.ts
+++ b/server/src/telemetry/anonymization.ts
@@ -1,0 +1,103 @@
+/* eslint-disable @typescript-eslint/strict-boolean-expressions */
+import { Event, Exception } from "@sentry/core";
+
+const ANONYMIZED_FILE = "<user-file>";
+
+function anonymizeBreadcrumbs(
+  breadcrumbs?: Event["breadcrumbs"]
+): Event["breadcrumbs"] {
+  if (breadcrumbs === undefined) {
+    return undefined;
+  }
+
+  return breadcrumbs.map((breadcrumb) => {
+    return {
+      ...breadcrumb,
+      message: anonymizeString(breadcrumb.message),
+    };
+  });
+}
+
+function anonymizeStackTrace(
+  stacktrace?: Exception["stacktrace"]
+): Exception["stacktrace"] {
+  if (stacktrace?.frames === undefined) {
+    return stacktrace;
+  }
+
+  return {
+    frames: stacktrace.frames.map((frame) => {
+      return {
+        ...frame,
+        filename: anonymizeString(frame.filename),
+        abs_path: anonymizeString(frame.abs_path),
+        module: anonymizeString(frame.module),
+      };
+    }),
+  };
+}
+
+function anonymizeExceptions(
+  exception?: Event["exception"]
+): Event["exception"] {
+  if (exception?.values === undefined) {
+    return exception;
+  }
+
+  return {
+    values: exception.values.map((exceptionValue) => {
+      return {
+        ...exceptionValue,
+        value: anonymizeString(exceptionValue.value),
+        module: anonymizeString(exceptionValue.module),
+        stacktrace: anonymizeStackTrace(exceptionValue.stacktrace),
+      };
+    }),
+  };
+}
+
+function anonymizeUser(user?: Event["user"]): Event["user"] {
+  if (user === undefined) {
+    return user;
+  }
+
+  return {
+    ...user,
+    username: undefined,
+    email: undefined,
+  };
+}
+
+export function anonymizeEvent(event: Event): Event {
+  const breadcrumbs = anonymizeBreadcrumbs(event.breadcrumbs);
+  const exception = anonymizeExceptions(event.exception);
+  const user = anonymizeUser(event.user);
+
+  const scrubbedEvent: Event = {
+    ...event,
+    message: anonymizeString(event.message), // Scrub message
+    server_name: undefined, // Remove server_name
+    breadcrumbs, // Anonimized breadcrumbs
+    exception, // Anonimized exception
+    user, // Anonimized user
+  };
+
+  return scrubbedEvent;
+}
+
+function anonymizeString(str?: string) {
+  if (str === undefined) {
+    return undefined;
+  }
+
+  const pathRegex = /\S+[/\\]\S+/g;
+  const internalRegex = /.*nomicfoundation\.hardhat-solidity[^(\\|/)]*/;
+
+  return str.replace(pathRegex, (match) => {
+    if (internalRegex.test(match) && match.endsWith(".js")) {
+      return `<extension-root>${match.replace(internalRegex, "")}`;
+    } else {
+      return ANONYMIZED_FILE;
+    }
+  });
+}

--- a/server/src/telemetry/anonymization.ts
+++ b/server/src/telemetry/anonymization.ts
@@ -3,8 +3,8 @@ import { Event, Exception } from "@sentry/core";
 
 const ANONYMIZED_FILE = "<user-file>";
 
-export function anonymizeEvent<T extends Event>(event: T): T {
-  const scrubbedEvent: T = {
+export function anonymizeEvent<TEvent extends Event>(event: TEvent): TEvent {
+  const scrubbedEvent: TEvent = {
     ...event,
     message: anonymizeString(event.message), // Scrub message
     server_name: undefined, // Remove server_name

--- a/server/src/telemetry/anonymization.ts
+++ b/server/src/telemetry/anonymization.ts
@@ -68,12 +68,12 @@ function anonymizeUser(user?: Event["user"]): Event["user"] {
   };
 }
 
-export function anonymizeEvent(event: Event): Event {
+export function anonymizeEvent<T extends Event>(event: T): T {
   const breadcrumbs = anonymizeBreadcrumbs(event.breadcrumbs);
   const exception = anonymizeExceptions(event.exception);
   const user = anonymizeUser(event.user);
 
-  const scrubbedEvent: Event = {
+  const scrubbedEvent: T = {
     ...event,
     message: anonymizeString(event.message), // Scrub message
     server_name: undefined, // Remove server_name

--- a/server/test/telemetry/anonymization.ts
+++ b/server/test/telemetry/anonymization.ts
@@ -1,0 +1,235 @@
+import { ErrorEvent } from "@sentry/core";
+import { assert } from "chai";
+import { anonymizeEvent } from "../../src/telemetry/anonymization";
+
+describe("anonymization", () => {
+  describe("anonymizeEvent", () => {
+    describe("message anonymization", () => {
+      it("anonymizes solidity file paths and urls in message", () => {
+        const event: ErrorEvent = {
+          type: undefined,
+          message:
+            "file:///test/path/file.sol /absolute/path/file.sol C:\\absolute\\path\\file.sol contracts/MyContract.sol contracts\\MyContract.sol",
+        };
+
+        const anonymizedEvent = anonymizeEvent(event);
+
+        assert.strictEqual(
+          anonymizedEvent.message,
+          "<user-file> <user-file> <user-file> <user-file> <user-file>"
+        );
+      });
+
+      it("anonymizes javascript files if they dont belong to the extension", async () => {
+        const event: ErrorEvent = {
+          type: undefined,
+          message:
+            "file:///test/path/file.js /absolute/path/file.js C:\\absolute\\path\\file.js contracts/MyContract.js contracts\\MyContract.js",
+        };
+
+        const anonymizedEvent = anonymizeEvent(event);
+
+        assert.strictEqual(
+          anonymizedEvent.message,
+          "<user-file> <user-file> <user-file> <user-file> <user-file>"
+        );
+      });
+
+      it("anonymizes javascript files if they belong to the extension", async () => {
+        const event: ErrorEvent = {
+          type: undefined,
+          message:
+            "file:///user_path/nomicfoundation.hardhat-solidity-0.8.20/internal_path/file.js /user_path/nomicfoundation.hardhat-solidity-0.8.20/internal_path/file2.js C:\\user_path\\nomicfoundation.hardhat-solidity-0.8.20\\internal_path\\file3.js /c:/user_path/nomicfoundation.hardhat-solidity-0.8.20/internal_path/file4.js ",
+        };
+
+        const anonymizedEvent = anonymizeEvent(event);
+
+        assert.strictEqual(
+          anonymizedEvent.message,
+          "<extension-root>/internal_path/file.js <extension-root>/internal_path/file2.js <extension-root>\\internal_path\\file3.js <extension-root>/internal_path/file4.js "
+        );
+      });
+    });
+
+    describe("breadcrumbs anonymization", () => {
+      it("anonymizes breadcrumbs", () => {
+        const event: ErrorEvent = {
+          type: undefined,
+          breadcrumbs: [
+            {
+              message: "error in file /test/path/file.sol",
+            },
+            {
+              message: "error in file c:\\test\\path\\file.sol",
+            },
+            {
+              message: "error in file file:///test/path/file.sol",
+            },
+            {
+              message: "error in file /c:/test/path/file.sol",
+            },
+          ],
+        };
+
+        const anonymizedEvent = anonymizeEvent(event);
+
+        assert.deepEqual(anonymizedEvent.breadcrumbs, [
+          { message: "error in file <user-file>" },
+          { message: "error in file <user-file>" },
+          { message: "error in file <user-file>" },
+          { message: "error in file <user-file>" },
+        ]);
+      });
+    });
+
+    describe("exception anonymization", () => {
+      it("anonymizes exception values and modules", () => {
+        const event: ErrorEvent = {
+          type: undefined,
+          exception: {
+            values: [
+              {
+                value: "error in file /test/path/file.sol",
+                module: "file:///test/path/file.sol",
+              },
+              {
+                value: "error in file c:\\test\\path\\file.sol",
+                module: "C:\\test\\path\\file.sol",
+              },
+              {
+                value: "error in file file:///test/path/file.sol",
+                module: "file:///test/path/file.sol",
+              },
+              {
+                value: "error in file /c:/test/path/file.sol",
+                module: "C:\\test\\path\\file.sol",
+              },
+            ],
+          },
+        };
+
+        const anonymizedEvent = anonymizeEvent(event);
+
+        assert.deepEqual(anonymizedEvent.exception?.values, [
+          {
+            value: "error in file <user-file>",
+            stacktrace: undefined,
+            module: "<user-file>",
+          },
+          {
+            value: "error in file <user-file>",
+            stacktrace: undefined,
+            module: "<user-file>",
+          },
+          {
+            value: "error in file <user-file>",
+            stacktrace: undefined,
+            module: "<user-file>",
+          },
+          {
+            value: "error in file <user-file>",
+            stacktrace: undefined,
+            module: "<user-file>",
+          },
+        ]);
+      });
+
+      it("anonymizes exception stacktraces", () => {
+        const event: ErrorEvent = {
+          type: undefined,
+          exception: {
+            values: [
+              {
+                value: "error in file /test/path/file.sol",
+                module: "file:///test/path/file.sol",
+                stacktrace: {
+                  frames: [
+                    {
+                      filename: "file:///test/path/file.sol",
+                      abs_path: "/test/path/file.sol",
+                      module: "file:///test/path/file.sol",
+                    },
+                    {
+                      filename: "C:\\test\\path\\file.sol",
+                      abs_path: "C:\\test\\path\\file.sol",
+                      module: "C:\\test\\path\\file.sol",
+                    },
+                    {
+                      filename: "file:///test/path/file.sol",
+                      abs_path: "/test/path/file.sol",
+                      module: "file:///test/path/file.sol",
+                    },
+                    {
+                      filename: "C:\\test\\path\\file.sol",
+                      abs_path: "C:\\test\\path\\file.sol",
+                      module: "C:\\test\\path\\file.sol",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        };
+
+        const anonymizedEvent = anonymizeEvent(event);
+
+        assert.deepEqual(anonymizedEvent.exception?.values, [
+          {
+            value: "error in file <user-file>",
+            module: "<user-file>",
+            stacktrace: {
+              frames: [
+                {
+                  filename: "<user-file>",
+                  abs_path: "<user-file>",
+                  module: "<user-file>",
+                },
+                {
+                  filename: "<user-file>",
+                  abs_path: "<user-file>",
+                  module: "<user-file>",
+                },
+                {
+                  filename: "<user-file>",
+                  abs_path: "<user-file>",
+                  module: "<user-file>",
+                },
+                {
+                  filename: "<user-file>",
+                  abs_path: "<user-file>",
+                  module: "<user-file>",
+                },
+              ],
+            },
+          },
+        ]);
+      });
+    });
+
+    describe("user anonymization", () => {
+      it("anonymizes user", () => {
+        const event: ErrorEvent = {
+          type: undefined,
+          user: {
+            username: "user",
+            email: "user@email.com",
+          },
+        };
+        const anonymizedEvent = anonymizeEvent(event);
+        assert.deepEqual(anonymizedEvent.user, {
+          username: undefined,
+          email: undefined,
+        });
+      });
+    });
+
+    it("removes server_name", () => {
+      const event: ErrorEvent = {
+        type: undefined,
+        server_name: "server_name",
+      };
+      const anonymizedEvent = anonymizeEvent(event);
+      assert.deepEqual(anonymizedEvent.server_name, undefined);
+    });
+  });
+});


### PR DESCRIPTION
Closes #485 

All potential user-identifying information that may be present in error events or performance traces are now scrubbed before being sent to Sentry.

File paths and URLs are replaced with `<user_file>` strings. For the extension's internal files, we scrub up to the the extension root path, and keep the internal file subpath for debugging purposes. This will result in paths looking like `<extension_root>/server/out/index.js`. This detection of internal files additionally is only applied to `.js` files, so we default on the safe side of scrubbing most file paths (which include .sol files).

Additionally some default fields that may be populated by the SDK are cleared as well:
- User email
- User name
- Server name

Some fields may differ from what has been specified in the design document, and this is because the `Event` structure changed significantly from Sentry v6 to Sentry v9. Since this change is subject to the Sentry 9 upgrade, we only care about the new event format.