### PR TITLE
coc: add @nomicfoundation/coc-solidity.formatter in coc.property

### DIFF
--- a/coc/package.json
+++ b/coc/package.json
@@ -65,6 +65,16 @@
           "type": "boolean",
           "default": false,
           "description": "Allow this extension to send telemetry. This helps us understand how it is used and how it is performing. Read more in our [privacy policy](https://hardhat.org/privacy-policy.html)."
+        },
+        "@nomicfoundation/coc-solidity.formatter": {
+          "type": "string",
+          "default": "prettier",
+          "enum": [
+            "none",
+            "prettier",
+            "forge"
+          ],
+          "description": "Enables / disables the solidity formatter (prettier solidity default)"
         }
       }
     }


### PR DESCRIPTION
<!--
Thank you for using **Solidity for Visual Studio Code by Nomic Foundation** and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.

---

<!-- Add a description of your PR here -->

Add `@nomicfoundation/coc-solidity.formatter` in coc.configuration.properites, else the coc will popup with a warning of `Property @nomicfoundation/coc-solidity.formatter is not allowed.`

<img width="987" alt="image" src="https://github.com/user-attachments/assets/14055ac2-6758-4b92-886a-508303889fe3" />

