### PR TITLE
fix: add fallback mechanisms for hover and find references

### DIFF
--- a/server/src/services/hover/onHover.ts
+++ b/server/src/services/hover/onHover.ts
@@ -5,7 +5,8 @@ import {
 } from "@analyzer/utils/typeGuards";
 import { getParserPositionFromVSCodePosition } from "@common/utils";
 import { HoverParams, Hover } from "vscode-languageserver/node";
-import { ISolFileEntry, IdentifierNode, MemberAccessNode, Node } from "@common/types";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { ISolFileEntry, IdentifierNode, MemberAccessNode, Node, Position } from "@common/types";
 import { onCommand } from "@utils/onCommand";
 import { ServerState } from "../../types";
 import { astToText } from "./utils/astToText";
@@ -18,8 +19,8 @@ export function onHover(serverState: ServerState) {
         serverState,
         "onHover",
         params.textDocument.uri,
-        (documentAnalyzer) =>
-          findHoverForNodeAtPosition(documentAnalyzer, params)
+        (documentAnalyzer, document) =>
+          findHoverForNodeAtPosition(documentAnalyzer, document, params)
       );
     } catch (err) {
       serverState.logger.error(err);
@@ -31,23 +32,156 @@ export function onHover(serverState: ServerState) {
 
 function findHoverForNodeAtPosition(
   documentAnalyzer: ISolFileEntry,
+  document: TextDocument,
   params: HoverParams
 ) {
-  const node = documentAnalyzer.searcher.findNodeByPosition(
+  const position = getParserPositionFromVSCodePosition(params.position);
+
+  // 完全复用 goToDefinition 的方式查找定义节点
+  const definitionNode = documentAnalyzer.searcher.findDefinitionNodeByPosition(
     documentAnalyzer.uri,
-    getParserPositionFromVSCodePosition(params.position),
+    position,
     documentAnalyzer.analyzerTree.tree
   );
 
-  if (node === undefined) {
-    return null;
+  if (definitionNode !== undefined) {
+    const hoverText = astToText(definitionNode.astNode);
+    if (hoverText !== null) {
+      return textToHover(hoverText);
+    }
   }
 
-  if (!isIdentifierNode(node) && !isMemberAccessNode(node) && !isUserDefinedTypeNameNode(node)) {
-    return null;
+  // fallback: 原始 typeNodes 逻辑 (仅对声明位置有效)
+  const node = documentAnalyzer.searcher.findNodeByPosition(
+    documentAnalyzer.uri,
+    position,
+    documentAnalyzer.analyzerTree.tree
+  );
+
+  if (
+    node !== undefined &&
+    (isIdentifierNode(node) || isMemberAccessNode(node) || isUserDefinedTypeNameNode(node))
+  ) {
+    const typeNode = node.typeNodes[0];
+    if (typeNode !== undefined) {
+      const hoverText = astToText(typeNode.astNode);
+      if (hoverText !== null) {
+        return textToHover(hoverText);
+      }
+    }
   }
 
-  return convertNodeToHover(node);
+  // fallback: orphanNodes 搜索
+  const orphanNode = findNodeInOrphans(documentAnalyzer.orphanNodes, position);
+  if (orphanNode !== undefined) {
+    const defNode = orphanNode.getDefinitionNode() ?? orphanNode;
+    const hoverText = astToText(defNode.astNode);
+    return textToHover(hoverText);
+  }
+
+  // fallback: 从源文本提取标识符, 按名字搜索定义节点
+  const word = extractIdentifierAtPosition(document, params.position);
+  if (word !== null) {
+    const foundNode = searchDefinitionByName(
+      word,
+      documentAnalyzer.analyzerTree.tree,
+      documentAnalyzer.orphanNodes
+    );
+    if (foundNode) {
+      const hoverText = astToText(foundNode.astNode);
+      if (hoverText !== null) {
+        return textToHover(hoverText);
+      }
+    }
+  }
+
+  return null;
+}
+
+// 从 orphanNodes 中按位置查找节点
+function findNodeInOrphans(
+  orphanNodes: Node[],
+  position: Position
+): Node | undefined {
+  for (const node of orphanNodes) {
+    if (
+      node.nameLoc &&
+      node.nameLoc.start.line === position.line &&
+      node.nameLoc.end.line === position.line &&
+      node.nameLoc.start.column <= position.column &&
+      node.nameLoc.end.column >= position.column
+    ) {
+      return node;
+    }
+  }
+  return undefined;
+}
+
+// 从整个分析树按名字搜索定义节点
+function searchDefinitionByName(
+  name: string,
+  rootNode: Node,
+  orphanNodes: Node[]
+): Node | undefined {
+  const visited = new Set<Node>();
+  const candidates: Node[] = [];
+
+  function walk(node: Node): void {
+    if (visited.has(node)) return;
+    visited.add(node);
+
+    if (node.getName() === name) {
+      const defNode = node.getDefinitionNode() ?? node;
+      candidates.push(defNode);
+    }
+
+    for (const child of node.children) {
+      walk(child);
+    }
+  }
+
+  walk(rootNode);
+
+  // 也搜索 orphanNodes
+  for (const orphan of orphanNodes) {
+    if (orphan.getName() === name) {
+      candidates.push(orphan.getDefinitionNode() ?? orphan);
+    }
+  }
+
+  if (candidates.length === 0) return undefined;
+
+  // 多个引用可能指向同一个定义, 直接返回第一个
+  return candidates[0];
+}
+
+// 从源文本中提取光标位置的标识符
+function extractIdentifierAtPosition(
+  document: TextDocument,
+  position: { line: number; character: number }
+): string | null {
+  const lineText = document.getText({
+    start: { line: position.line, character: 0 },
+    end: { line: position.line, character: 65535 },
+  });
+
+  const char = Math.min(position.character, lineText.length);
+
+  // 向左扫描找到标识符起始位置
+  let start = char;
+  while (start > 0 && /[a-zA-Z0-9_]/.test(lineText[start - 1])) {
+    start--;
+  }
+
+  // 向右扫描找到标识符结束位置
+  let end = char;
+  while (end < lineText.length && /[a-zA-Z0-9_]/.test(lineText[end])) {
+    end++;
+  }
+
+  if (start === end) return null;
+
+  return lineText.substring(start, end);
 }
 
 export function convertNodeToHover(

--- a/server/src/services/references/onReferences.ts
+++ b/server/src/services/references/onReferences.ts
@@ -40,7 +40,19 @@ function findReferences(
     documentAnalyzer.analyzerTree.tree
   );
 
-  const references: Node[] = findReferencesFor(definitionNode);
+  // 先用原逻辑从 children 收集
+  let references: Node[] = findReferencesFor(definitionNode);
+
+  // fallback: children 不完整时, 从整个 analyzerTree 按名字搜索
+  if (references.length === 0 && definitionNode !== undefined) {
+    const nodeName = definitionNode.getName();
+    if (nodeName !== undefined) {
+      references = searchReferencesByName(
+        nodeName,
+        documentAnalyzer.analyzerTree.tree
+      );
+    }
+  }
 
   return references
     .filter(
@@ -51,4 +63,29 @@ function findReferences(
       uri: toUri(refNode.uri),
       range: getRange(refNode.nameLoc),
     }));
+}
+
+// 从整个分析树按名字递归搜索所有同名节点
+function searchReferencesByName(
+  name: string,
+  rootNode: Node
+): Node[] {
+  const results: Node[] = [];
+  const visited = new Set<Node>();
+
+  function walk(node: Node): void {
+    if (visited.has(node)) return;
+    visited.add(node);
+
+    if (node.getName() === name || node.getAliasName() === name) {
+      results.push(node);
+    }
+
+    for (const child of node.children) {
+      walk(child);
+    }
+  }
+
+  walk(rootNode);
+  return results;
 }


### PR DESCRIPTION
## Summary

The upstream `usedef` module has incomplete `typeNodes` connections, causing **hover** and **find references** to return `null` on many symbols, while **goToDefinition** works correctly via parent chains.

This PR adds multi-layer fallback mechanisms to both features.

### Problem

In the current implementation:
- `goToDefinition` works reliably because it follows the `parent` chain in the analyzer tree
- `hover` depends on `typeNodes[0]` which is frequently `undefined` due to incomplete `usedef` resolution
- `find references` depends on `definitionNode.children` which is often incomplete for the same reason

### Solution

#### Hover (`onHover.ts`) - 4-layer fallback

1. **`findDefinitionNodeByPosition`** (reuse goToDefinition's parent chain lookup) - covers most cases
2. **`typeNodes[0]`** (original logic) - still works for declaration sites
3. **orphanNodes search** - matches by position in nodes not attached to the main tree
4. **Text-based name search** - extracts identifier from source text at cursor position, then searches the entire analyzerTree by name

#### Find References (`onReferences.ts`) - 2-layer fallback

1. **`findReferencesFor`** (original children-based logic)
2. **`searchReferencesByName`** - recursive tree walk matching `getName()` / `getAliasName()` when children result is empty

### Testing

Tested using the LSP server directly (via Claude Code's LSP integration) with two Solidity test files:

**Counter.sol** (simple contract):
| Test | Position | Result |
|------|----------|--------|
| `uint256 public number` declaration | line 5 | `uint256 public number` |
| `function setNumber` declaration | line 7 | `function setNumber(uint256 newNumber) public` |
| `function increment` declaration | line 11 | `function increment() public` |
| `number` reference in assignment | line 8 | `uint256 public number` |

**TestLSP.sol** (complex contract with struct/enum/event/error/mapping/modifier):
| Test | Position | Result |
|------|----------|--------|
| `uint256 public count` declaration | line 5 | `uint256 public count` |
| `struct UserInfo` declaration | line 8 | `struct UserInfo { string name; uint256 balance; }` |
| `enum Status` declaration | line 13 | `enum Status { Active, Paused, Stopped }` |
| `event CountChanged` declaration | line 15 | `event CountChanged(uint256 newCount)` |
| `function increment` declaration | line 37 | `function increment() public` |
| `count` reference in `count++` | line 38 | `uint256 public count` |

### Limitations

- The text-based name search (fallback layer 4) matches by name only without scope awareness. In practice this rarely triggers because layer 1 (`findDefinitionNodeByPosition`) resolves most cases.
- This is a pragmatic patch for the v1 engine. The v2 rewrite may address the root cause.

## Test plan

- [x] Hover on variable declarations returns type + name
- [x] Hover on function declarations returns full signature
- [x] Hover on struct/enum/event declarations returns definition
- [x] Hover on variable references resolves to the declaration
- [x] goToDefinition still works (unaffected)
- [ ] Find references works with fallback (tested manually, no automated test)