### PR TITLE
Sentry event anonymization for extension client

### DIFF
--- a/client/src/telemetry/SentryClientTelemetry.ts
+++ b/client/src/telemetry/SentryClientTelemetry.ts
@@ -4,6 +4,7 @@ import { getDefaultIntegrations, defaultStackParser } from "@sentry/node";
 import { ExtensionState } from "../types";
 import { isTelemetryEnabled } from "../utils/telemetry";
 import { Telemetry } from "./types";
+import { anonymizeEvent } from "./anonymization";
 
 const SENTRY_CLOSE_TIMEOUT = 2000;
 
@@ -35,7 +36,8 @@ export class SentryClientTelemetry implements Telemetry {
       integrations,
       environment: this.extensionState.env,
       release: `${this.extensionState.name}@${this.extensionState.version}`,
-      beforeSend: (event) => (isTelemetryEnabled() ? event : null),
+      beforeSend: (event) =>
+        isTelemetryEnabled() ? anonymizeEvent(event) : null,
     });
     Sentry.getGlobalScope().setUser({ id: this.extensionState.machineId });
     Sentry.getGlobalScope().setTag("component", "ext");

--- a/client/src/telemetry/anonymization.ts
+++ b/client/src/telemetry/anonymization.ts
@@ -1,4 +1,4 @@
-// This file and client/src/telemetry/anonymization.ts are identical, at some point we may consider merging them
+// This file and server/src/telemetry/anonymization.ts are identical, at some point we may consider merging them
 
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
 import { Event, Exception } from "@sentry/core";


### PR DESCRIPTION
Duplicated server anonimization logic. We may get rid of this duplication once we set up a monorepo structure