### PR TITLE
drop node 20 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        node: [20.18.0, 20.19.0, 22.15.0]
+        node: [22.15.1, 22]
 
     steps:
       - name: Clone repository

--- a/client/package.json
+++ b/client/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/NomicFoundation/hardhat-vscode/issues"
   },
   "engines": {
-    "vscode": "^1.99.0"
+    "vscode": "^1.101.0"
   },
   "activationEvents": [
     "workspaceContains:**/hardhat.config.{ts,js}",


### PR DESCRIPTION
Cursor has been updated to VSCode 1.105.1 in the latest version. As such we no longer have to include support for Node 20 in our test matrix.

This PR updates the minimum supported version of VSCode for the extension to `1.101.0` the first version with Node 22 support. It also drops Node 20 from our test matrix.
