### PR TITLE
Fix validation failing when there's a hh3 cache hit

### DIFF
--- a/server/src/frameworks/Hardhat/Hardhat3/Hardhat3Project.ts
+++ b/server/src/frameworks/Hardhat/Hardhat3/Hardhat3Project.ts
@@ -17,6 +17,7 @@ import type { HookContext } from "hardhat3/types/hooks" with { "resolution-mode"
 import { analyze } from "@nomicfoundation/solidity-analyzer";
 import { cpSync } from "fs";
 import { removeSync } from "fs-extra";
+import { lstat } from "fs/promises";
 import {
   BuildInputError,
   FileSpecificError,
@@ -318,9 +319,11 @@ export class Hardhat3Project extends Project {
     changes,
   }: DidChangeWatchedFilesParams): Promise<void> {
     for (const change of changes) {
-      if (pathsEqual(toPath(change.uri), this.configPath)) {
+      const filePath = toPath(change.uri);
+      const fileStat = await lstat(filePath);
+      if (pathsEqual(filePath, this.configPath)) {
         await this.#handleConfigChange();
-      } else if (change.uri.endsWith(".sol")) {
+      } else if (change.uri.endsWith(".sol") && fileStat.isFile()) {
         await this.#handleSourceFileChange(change);
       }
     }


### PR DESCRIPTION
If you compile a hardhat3 project, cache entries will be set for the contracts that were compiled successfully. When attempting validation for a file, `getCompilationJobs` is used, which returns an empty array if there are no jobs to compile (because there was a cache hit). Two possible options would be to either skip validation when there are no jobs to compile, or to pass `force: true`. I chose the latter one since I think it's consistent with our model of compiling on every file change.