### PR TITLE
fix(server): prevent crash when solc error has no source location

### DIFF
--- a/.changeset/fix-validation-forge-crash.md
+++ b/.changeset/fix-validation-forge-crash.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/solidity-language-server": patch
+---
+
+Prevent language server crash during validation when compiler warning or error lacks sourceLocation information.

--- a/server/src/services/validation/OutputConverter.ts
+++ b/server/src/services/validation/OutputConverter.ts
@@ -13,13 +13,21 @@ export class OutputConverter {
         status: "VALIDATION_FAIL",
         projectBasePath,
         version: compilationDetails.solcVersion,
-        errors: solcOutput.errors.map((solcError: any) => ({
-          ...solcError,
-          sourceLocation: {
-            ...solcError.sourceLocation,
-            file: normalizeSourceName(solcError.sourceLocation.file),
-          },
-        })),
+        errors: solcOutput.errors.map((solcError: any) => {
+          if (!solcError.sourceLocation) {
+            return solcError;
+          }
+
+          return {
+            ...solcError,
+            sourceLocation: {
+              ...solcError.sourceLocation,
+              file: solcError.sourceLocation.file
+                ? normalizeSourceName(solcError.sourceLocation.file)
+                : undefined,
+            },
+          };
+        }),
       };
 
       return validationFailMessage;


### PR DESCRIPTION
This PR resolves #711, which causes the Solidity language server to crash with a `TypeError: Cannot read properties of undefined (reading 'file')` on newer versions of Solidity (e.g. `0.8.25`+) or projects using Foundry.

### Root Cause
In newer Solidity versions or project-wide compilation environments (like Foundry warnings/errors that don't belong to a specific file), compiler errors/warnings might not have a `sourceLocation` property. 
During the validation step, `OutputConverter.ts` maps the errors and attempts to read `solcError.sourceLocation.file` to normalize the source name, assuming it always exists. If `sourceLocation` is undefined, this throws a TypeError and crashes the language server.

### Solution
This PR checks if `solcError.sourceLocation` is defined before attempting to read its properties. It also safely guards `sourceLocation.file` in case it is undefined.

A changeset has been included to patch `@nomicfoundation/solidity-language-server` and its dependents.