### PR TITLE
fix error with pre-release solc

### DIFF
--- a/client/src/popups/showSoliditySurveyPopup.ts
+++ b/client/src/popups/showSoliditySurveyPopup.ts
@@ -1,13 +1,13 @@
 import { window, ExtensionContext, commands, Uri } from "vscode";
 
-const SURVEY_URL = "https://hardhat.org/solidity-survey-2024";
-const SURVEY_COMPLETED_KEY = "soliditySurvey2024Completed";
-const SURVEY_LAST_SEEN_KEY = "soliditySurvey2024LastSeen";
+const SURVEY_URL = "https://solidity.survey-research.net/solidity-survey";
+const SURVEY_COMPLETED_KEY = "soliditySurvey2026Completed";
+const SURVEY_LAST_SEEN_KEY = "soliditySurvey2026LastSeen";
+
 // Show the survey popup if the user hasn't seen it in the last 7 days
 const SURVEY_COOLDOWN_PERIOD = 7 * 24 * 60 * 60 * 1000;
-const SURVEY_END_DATE = Date.parse("2025-01-31 23:59:00 +0000");
-const SURVEY_TEXT =
-  "Please take a few minutes to complete the 2024 Solidity Survey";
+const SURVEY_END_DATE = Date.parse("2026-03-31 23:59:00 +0000");
+const SURVEY_TEXT = "Please take a few minutes to complete the Solidity Survey";
 const SURVEY_CTA = "Complete";
 
 export async function showSoliditySurveyPopup({

--- a/server/src/services/validation/OutputConverter.ts
+++ b/server/src/services/validation/OutputConverter.ts
@@ -8,12 +8,16 @@ export class OutputConverter {
     solcOutput: any,
     projectBasePath: string
   ): ValidationResult {
-    if (solcOutput.errors?.length > 0) {
+
+    // pre release solc emits a warning without a sourceLocation
+    const errors = (solcOutput.errors || []).filter((e: any) => String(e.errorCode) != '3805')
+
+    if (errors.length > 0) {
       const validationFailMessage: ValidationFail = {
         status: "VALIDATION_FAIL",
         projectBasePath,
         version: compilationDetails.solcVersion,
-        errors: solcOutput.errors.map((solcError: any) => ({
+        errors: errors.map((solcError: any) => ({
           ...solcError,
           sourceLocation: {
             ...solcError.sourceLocation,


### PR DESCRIPTION
Pre release solc (can happen if version is not specified for example in foundry.toml) breaks the client because it emits:

```json
    {
      component: 'general',
      errorCode: '3805',
      formattedMessage: 'Warning: This is a pre-release compiler version, please do not use it in production.\n' +
        '\n',
      message: 'This is a pre-release compiler version, please do not use it in production.',
      severity: 'warning',
      type: 'Warning'
    }
```

Causing `Cannot read properties of undefined (reading 'file')` in `OutputConverter.ts`, because it has no `sourceLocation`.