### PR TITLE
fix: exclude node_modules from Foundry project search

### DIFF
--- a/server/src/frameworks/Foundry/FoundryIndexer.ts
+++ b/server/src/frameworks/Foundry/FoundryIndexer.ts
@@ -10,7 +10,7 @@ export class FoundryIndexer extends ProjectIndexer {
     const configFiles = await this.fileRetriever.findFiles(
       uri,
       "**/foundry.toml",
-      ["**/lib/**"]
+      ["**/lib/**", "**/node_modules/**"]
     );
 
     return configFiles.map((configFile) => {


### PR DESCRIPTION
The initial scan for potential projects excludes Hardhat projects within `node_modules`, however previously this exclusion was not being applied to the search for Foundry projects (which are more typically installed via git submodules).

The fix here is to exclude `foundry.toml` files found within `node_modules` at any level of a monorepo from consideration in the Foundry project search.

Fixes #722 
