### PR TITLE
fix(#542): highlight only uninitialized immutable variables and const…

### DIFF
--- a/server/src/compilerDiagnostics/compilerDiagnostics.ts
+++ b/server/src/compilerDiagnostics/compilerDiagnostics.ts
@@ -10,6 +10,7 @@ import { SpecifyCompilerVersion } from "./diagnostics/SpecifyCompilerVersion";
 import { CompilerDiagnostic } from "./types";
 import { SpecifyDataLocation } from "./diagnostics/SpecifyDataLocation";
 import { InvalidChecksum } from "./diagnostics/InvalidChecksum";
+import { UninitializedImmutable } from "./diagnostics/UninitializedImmutable";
 
 export const compilerDiagnostics: { [key: string]: CompilerDiagnostic } = [
   new AddOverrideSpecifier(),
@@ -23,4 +24,5 @@ export const compilerDiagnostics: { [key: string]: CompilerDiagnostic } = [
   new SpecifyVisibility(),
   new SpecifyCompilerVersion(),
   new SpecifyDataLocation(),
+  new UninitializedImmutable(),
 ].reduce((acc, item) => ({ ...acc, [item.code]: item }), {});

--- a/server/src/compilerDiagnostics/conversions/byteOffsetToStringIndex.ts
+++ b/server/src/compilerDiagnostics/conversions/byteOffsetToStringIndex.ts
@@ -1,0 +1,40 @@
+/**
+ * solc reports source locations as offsets into the UTF-8 encoded source, while
+ * `TextDocument` and `@solidity-parser` both work in UTF-16 code units. The two
+ * agree only while the file stays ASCII - one accented character, em dash or
+ * emoji anywhere earlier in the file and every solc offset after it is too
+ * large.
+ *
+ * Returns the index into `text` that `byteOffset` points at.
+ */
+export function byteOffsetToStringIndex(
+  text: string,
+  byteOffset: number
+): number {
+  if (byteOffset <= 0) {
+    return 0;
+  }
+
+  let bytes = 0;
+  let index = 0;
+
+  while (index < text.length && bytes < byteOffset) {
+    // Non-null assertion is safe: index is inside the string.
+    const codePoint = text.codePointAt(index)!;
+
+    if (codePoint < 0x80) {
+      bytes += 1;
+    } else if (codePoint < 0x800) {
+      bytes += 2;
+    } else if (codePoint < 0x10000) {
+      bytes += 3;
+    } else {
+      bytes += 4;
+    }
+
+    // Anything above the BMP is stored as a surrogate pair.
+    index += codePoint > 0xffff ? 2 : 1;
+  }
+
+  return index;
+}

--- a/server/src/compilerDiagnostics/diagnostics/UninitializedImmutable.ts
+++ b/server/src/compilerDiagnostics/diagnostics/UninitializedImmutable.ts
@@ -1,0 +1,99 @@
+import * as parser from "@solidity-parser/parser";
+import type * as ast from "@solidity-parser/parser/dist/src/ast-types";
+import { CodeAction, Diagnostic, Range } from "vscode-languageserver/node";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { ResolveActionsContext } from "../types";
+import { SolcError, ServerState } from "../../types";
+import { passThroughConversion } from "../conversions/passThroughConversion";
+
+export class UninitializedImmutable {
+  public code = "2658";
+  public blocks = [];
+
+  public fromHardhatCompilerError(
+    document: TextDocument,
+    error: SolcError
+  ): Diagnostic | Diagnostic[] {
+    const defaultDiagnostic = passThroughConversion(document, error);
+
+    try {
+      const text = document.getText();
+      const ast = parser.parse(text, { loc: true, tolerant: true });
+
+      const diagnostics: Diagnostic[] = [];
+
+      let constructorRange: Range | null = null;
+      const uninitializedImmutablesRanges: Range[] = [];
+
+      // Find constructor and uninitialized immutable variables within the contract AST
+      parser.visit(ast, {
+        StateVariableDeclaration: (node: ast.StateVariableDeclaration) => {
+          if (
+            node.variables === null ||
+            node.variables === undefined ||
+            node.variables.length === 0
+          )
+            return;
+          for (const variable of node.variables) {
+            if (variable.isDeclaredConst === true) continue; // Not immutable
+            if (
+              variable.isImmutable === true &&
+              (node.initialValue === null || node.initialValue === undefined)
+            ) {
+              if (variable.loc) {
+                uninitializedImmutablesRanges.push(
+                  Range.create(
+                    variable.loc.start.line - 1,
+                    variable.loc.start.column,
+                    variable.loc.end.line - 1,
+                    variable.loc.end.column
+                  )
+                );
+              }
+            }
+          }
+        },
+        FunctionDefinition: (node: ast.FunctionDefinition) => {
+          if (node.isConstructor && node.loc) {
+            constructorRange = Range.create(
+              node.loc.start.line - 1,
+              node.loc.start.column,
+              node.loc.end.line - 1,
+              node.loc.end.column
+            );
+          }
+        },
+      });
+
+      if (constructorRange !== null) {
+        diagnostics.push({
+          ...defaultDiagnostic,
+          range: constructorRange,
+        });
+      }
+
+      for (const range of uninitializedImmutablesRanges) {
+        diagnostics.push({
+          ...defaultDiagnostic,
+          range,
+        });
+      }
+
+      if (diagnostics.length > 0) {
+        return diagnostics;
+      }
+
+      return defaultDiagnostic;
+    } catch (e) {
+      return defaultDiagnostic;
+    }
+  }
+
+  public resolveActions(
+    _serverState: ServerState,
+    _diagnostic: Diagnostic,
+    _context: ResolveActionsContext
+  ): CodeAction[] {
+    return [];
+  }
+}

--- a/server/src/compilerDiagnostics/diagnostics/UninitializedImmutable.ts
+++ b/server/src/compilerDiagnostics/diagnostics/UninitializedImmutable.ts
@@ -2,10 +2,23 @@ import * as parser from "@solidity-parser/parser";
 import type * as ast from "@solidity-parser/parser/dist/src/ast-types";
 import { CodeAction, Diagnostic, Range } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
+import {
+  isFunctionDefinition,
+  isStateVariableDeclaration,
+} from "@analyzer/utils/typeGuards";
 import { ResolveActionsContext } from "../types";
 import { SolcError, ServerState } from "../../types";
+import { toUnixStyle } from "../../utils";
 import { passThroughConversion } from "../conversions/passThroughConversion";
+import { byteOffsetToStringIndex } from "../conversions/byteOffsetToStringIndex";
 
+/**
+ * solc reports 2658 ("Construction control flow ends without initializing all
+ * immutable state variables") against the whole contract definition, which
+ * paints the entire contract red. This narrows it down to the immutables that
+ * are actually left uninitialized, plus the constructor that should have
+ * initialized them.
+ */
 export class UninitializedImmutable {
   public code = "2658";
   public blocks = [];
@@ -16,74 +29,84 @@ export class UninitializedImmutable {
   ): Diagnostic | Diagnostic[] {
     const defaultDiagnostic = passThroughConversion(document, error);
 
+    // convertErrors hands over the document that changed, which is not always
+    // the file the error belongs to. Reading another file's AST would put the
+    // ranges on whatever happens to sit at those offsets here.
+    if (!this._errorBelongsTo(document, error)) {
+      return defaultDiagnostic;
+    }
+
     try {
       const text = document.getText();
-      const ast = parser.parse(text, { loc: true, tolerant: true });
 
-      const diagnostics: Diagnostic[] = [];
-
-      let constructorRange: Range | null = null;
-      const uninitializedImmutablesRanges: Range[] = [];
-
-      // Find constructor and uninitialized immutable variables within the contract AST
-      parser.visit(ast, {
-        StateVariableDeclaration: (node: ast.StateVariableDeclaration) => {
-          if (
-            node.variables === null ||
-            node.variables === undefined ||
-            node.variables.length === 0
-          )
-            return;
-          for (const variable of node.variables) {
-            if (variable.isDeclaredConst === true) continue; // Not immutable
-            if (
-              variable.isImmutable === true &&
-              (node.initialValue === null || node.initialValue === undefined)
-            ) {
-              if (variable.loc) {
-                uninitializedImmutablesRanges.push(
-                  Range.create(
-                    variable.loc.start.line - 1,
-                    variable.loc.start.column,
-                    variable.loc.end.line - 1,
-                    variable.loc.end.column
-                  )
-                );
-              }
-            }
-          }
-        },
-        FunctionDefinition: (node: ast.FunctionDefinition) => {
-          if (node.isConstructor && node.loc) {
-            constructorRange = Range.create(
-              node.loc.start.line - 1,
-              node.loc.start.column,
-              node.loc.end.line - 1,
-              node.loc.end.column
-            );
-          }
-        },
+      const sourceUnit = parser.parse(text, {
+        loc: true,
+        range: true,
+        tolerant: true,
       });
 
-      if (constructorRange !== null) {
-        diagnostics.push({
-          ...defaultDiagnostic,
-          range: constructorRange,
-        });
+      const contract = this._findErroringContract(sourceUnit, text, error);
+
+      if (contract === null) {
+        return defaultDiagnostic;
       }
 
-      for (const range of uninitializedImmutablesRanges) {
-        diagnostics.push({
-          ...defaultDiagnostic,
-          range,
-        });
+      const constructorNode = this._findConstructor(contract);
+
+      // An immutable can be given its value either inline or in the
+      // constructor body, so both have to be taken into account before calling
+      // one uninitialized.
+      const assignedInConstructor =
+        constructorNode === null
+          ? new Set<string>()
+          : this._collectAssignedNames(constructorNode);
+
+      const ranges: Range[] = [];
+
+      for (const node of contract.subNodes) {
+        if (!isStateVariableDeclaration(node)) {
+          continue;
+        }
+
+        if (node.initialValue !== null && node.initialValue !== undefined) {
+          continue;
+        }
+
+        for (const variable of node.variables) {
+          if (variable.isImmutable !== true) {
+            continue;
+          }
+
+          if (
+            variable.name !== null &&
+            assignedInConstructor.has(variable.name)
+          ) {
+            continue;
+          }
+
+          const range = this._toRange(document, variable);
+
+          if (range !== null) {
+            ranges.push(range);
+          }
+        }
       }
 
-      if (diagnostics.length > 0) {
-        return diagnostics;
+      // Nothing identified means our reading of the contract disagrees with
+      // solc's. Report the original error rather than swallow it.
+      if (ranges.length === 0) {
+        return defaultDiagnostic;
       }
 
-      return defaultDiagnostic;
+      if (constructorNode !== null) {
+        const constructorRange = this._toRange(document, constructorNode);
+
+        if (constructorRange !== null) {
+          ranges.push(constructorRange);
+        }
+      }
+
+      return ranges.map((range) => ({ ...defaultDiagnostic, range }));
     } catch (e) {
       return defaultDiagnostic;
     }
@@ -95,5 +118,121 @@ export class UninitializedImmutable {
     _context: ResolveActionsContext
   ): CodeAction[] {
     return [];
+  }
+
+  /**
+   * Whether the error was reported against the document being parsed. Paths are
+   * compared by suffix because solc reports them relative to the project root.
+   */
+  private _errorBelongsTo(document: TextDocument, error: SolcError): boolean {
+    if (error.sourceLocation === undefined) {
+      return false;
+    }
+
+    const documentPath = toUnixStyle(decodeURIComponent(document.uri));
+
+    return documentPath.endsWith(toUnixStyle(error.sourceLocation.file));
+  }
+
+  /**
+   * A file can hold several contracts, only one of which the error is about,
+   * so the error's own source location decides which one to look at. Finding
+   * no contract is a valid answer - the caller then reports the error as solc
+   * framed it.
+   */
+  private _findErroringContract(
+    sourceUnit: ast.SourceUnit,
+    text: string,
+    error: SolcError
+  ): ast.ContractDefinition | null {
+    if (error.sourceLocation === undefined) {
+      return null;
+    }
+
+    const start = byteOffsetToStringIndex(text, error.sourceLocation.start);
+
+    const contracts: ast.ContractDefinition[] = [];
+
+    parser.visit(sourceUnit, {
+      ContractDefinition: (node) => {
+        if (node.range !== undefined) {
+          contracts.push(node);
+        }
+      },
+    });
+
+    // `range` ends on the contract's last character, not past it.
+    const containing = contracts.find(
+      (contract) => contract.range![0] <= start && start <= contract.range![1]
+    );
+
+    return containing ?? null;
+  }
+
+  private _findConstructor(
+    contract: ast.ContractDefinition
+  ): ast.FunctionDefinition | null {
+    for (const node of contract.subNodes) {
+      if (isFunctionDefinition(node) && node.isConstructor === true) {
+        return node;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Names assigned to somewhere inside the constructor. Immutables only accept
+   * plain assignment, so `=` is the only operator worth looking at.
+   *
+   * A local variable shadowing an immutable would be counted here as well. That
+   * leaves the immutable looking initialized, no range is collected for it, and
+   * the whole-contract diagnostic is reported instead - the same thing the user
+   * saw before this diagnostic existed.
+   */
+  private _collectAssignedNames(
+    constructorNode: ast.FunctionDefinition
+  ): Set<string> {
+    const names = new Set<string>();
+
+    const record = (node: ast.Expression) => {
+      if (node.type === "Identifier") {
+        names.add(node.name);
+      } else if (node.type === "TupleExpression") {
+        for (const component of node.components) {
+          if (component !== null) {
+            record(component as ast.Expression);
+          }
+        }
+      }
+    };
+
+    parser.visit(constructorNode, {
+      BinaryOperation: (node) => {
+        if (node.operator === "=") {
+          record(node.left);
+        }
+      },
+    });
+
+    return names;
+  }
+
+  /**
+   * `range` is a pair of character offsets whose end is inclusive, while an LSP
+   * range ends one past its last character.
+   */
+  private _toRange(
+    document: TextDocument,
+    node: ast.BaseASTNode
+  ): Range | null {
+    if (node.range === undefined) {
+      return null;
+    }
+
+    return Range.create(
+      document.positionAt(node.range[0]),
+      document.positionAt(node.range[1] + 1)
+    );
   }
 }

--- a/server/src/compilerDiagnostics/types.ts
+++ b/server/src/compilerDiagnostics/types.ts
@@ -20,5 +20,5 @@ export interface CompilerDiagnostic {
   fromHardhatCompilerError: (
     document: TextDocument,
     error: SolcError
-  ) => Diagnostic;
+  ) => Diagnostic | Diagnostic[];
 }

--- a/server/src/parser/analyzer/utils/typeGuards.ts
+++ b/server/src/parser/analyzer/utils/typeGuards.ts
@@ -18,6 +18,7 @@ import {
   EventDefinition,
   UserDefinedTypeName,
   VariableDeclaration,
+  StateVariableDeclaration,
   StructDefinition,
   EnumDefinition,
 } from "@solidity-parser/parser/dist/src/ast-types";
@@ -82,6 +83,12 @@ export function isVariableDeclaration(
   node: BaseASTNode | EmptyNodeType
 ): node is VariableDeclaration {
   return node.type === "VariableDeclaration";
+}
+
+export function isStateVariableDeclaration(
+  node: BaseASTNode | EmptyNodeType
+): node is StateVariableDeclaration {
+  return node.type === "StateVariableDeclaration";
 }
 
 export function isEventDefinition(

--- a/server/src/services/validation/DiagnosticConverter.ts
+++ b/server/src/services/validation/DiagnosticConverter.ts
@@ -31,13 +31,20 @@ export class DiagnosticConverter {
 
       const diagnostic = this.convert(document, error);
 
-      diagnostics[diagnosticPath].push(diagnostic);
+      if (Array.isArray(diagnostic)) {
+        diagnostics[diagnosticPath].push(...diagnostic);
+      } else {
+        diagnostics[diagnosticPath].push(diagnostic);
+      }
     }
 
     return diagnostics;
   }
 
-  public convert(document: TextDocument, error: SolcError): Diagnostic {
+  public convert(
+    document: TextDocument,
+    error: SolcError
+  ): Diagnostic | Diagnostic[] {
     if (error.errorCode in compilerDiagnostics) {
       return compilerDiagnostics[error.errorCode].fromHardhatCompilerError(
         document,

--- a/server/test/compilerDiagnostics/diagnostics/UninitializedImmutable.test.ts
+++ b/server/test/compilerDiagnostics/diagnostics/UninitializedImmutable.test.ts
@@ -12,16 +12,18 @@ const END_MARKER = "/*]*/";
 
 /**
  * Builds the error the way solc reports 2658: the source location spans the
- * whole contract definition, delimited in the fixtures below by the markers.
+ * contract definition the compiler is complaining about, delimited in the
+ * fixtures below by the markers. `start` lands on the `contract` keyword and
+ * `end` one past the closing brace, matching what solc emits.
  *
  * The markers are swapped for equal-length whitespace, so every offset, line
  * and column in the fixture stays exactly where it was written.
  */
 function buildError(text: string): { error: SolcError; source: string } {
-  const start = text.indexOf(START_MARKER);
-  const end = text.indexOf(END_MARKER);
+  const markerStart = text.indexOf(START_MARKER);
+  const markerEnd = text.indexOf(END_MARKER);
 
-  if (start === -1 || end === -1) {
+  if (markerStart === -1 || markerEnd === -1) {
     throw new Error("fixture is missing its contract markers");
   }
 
@@ -37,7 +39,15 @@ function buildError(text: string): { error: SolcError; source: string } {
       formattedMessage: MESSAGE,
       message: MESSAGE,
       severity: "error",
-      sourceLocation: { file: "test.sol", start, end: end + END_MARKER.length },
+      sourceLocation: {
+        file: "test.sol",
+        // solc counts UTF-8 bytes, not UTF-16 code units.
+        start: Buffer.byteLength(
+          source.slice(0, markerStart + START_MARKER.length),
+          "utf8"
+        ),
+        end: Buffer.byteLength(source.slice(0, markerEnd), "utf8"),
+      },
       type: "DeclarationError",
     } as SolcError,
   };
@@ -204,10 +214,32 @@ pragma solidity ^0.8.0;
     });
   });
 
-  describe("unparseable source", () => {
+  describe("a local shadowing an immutable", () => {
+    it("falls back rather than guessing", () => {
+      const { diagnostics } = run(`
+pragma solidity ^0.8.0;
+/*[*/contract Test {
+  uint256 public immutable myVar;
+
+  constructor() {
+    uint256 myVar;
+    myVar = 1;
+  }
+}/*]*/
+`);
+
+      // The local makes the immutable look initialized. Reporting nothing would
+      // hide a real compiler error, so the whole-contract diagnostic stands.
+      expect(diagnostics).to.have.length(1);
+      expect(diagnostics[0].message).to.equal(MESSAGE);
+    });
+  });
+
+  describe("source the parser recovers from", () => {
     it("falls back to the single whole-contract diagnostic", () => {
-      // An unterminated string literal is one of the few things that still
-      // throws with `tolerant: true`, so it exercises the catch branch.
+      // Error recovery keeps going here rather than throwing, and hands back an
+      // AST whose flags cannot be trusted. Nothing is identified as
+      // uninitialized, so the original error is reported unchanged.
       const { diagnostics } = run(`
 pragma solidity ^0.8.0;
 /*[*/contract Test {
@@ -220,6 +252,76 @@ pragma solidity ^0.8.0;
 
       expect(diagnostics).to.have.length(1);
       expect(diagnostics[0].message).to.equal(MESSAGE);
+    });
+  });
+
+  describe("source the parser throws on", () => {
+    it("falls back to the single whole-contract diagnostic", () => {
+      const { diagnostics } = run(`
+pragma solidity ^0.8.0;
+/*[*/contract Test {
+  uint256 public immutable myVar;
+  string s = "abc;
+}/*]*/
+`);
+
+      expect(diagnostics).to.have.length(1);
+      expect(diagnostics[0].message).to.equal(MESSAGE);
+    });
+  });
+
+  describe("an error reported against a different file", () => {
+    it("is left alone rather than mapped onto this document", () => {
+      const { source, error } = buildError(`
+pragma solidity ^0.8.0;
+/*[*/contract Test {
+  uint256 public immutable myVar;
+
+  constructor() {}
+}/*]*/
+`);
+
+      const document = TextDocument.create(
+        "/project/src/Open.sol",
+        "solidity",
+        1,
+        source
+      );
+
+      const result = new UninitializedImmutable().fromHardhatCompilerError(
+        document,
+        {
+          ...error,
+          sourceLocation: { ...error.sourceLocation!, file: "src/Other.sol" },
+        }
+      );
+
+      expect(Array.isArray(result)).to.equal(false);
+    });
+  });
+
+  describe("a file with multi-byte characters", () => {
+    it("still picks the contract solc pointed at", () => {
+      // solc counts UTF-8 bytes, everything else here counts UTF-16 code
+      // units. The comment is long enough that the 132 byte drift pushes the
+      // unconverted offset past `First` and into `Second`, so this fails if
+      // the conversion is dropped.
+      const { covered } = run(`
+pragma solidity ^0.8.0;
+/// 这个合约包含中文注释，偏移量会因此产生差异，需要足够长才能跨过第一个合约的范围。
+/// 第二行中文注释继续增加字节偏移与字符偏移之间的差值。
+/*[*/contract First {
+  uint256 public immutable missing;
+}/*]*/
+
+contract Second {
+  uint256 public immutable alsoMissing;
+
+  constructor() {}
+}
+`);
+
+      expect(covered).to.deep.equal(["uint256 public immutable missing;"]);
     });
   });
 

--- a/server/test/compilerDiagnostics/diagnostics/UninitializedImmutable.test.ts
+++ b/server/test/compilerDiagnostics/diagnostics/UninitializedImmutable.test.ts
@@ -1,0 +1,46 @@
+import { UninitializedImmutable } from "@compilerDiagnostics/diagnostics/UninitializedImmutable";
+import { expect } from "chai";
+import { TextDocument } from "vscode-languageserver-textdocument";
+
+describe("UninitializedImmutable Compiler Diagnostic", () => {
+  it("should return constructor and uninitialized immutable ranges", () => {
+    const diagnostic = new UninitializedImmutable();
+    const fakeTextDocument = TextDocument.create(
+      "test.sol",
+      "solidity",
+      1,
+      `
+pragma solidity ^0.8.0; 
+contract Test { 
+  uint256 public immutable myVar; 
+  uint256 public immutable myVar2 = 1; 
+  constructor() {} 
+}`
+    );
+
+    const fakeError = {
+      errorCode: "2658",
+      message:
+        "Construction control flow ends without initializing all immutable state variables.",
+      sourceLocation: { start: 0, end: 100 },
+    };
+
+    const result = diagnostic.fromHardhatCompilerError(
+      fakeTextDocument,
+      fakeError as never
+    );
+
+    expect(Array.isArray(result)).to.equal(true);
+    if (Array.isArray(result)) {
+      expect(result.length).to.equal(2);
+
+      // Constructor range
+      const constructorResult = result.find((r) => r.range.start.line === 5);
+      expect(constructorResult).to.not.equal(undefined);
+
+      // Uninitialized immutable range
+      const immutableResult = result.find((r) => r.range.start.line === 3);
+      expect(immutableResult).to.not.equal(undefined);
+    }
+  });
+});

--- a/server/test/compilerDiagnostics/diagnostics/UninitializedImmutable.test.ts
+++ b/server/test/compilerDiagnostics/diagnostics/UninitializedImmutable.test.ts
@@ -1,46 +1,237 @@
 import { UninitializedImmutable } from "@compilerDiagnostics/diagnostics/UninitializedImmutable";
 import { expect } from "chai";
+import { Diagnostic } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
+import { SolcError } from "../../../src/types";
+
+const MESSAGE =
+  "Construction control flow ends without initializing all immutable state variables.";
+
+const START_MARKER = "/*[*/";
+const END_MARKER = "/*]*/";
+
+/**
+ * Builds the error the way solc reports 2658: the source location spans the
+ * whole contract definition, delimited in the fixtures below by the markers.
+ *
+ * The markers are swapped for equal-length whitespace, so every offset, line
+ * and column in the fixture stays exactly where it was written.
+ */
+function buildError(text: string): { error: SolcError; source: string } {
+  const start = text.indexOf(START_MARKER);
+  const end = text.indexOf(END_MARKER);
+
+  if (start === -1 || end === -1) {
+    throw new Error("fixture is missing its contract markers");
+  }
+
+  const source = text
+    .replace(START_MARKER, " ".repeat(START_MARKER.length))
+    .replace(END_MARKER, " ".repeat(END_MARKER.length));
+
+  return {
+    source,
+    error: {
+      component: "general",
+      errorCode: "2658",
+      formattedMessage: MESSAGE,
+      message: MESSAGE,
+      severity: "error",
+      sourceLocation: { file: "test.sol", start, end: end + END_MARKER.length },
+      type: "DeclarationError",
+    } as SolcError,
+  };
+}
+
+function run(text: string): { covered: string[]; diagnostics: Diagnostic[] } {
+  const { source, error } = buildError(text);
+
+  const document = TextDocument.create("test.sol", "solidity", 1, source);
+  const result = new UninitializedImmutable().fromHardhatCompilerError(
+    document,
+    error
+  );
+
+  const diagnostics = Array.isArray(result) ? result : [result];
+
+  // Each diagnostic is labelled by the line its range starts on. That keeps the
+  // assertions readable, independent of the fixture's exact line numbering, and
+  // - deliberately - independent of where the range *ends*, so that only the
+  // "range boundaries" test below fails when the end column is off.
+  const lines = source.split("\n");
+  const covered = diagnostics.map((d) => lines[d.range.start.line].trim());
+
+  return { covered, diagnostics };
+}
 
 describe("UninitializedImmutable Compiler Diagnostic", () => {
-  it("should return constructor and uninitialized immutable ranges", () => {
-    const diagnostic = new UninitializedImmutable();
-    const fakeTextDocument = TextDocument.create(
-      "test.sol",
-      "solidity",
-      1,
-      `
-pragma solidity ^0.8.0; 
-contract Test { 
-  uint256 public immutable myVar; 
-  uint256 public immutable myVar2 = 1; 
-  constructor() {} 
-}`
-    );
+  describe("a single uninitialized immutable", () => {
+    it("underlines the variable and the constructor", () => {
+      const { covered } = run(`
+pragma solidity ^0.8.0;
+/*[*/contract Test {
+  uint256 public immutable myVar;
+  uint256 public immutable myVar2 = 1;
 
-    const fakeError = {
-      errorCode: "2658",
-      message:
-        "Construction control flow ends without initializing all immutable state variables.",
-      sourceLocation: { start: 0, end: 100 },
-    };
+  constructor() {}
+}/*]*/
+`);
 
-    const result = diagnostic.fromHardhatCompilerError(
-      fakeTextDocument,
-      fakeError as never
-    );
+      expect(covered).to.have.members([
+        "uint256 public immutable myVar;",
+        "constructor() {}",
+      ]);
+    });
+  });
 
-    expect(Array.isArray(result)).to.equal(true);
-    if (Array.isArray(result)) {
-      expect(result.length).to.equal(2);
+  describe("an immutable that IS assigned in the constructor", () => {
+    it("underlines only the one solc is complaining about", () => {
+      const { covered } = run(`
+pragma solidity ^0.8.0;
+/*[*/contract Test {
+  uint256 public immutable a;
+  uint256 public immutable b;
+  uint256 public immutable c;
 
-      // Constructor range
-      const constructorResult = result.find((r) => r.range.start.line === 5);
-      expect(constructorResult).to.not.equal(undefined);
+  constructor(uint256 _a) {
+    a = _a;
+    b = _a * 2;
+  }
+}/*]*/
+`);
 
-      // Uninitialized immutable range
-      const immutableResult = result.find((r) => r.range.start.line === 3);
-      expect(immutableResult).to.not.equal(undefined);
-    }
+      // `a` and `b` are initialized in the constructor body, so `c` is the only
+      // uninitialized one. Telling them apart means looking at what the
+      // constructor assigns, not just at whether the declaration has an inline
+      // initializer.
+      expect(covered).to.include("uint256 public immutable c;");
+      expect(covered).to.not.include("uint256 public immutable a;");
+      expect(covered).to.not.include("uint256 public immutable b;");
+    });
+  });
+
+  describe("several contracts in one file", () => {
+    const fixture = `
+pragma solidity ^0.8.0;
+/*[*/contract Bad {
+  uint256 public immutable broken;
+
+  constructor() {}
+}/*]*/
+
+contract Good {
+  uint256 public immutable ok;
+
+  constructor(uint256 _ok) {
+    ok = _ok;
+  }
+}
+`;
+
+    it("ignores contracts the error is not about", () => {
+      const { covered } = run(fixture);
+
+      // `Good` compiles fine - it just has no *inline* initializer.
+      expect(covered).to.include("uint256 public immutable broken;");
+      expect(covered).to.not.include("uint256 public immutable ok;");
+    });
+
+    it("underlines the constructor of the offending contract", () => {
+      const { covered } = run(fixture);
+
+      // Only one constructor is kept for the whole file, so the last one wins
+      // unless the error's sourceLocation is used to narrow the search.
+      expect(covered).to.include("constructor() {}");
+      expect(covered).to.not.include("constructor(uint256 _ok) {");
+    });
+  });
+
+  describe("no constructor at all", () => {
+    it("underlines just the variable", () => {
+      const { covered } = run(`
+pragma solidity ^0.8.0;
+/*[*/contract Test {
+  uint256 public immutable myVar;
+}/*]*/
+`);
+
+      expect(covered).to.deep.equal(["uint256 public immutable myVar;"]);
+    });
+  });
+
+  describe("non-immutable state variables", () => {
+    it("are left alone", () => {
+      const { covered } = run(`
+pragma solidity ^0.8.0;
+/*[*/contract Test {
+  uint256 public plain;
+  uint256 public constant CONST = 1;
+  uint256 public immutable myVar;
+
+  constructor() {}
+}/*]*/
+`);
+
+      expect(covered).to.have.members([
+        "uint256 public immutable myVar;",
+        "constructor() {}",
+      ]);
+    });
+  });
+
+  describe("range boundaries", () => {
+    it("includes the last character of the underlined text", () => {
+      const { diagnostics } = run(`
+pragma solidity ^0.8.0;
+/*[*/contract Test {
+  uint256 public immutable myVar;
+
+  constructor() {}
+}/*]*/
+`);
+
+      const constructorDiagnostic = diagnostics.find(
+        (d) => d.range.start.line === 5
+      );
+
+      expect(constructorDiagnostic).to.not.equal(undefined);
+
+      // `  constructor() {}` - the closing brace sits at column 17, so an
+      // exclusive LSP end has to be 18. @solidity-parser's `loc.end.column` is
+      // 0-based and inclusive of the last character, so it needs a +1 when
+      // converted into a Range.
+      expect(constructorDiagnostic?.range.end.character).to.equal(18);
+    });
+  });
+
+  describe("unparseable source", () => {
+    it("falls back to the single whole-contract diagnostic", () => {
+      // An unterminated string literal is one of the few things that still
+      // throws with `tolerant: true`, so it exercises the catch branch.
+      const { diagnostics } = run(`
+pragma solidity ^0.8.0;
+/*[*/contract Test {
+  string public name = "unterminated;
+  uint256 public immutable myVar;
+
+  constructor() {}
+}/*]*/
+`);
+
+      expect(diagnostics).to.have.length(1);
+      expect(diagnostics[0].message).to.equal(MESSAGE);
+    });
+  });
+
+  // Skipped: `DiagnosticConverter.convertErrors` hands over the document that
+  // changed, but errors can belong to imported files, so the handler parses the
+  // wrong text and files the resulting ranges under the other file's path. This
+  // predates the PR - `passThroughConversion` mis-resolves offsets the same way
+  // - and fixing it means changing the converter rather than this diagnostic.
+  // See local/proj/02_immutable_2658 case E for a live reproduction.
+  describe.skip("an error reported against an imported file", () => {
+    it("computes ranges from the file the error belongs to", () => {
+      // Intentionally empty.
+    });
   });
 });

--- a/test/protocol/projects/foundry/src/diagnostics/UninitializedImmutable.sol
+++ b/test/protocol/projects/foundry/src/diagnostics/UninitializedImmutable.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: SEE LICENSE IN LICENSE
+pragma solidity ^0.8.3;
+
+// solc error 2658. Note it was removed in solc 0.8.21 - this project pins
+// 0.8.8 in foundry.toml, so the error is still emitted here.
+contract Bad {
+  uint256 public immutable broken;
+  uint256 public immutable assignedInConstructor;
+
+  constructor(uint256 _a) {
+    assignedInConstructor = _a;
+  }
+}
+
+// Compiles fine: `ok` has no inline initializer but the constructor assigns it.
+contract Good {
+  uint256 public immutable ok;
+
+  constructor(uint256 _ok) {
+    ok = _ok;
+  }
+}

--- a/test/protocol/test/textDocument/publishDiagnostics/foundry/publishDiagnostics.test.ts
+++ b/test/protocol/test/textDocument/publishDiagnostics/foundry/publishDiagnostics.test.ts
@@ -1,8 +1,9 @@
+import { expect } from 'chai'
 import { DiagnosticSeverity } from 'vscode-languageserver-protocol'
 import { TestLanguageClient } from '../../../../src/TestLanguageClient'
 import { getInitializedClient } from '../../../client'
 import { getProjectPath } from '../../../helpers'
-import { shouldSkipFoundryTests } from '../../../../src/helpers'
+import { shouldSkipFoundryTests, toUri } from '../../../../src/helpers'
 
 let client!: TestLanguageClient
 
@@ -41,6 +42,56 @@ describe('[foundry] publishDiagnostics', () => {
           },
         },
       })
+    })
+  })
+
+  describe('uninitialized immutable', function () {
+    const documentPath = getProjectPath('foundry/src/diagnostics/UninitializedImmutable.sol')
+    const message = 'Construction control flow ends without initializing all immutable state variables.'
+
+    it('should point at the uninitialized variable', async () => {
+      await client.openDocument(documentPath)
+
+      await client.getDiagnostic(documentPath, {
+        source: 'solidity',
+        severity: DiagnosticSeverity.Error,
+        message,
+        range: {
+          start: { line: 6, character: 2 },
+          end: { line: 6, character: 33 },
+        },
+      })
+    })
+
+    it('should point at the constructor of the offending contract', async () => {
+      await client.openDocument(documentPath)
+
+      await client.getDiagnostic(documentPath, {
+        source: 'solidity',
+        severity: DiagnosticSeverity.Error,
+        message,
+        range: {
+          start: { line: 9, character: 2 },
+          end: { line: 11, character: 3 },
+        },
+      })
+    })
+
+    it('should not touch initialized immutables or unrelated contracts', async () => {
+      await client.openDocument(documentPath)
+
+      // Wait for the diagnostics to land before inspecting the whole set.
+      await client.getDiagnostic(documentPath, { message })
+
+      const diagnostics = client.documents[toUri(documentPath)].diagnostics ?? []
+      const startLines = diagnostics.filter((d) => d.message === message).map((d) => d.range.start.line)
+
+      // line 7  -> `assignedInConstructor`, assigned in Bad's constructor
+      // line 16 -> `Good.ok`, a contract with no error at all
+      // line 19 -> Good's constructor
+      expect(startLines).to.not.include(7)
+      expect(startLines).to.not.include(16)
+      expect(startLines).to.not.include(19)
     })
   })
 })

--- a/test/protocol/test/textDocument/publishDiagnostics/foundry/publishDiagnostics.test.ts
+++ b/test/protocol/test/textDocument/publishDiagnostics/foundry/publishDiagnostics.test.ts
@@ -56,9 +56,11 @@ describe('[foundry] publishDiagnostics', () => {
         source: 'solidity',
         severity: DiagnosticSeverity.Error,
         message,
+        // The whole declaration, terminating semicolon included - that is where
+        // the declaration node ends.
         range: {
           start: { line: 6, character: 2 },
-          end: { line: 6, character: 33 },
+          end: { line: 6, character: 34 },
         },
       })
     })
@@ -86,12 +88,16 @@ describe('[foundry] publishDiagnostics', () => {
       const diagnostics = client.documents[toUri(documentPath)].diagnostics ?? []
       const startLines = diagnostics.filter((d) => d.message === message).map((d) => d.range.start.line)
 
-      // line 7  -> `assignedInConstructor`, assigned in Bad's constructor
-      // line 16 -> `Good.ok`, a contract with no error at all
-      // line 19 -> Good's constructor
+      // Lines are 0-based here.
+      // 7  -> `assignedInConstructor`, assigned in Bad's constructor
+      // 16 -> `Good.ok`, a contract with no error at all
+      // 18 -> Good's constructor
       expect(startLines).to.not.include(7)
       expect(startLines).to.not.include(16)
-      expect(startLines).to.not.include(19)
+      expect(startLines).to.not.include(18)
+
+      // And nothing beyond the two that belong to Bad.
+      expect(startLines).to.deep.equal([6, 9])
     })
   })
 })


### PR DESCRIPTION


<!--
Thank you for using **Solidity for Visual Studio Code by Nomic Foundation** and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

Fixes #542

When an immutable state variable is declared but not initialized in the constructor, the Solidity compiler emits error code 2658 ("Construction control flow ends without initializing all immutable state variables"). Previously, this error resulted in a single diagnostic that highlighted the entire contract block with a red squiggly line, making it hard to pinpoint the uninitialized variable.

This PR updates the diagnostic mapping to parse the AST for error 2658 and explicitly highlight only the uninitialized immutable variable(s) and the constructor.