### PR TITLE
Fix: merge foundry remappings

### DIFF
--- a/server/src/frameworks/Foundry/FoundryProject.ts
+++ b/server/src/frameworks/Foundry/FoundryProject.ts
@@ -175,7 +175,12 @@ export class FoundryProject extends Project {
       (remapping) => `${remapping.from}=${remapping.to}`
     );
 
-    (basicCompilation.input.settings as any).remappings = remappings; // CompilerInput type doesn't have remappings
+    const inputRemappings = basicCompilation.input.settings.remappings ?? [];
+
+    (basicCompilation.input.settings as any).remappings = [
+      ...remappings,
+      ...inputRemappings,
+    ]; // CompilerInput type doesn't have remappings
 
     return basicCompilation;
   }


### PR DESCRIPTION
Closes #704 

This fixes the issue where a user remaps to contracts in a parent directory on foundry (e.g. monorepos)