### PR TITLE
fix: keep solc version list usable when the version fetch fails

### DIFF
--- a/.changeset/remember-fetched-solc-versions.md
+++ b/.changeset/remember-fetched-solc-versions.md
@@ -1,0 +1,11 @@
+---
+"@nomicfoundation/solidity-language-server": patch
+"hardhat-solidity": patch
+"@nomicfoundation/coc-solidity": patch
+---
+
+Remember solc versions across restarts so a failed version fetch no longer blocks validation.
+
+The list of available solc versions was rebuilt on every start from a hardcoded list plus a network fetch. When the fetch failed - offline, VPN, proxy, or just a slow response - the server silently fell back to the hardcoded list, which had not been updated since 0.8.16. Any project requiring something newer then failed with "No available solc version satisfying ...".
+
+The bundled list is now up to date (through 0.8.36), versions fetched at least once are persisted and reused, hardhat's own compiler list is used as an additional offline source, and the fetch no longer blocks initialization. The error message when no version matches now reports the deduplicated requirement and which versions were actually available.

--- a/client/src/setup/setupLanguageServerHooks.ts
+++ b/client/src/setup/setupLanguageServerHooks.ts
@@ -67,6 +67,7 @@ const startLanguageServer = async (
       telemetryEnabled: extensionState.telemetryEnabled,
       machineId: extensionState.machineId,
       extensionConfig: workspace.getConfiguration("solidity"),
+      globalStoragePath: extensionState.context.globalStorageUri.fsPath,
     },
   };
 

--- a/coc/src/index.ts
+++ b/coc/src/index.ts
@@ -40,6 +40,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
         telemetryEnabled,
         machineId: await machineId(),
         extensionConfig: getExtensionConfig(),
+        globalStoragePath: context.storagePath,
       },
     }
   );

--- a/server/src/frameworks/shared/buildBasicCompilation.ts
+++ b/server/src/frameworks/shared/buildBasicCompilation.ts
@@ -35,13 +35,18 @@ export async function buildBasicCompilation(
   let solcVersion = explicitSolcVersion;
 
   if (solcVersion === undefined) {
+    // every pragma in the dependency tree has to be satisfied at once
+    const combinedRange = pragmas.join(" ");
+
     const resolvedSolcVersion = semver.maxSatisfying(
       project.serverState.solcVersions,
-      pragmas.join(" ")
+      combinedRange
     );
 
     if (resolvedSolcVersion === null) {
-      throw new Error(`No available solc version satisfying ${pragmas}`);
+      throw new Error(
+        buildNoVersionError(pragmas, project.serverState.solcVersions)
+      );
     }
 
     solcVersion = resolvedSolcVersion;
@@ -83,4 +88,36 @@ export async function buildBasicCompilation(
     },
     solcVersion,
   };
+}
+
+/**
+ * The pragmas are ANDed together, so the useful thing to report is the distinct
+ * set and what was actually available to satisfy it - not a comma-joined dump
+ * of every pragma in the dependency tree, most of which are duplicates.
+ */
+export function buildNoVersionError(
+  pragmas: string[],
+  availableVersions: string[]
+) {
+  const distinctPragmas = _.uniq(pragmas);
+
+  const requirement = distinctPragmas.join(" ");
+  const pragmaCount =
+    distinctPragmas.length === 1
+      ? "1 pragma"
+      : `${distinctPragmas.length} distinct pragmas`;
+
+  // Only the bounds - the full list is ~100 entries and tells the reader
+  // nothing the range doesn't. Computed rather than taken from the ends of the
+  // array so the message stays correct if the list is ever unsorted.
+  const sorted = [...availableVersions].sort(semver.compare);
+
+  const available =
+    sorted.length === 0
+      ? "none"
+      : sorted.length === 1
+        ? sorted[0]
+        : `${sorted[0]} - ${sorted[sorted.length - 1]}`;
+
+  return `No available solc version satisfying ${requirement} (${pragmaCount} across the dependency tree). Available versions: ${available}`;
 }

--- a/server/src/services/initialization/onInitialize.ts
+++ b/server/src/services/initialization/onInitialize.ts
@@ -151,6 +151,9 @@ function updateServerStateFromParams(
 
   serverState.extensionConfig =
     params.initializationOptions?.extensionConfig ?? {};
+
+  serverState.globalStoragePath =
+    params.initializationOptions?.globalStoragePath;
 }
 
 function logInitializationInfo(

--- a/server/src/services/initialization/solcVersionsCache.ts
+++ b/server/src/services/initialization/solcVersionsCache.ts
@@ -1,0 +1,198 @@
+import fs from "fs/promises";
+import _ from "lodash";
+import os from "os";
+import path from "path";
+import semver from "semver";
+import { Logger } from "../../utils/Logger";
+
+const CACHE_FILE_NAME = "solc-versions.json";
+
+interface CacheFileContents {
+  versions: string[];
+}
+
+/**
+ * Compute the per-user cache directory for a given package, matching the
+ * layout `env-paths` produces. Reimplemented here so the server doesn't take a
+ * dependency on it, and so we can locate hardhat's cache without reaching into
+ * its internals.
+ */
+function cacheDirFor(packageName: string): string {
+  const home = os.homedir();
+
+  if (process.platform === "win32") {
+    const localAppData =
+      process.env.LOCALAPPDATA ?? path.join(home, "AppData", "Local");
+
+    return path.join(localAppData, packageName, "Cache");
+  }
+
+  if (process.platform === "darwin") {
+    return path.join(home, "Library", "Caches", packageName);
+  }
+
+  return path.join(
+    process.env.XDG_CACHE_HOME ?? path.join(home, ".cache"),
+    packageName
+  );
+}
+
+/**
+ * Where to persist the versions we've seen. Prefers the storage directory the
+ * editor reserved for the extension, falling back to a per-user cache dir for
+ * clients that don't provide one.
+ */
+export function resolveStorageDir(globalStoragePath?: string): string {
+  if (globalStoragePath !== undefined && globalStoragePath.trim() !== "") {
+    return globalStoragePath;
+  }
+
+  return cacheDirFor("hardhat-vscode-nodejs");
+}
+
+export function onlyValidVersions(versions: unknown): string[] {
+  if (!Array.isArray(versions)) {
+    return [];
+  }
+
+  return versions.flatMap((version) => {
+    if (typeof version !== "string") {
+      return [];
+    }
+
+    const normalized = semver.valid(version);
+
+    return normalized === null ? [] : [normalized];
+  });
+}
+
+/**
+ * Versions successfully fetched at some point in the past. solc releases are
+ * append-only - a version is never unpublished - so this list can only ever be
+ * incomplete, never wrong. That's what makes it safe to union without any
+ * invalidation.
+ */
+export async function readRememberedVersions(
+  storageDir: string,
+  logger: Logger
+): Promise<string[]> {
+  const filePath = path.join(storageDir, CACHE_FILE_NAME);
+
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    const contents: CacheFileContents = JSON.parse(raw);
+
+    return onlyValidVersions(contents.versions);
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") {
+      logger.trace(`Could not read remembered solc versions: ${error}`);
+    }
+
+    return [];
+  }
+}
+
+export async function rememberVersions(
+  storageDir: string,
+  versions: string[],
+  logger: Logger
+): Promise<void> {
+  const filePath = path.join(storageDir, CACHE_FILE_NAME);
+
+  const tempPath = `${filePath}.${process.pid}.tmp`;
+
+  try {
+    await fs.mkdir(storageDir, { recursive: true });
+
+    const contents: CacheFileContents = {
+      versions: _.uniq(versions).sort(semver.compare),
+    };
+
+    await fs.writeFile(tempPath, JSON.stringify(contents, null, 2), "utf8");
+    await fs.rename(tempPath, filePath);
+  } catch (error: unknown) {
+    // Persisting is best-effort: a read-only or missing storage dir must not
+    // break validation.
+    logger.trace(`Could not persist solc versions: ${error}`);
+
+    try {
+      await fs.unlink(tempPath);
+    } catch {
+      // Nothing to clean up, or we can't - either way it doesn't matter.
+    }
+  }
+}
+
+const HARDHAT_COMPILER_DIRS = ["compilers-v2", "compilers-v3"];
+
+/**
+ * Anyone who has compiled once already has a compiler list on disk, and it's
+ * usually far fresher than the list bundled with this extension. Free, offline,
+ * and independent of whether our own cache has been written yet.
+ *
+ * Pre-release builds are excluded on purpose: they emit warnings that carry no
+ * `sourceLocation`, and they should never be selected to satisfy a pragma.
+ *
+ * `cacheRoot` exists so tests can point at a fixture instead of the developer's
+ * home directory.
+ */
+export async function readHardhatCompilerVersions(
+  logger: Logger,
+  cacheRoot: string = cacheDirFor("hardhat-nodejs")
+): Promise<string[]> {
+  const perGeneration = await Promise.all(
+    HARDHAT_COMPILER_DIRS.map((dir) =>
+      readCompilersDir(path.join(cacheRoot, dir), logger)
+    )
+  );
+
+  return _.union(...perGeneration);
+}
+
+async function readCompilersDir(
+  compilersDir: string,
+  logger: Logger
+): Promise<string[]> {
+  try {
+    const platformDirs = await fs.readdir(compilersDir);
+
+    const perPlatform = await Promise.all(
+      platformDirs.map((platformDir) =>
+        readCompilerListVersions(path.join(compilersDir, platformDir), logger)
+      )
+    );
+
+    return _.union(...perPlatform);
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") {
+      logger.trace(`Could not read hardhat compiler lists: ${error}`);
+    }
+
+    return [];
+  }
+}
+
+async function readCompilerListVersions(
+  platformDir: string,
+  logger: Logger
+): Promise<string[]> {
+  try {
+    const raw = await fs.readFile(path.join(platformDir, "list.json"), "utf8");
+    const list: { builds?: Array<{ version?: string; prerelease?: unknown }> } =
+      JSON.parse(raw);
+
+    // Truthiness rather than `!== undefined`: the field is absent on releases,
+    // but null or "" would otherwise read as "not a pre-release".
+    const released = (list.builds ?? [])
+      .filter((build) => !build.prerelease)
+      .map((build) => build.version);
+
+    return onlyValidVersions(released);
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") {
+      logger.trace(`Could not read compiler list in ${platformDir}: ${error}`);
+    }
+
+    return [];
+  }
+}

--- a/server/src/services/initialization/updateAvailableSolcVersions.ts
+++ b/server/src/services/initialization/updateAvailableSolcVersions.ts
@@ -1,7 +1,17 @@
 import _ from "lodash";
 import got from "got";
+import semver from "semver";
 import { ServerState } from "../../types";
 import { isTestMode } from "../../utils";
+import {
+  onlyValidVersions,
+  readHardhatCompilerVersions,
+  readRememberedVersions,
+  rememberVersions,
+  resolveStorageDir,
+} from "./solcVersionsCache";
+
+const FETCH_TIMEOUT_MS = 10_000;
 
 export const availableVersions = [
   "0.3.6",
@@ -87,31 +97,161 @@ export const availableVersions = [
   "0.8.14",
   "0.8.15",
   "0.8.16",
+  "0.8.17",
+  "0.8.18",
+  "0.8.19",
+  "0.8.20",
+  "0.8.21",
+  "0.8.22",
+  "0.8.23",
+  "0.8.24",
+  "0.8.25",
+  "0.8.26",
+  "0.8.27",
+  "0.8.28",
+  "0.8.29",
+  "0.8.30",
+  "0.8.31",
+  "0.8.32",
+  "0.8.33",
+  "0.8.34",
+  "0.8.35",
+  "0.8.36",
 ];
 
+/**
+ * Seed the known solc versions from local sources only, then kick off a network
+ * refresh in the background.
+ *
+ * The local sources are cheap file reads, so this stays off the critical path
+ * of `initialize`. Previously the network call was awaited here, which both
+ * delayed startup and - when it failed - silently left the server with the
+ * bundled list, whose newest entry is many releases old. Any project requiring
+ * something newer then failed to validate with "No available solc version
+ * satisfying ...".
+ */
 export async function updateAvailableSolcVersions(state: ServerState) {
   if (isTestMode()) {
     return;
   }
-  state.logger.info("Fetching latest solidity versions");
+
+  await loadKnownSolcVersions(state);
+
+  // Deliberately not awaited: initialization must not block on the network.
+  void refreshSolcVersions(state).catch((error) => {
+    try {
+      state.telemetry.captureException(error);
+    } catch {
+      // The connection or telemetry may already be gone. Nothing left to do.
+    }
+  });
+}
+
+export async function loadKnownSolcVersions(state: ServerState) {
+  const storageDir = resolveStorageDir(state.globalStoragePath);
+
+  const [remembered, fromHardhatCache] = await Promise.all([
+    readRememberedVersions(storageDir, state.logger),
+    readHardhatCompilerVersions(state.logger),
+  ]);
+
+  state.solcVersions = _.union(
+    availableVersions,
+    remembered,
+    fromHardhatCache
+  ).sort(compareVersions);
+
+  state.logger.info(
+    `Known solidity versions: ${describeVersions(state.solcVersions)}`
+  );
+}
+
+export async function refreshSolcVersions(state: ServerState) {
+  state.logger.trace("Fetching latest solidity versions");
 
   const latestVersions = await fetchLatestVersions(state);
 
-  state.solcVersions = _.union(availableVersions, latestVersions);
+  if (latestVersions.length === 0) {
+    state.logger.info(
+      `Could not fetch latest solidity versions, continuing with ${describeVersions(
+        state.solcVersions
+      )}`
+    );
+    return;
+  }
+
+  state.solcVersions = _.union(state.solcVersions, latestVersions).sort(
+    compareVersions
+  );
+
+  // Remember everything we've ever seen, so a later failed fetch still leaves
+  // the server with an up-to-date list.
+  await rememberVersions(
+    resolveStorageDir(state.globalStoragePath),
+    state.solcVersions,
+    state.logger
+  );
+
+  state.logger.trace(
+    `Updated solidity versions: ${describeVersions(state.solcVersions)}`
+  );
+}
+
+function describeVersions(versions: string[]) {
+  if (versions.length === 0) {
+    return "none";
+  }
+
+  return `${versions.length} versions, ${versions[0]} - ${
+    versions[versions.length - 1]
+  }`;
+}
+
+function compareVersions(a: string, b: string) {
+  return semver.compare(a, b);
 }
 
 interface VersionsResponse {
-  builds: Array<{ version: string }>;
+  // Every build, including pre-releases. A pre-release build carries the
+  // version it is a pre-release *of*, so mapping over this yields versions that
+  // have not been released yet.
+  builds?: Array<{ version?: string; prerelease?: unknown }>;
+  // Released versions only, keyed by version.
+  releases?: Record<string, string>;
 }
+
+/**
+ * Released versions only.
+ *
+ * `builds` cannot be used directly: an entry for 0.8.31-pre.1 has
+ * `version: "0.8.31"`, so mapping over it offers a version that solc has not
+ * released. Selecting it makes hardhat resolve the pre-release binary, which
+ * emits diagnostics with no `sourceLocation`. Worse, this list is persisted, so
+ * such a version would previously vanish on restart but would now be
+ * remembered forever.
+ */
+export function releasedVersionsFrom(data: VersionsResponse): string[] {
+  if (data?.releases !== undefined && !Array.isArray(data.releases)) {
+    return onlyValidVersions(Object.keys(data.releases));
+  }
+
+  // Older/alternative payloads without a `releases` map.
+  const builds = Array.isArray(data?.builds) ? data.builds : [];
+
+  return onlyValidVersions(
+    builds.filter((build) => !build?.prerelease).map((build) => build?.version)
+  );
+}
+
 async function fetchLatestVersions(state: ServerState) {
   try {
     const data: VersionsResponse = await got
       .get("https://binaries.soliditylang.org/wasm/list.json", {
-        timeout: 2000,
+        timeout: FETCH_TIMEOUT_MS,
       })
       .json();
 
-    return _.map(data.builds, "version");
+    return releasedVersionsFrom(data);
   } catch (error) {
     state.telemetry.captureException(error);
     return [];

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -26,6 +26,9 @@ export interface ServerState {
   telemetry: Telemetry;
   logger: Logger;
   solcVersions: string[];
+  // Editor-provided directory for extension data. Used to remember solc
+  // versions across restarts. Undefined for clients that don't provide one.
+  globalStoragePath?: string;
 
   // Associate validation request ids to files to solve parallel validation jobs on the same file
   validationCount: number;

--- a/server/test/frameworks/shared/buildNoVersionError.ts
+++ b/server/test/frameworks/shared/buildNoVersionError.ts
@@ -1,0 +1,71 @@
+import { assert } from "chai";
+import { buildNoVersionError } from "../../../src/frameworks/shared/buildBasicCompilation";
+
+// The pragmas of a real dependency tree are overwhelmingly duplicates - see
+// #711, where the message rendered 64 entries of which only 12 were distinct,
+// comma-joined even though the code ANDs them with spaces. That output was
+// unreadable and, worse, not a valid semver range, so it couldn't be pasted
+// anywhere to check.
+describe("no available solc version error", () => {
+  it("should deduplicate the pragmas", () => {
+    const message = buildNoVersionError(
+      ["^0.8.28", "^0.8.28", ">=0.7.5", "^0.8.28"],
+      ["0.8.16"]
+    );
+
+    assert.include(message, "^0.8.28 >=0.7.5");
+    assert.include(message, "2 distinct pragmas");
+    assert.notInclude(message, "^0.8.28 ^0.8.28");
+  });
+
+  it("should join with spaces so the requirement is a valid semver range", () => {
+    const message = buildNoVersionError(["^0.8.28", ">=0.7.5"], ["0.8.16"]);
+
+    assert.notInclude(message, "^0.8.28,>=0.7.5");
+  });
+
+  it("should report the available range, which is the actual cause", () => {
+    const message = buildNoVersionError(["^0.8.28"], ["0.3.6", "0.8.16"]);
+
+    assert.include(message, "Available versions: 0.3.6 - 0.8.16");
+  });
+
+  it("should report only the bounds, not every available version", () => {
+    const message = buildNoVersionError(
+      ["^0.9.0"],
+      ["0.8.14", "0.8.15", "0.8.16"]
+    );
+
+    assert.include(message, "Available versions: 0.8.14 - 0.8.16");
+    assert.notInclude(message, "0.8.15");
+  });
+
+  it("should report real bounds even if the list is not sorted", () => {
+    const message = buildNoVersionError(
+      ["^0.9.0"],
+      ["0.8.16", "0.3.6", "0.8.4"]
+    );
+
+    assert.include(message, "Available versions: 0.3.6 - 0.8.16");
+  });
+
+  it("should not render a range for a single available version", () => {
+    const message = buildNoVersionError(["^0.9.0"], ["0.8.16"]);
+
+    assert.include(message, "Available versions: 0.8.16");
+    assert.notInclude(message, "0.8.16 - 0.8.16");
+  });
+
+  it("should use the singular for a single pragma", () => {
+    const message = buildNoVersionError(["^0.8.28"], ["0.8.16"]);
+
+    assert.include(message, "1 pragma");
+    assert.notInclude(message, "distinct pragmas");
+  });
+
+  it("should handle an empty available list", () => {
+    const message = buildNoVersionError(["^0.8.28"], []);
+
+    assert.include(message, "Available versions: none");
+  });
+});

--- a/server/test/services/initialization/solcVersionsCache.ts
+++ b/server/test/services/initialization/solcVersionsCache.ts
@@ -1,0 +1,254 @@
+import { assert } from "chai";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import {
+  onlyValidVersions,
+  readHardhatCompilerVersions,
+  readRememberedVersions,
+  rememberVersions,
+  resolveStorageDir,
+} from "@services/initialization/solcVersionsCache";
+import { setupMockLogger } from "../../helpers/setupMockLogger";
+
+describe("solc versions cache", () => {
+  let storageDir: string;
+  const logger = setupMockLogger();
+
+  beforeEach(async () => {
+    storageDir = await fs.mkdtemp(path.join(os.tmpdir(), "solc-versions-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(storageDir, { recursive: true, force: true });
+  });
+
+  describe("resolveStorageDir", () => {
+    it("should prefer the editor-provided storage path", () => {
+      assert.strictEqual(
+        resolveStorageDir("/tmp/editor-storage"),
+        "/tmp/editor-storage"
+      );
+    });
+
+    it("should fall back to a per-user cache dir when not provided", () => {
+      assert.notStrictEqual(resolveStorageDir(undefined), "");
+      assert.notStrictEqual(resolveStorageDir("   "), "   ");
+    });
+  });
+
+  describe("round trip", () => {
+    it("should remember versions across reads", async () => {
+      await rememberVersions(storageDir, ["0.8.28", "0.8.16"], logger);
+
+      const remembered = await readRememberedVersions(storageDir, logger);
+
+      // Sorted and deduped on write.
+      assert.deepStrictEqual(remembered, ["0.8.16", "0.8.28"]);
+    });
+
+    it("should deduplicate on write", async () => {
+      await rememberVersions(
+        storageDir,
+        ["0.8.28", "0.8.28", "0.8.16"],
+        logger
+      );
+
+      assert.deepStrictEqual(await readRememberedVersions(storageDir, logger), [
+        "0.8.16",
+        "0.8.28",
+      ]);
+    });
+
+    it("should leave no temporary file behind", async () => {
+      await rememberVersions(storageDir, ["0.8.28"], logger);
+
+      // Written via a temp file and renamed, so a reader in another window can
+      // never observe a half-written file.
+      assert.deepStrictEqual(await fs.readdir(storageDir), [
+        "solc-versions.json",
+      ]);
+    });
+
+    it("should create the storage directory if it is missing", async () => {
+      const nested = path.join(storageDir, "does", "not", "exist");
+
+      await rememberVersions(nested, ["0.8.28"], logger);
+
+      assert.deepStrictEqual(await readRememberedVersions(nested, logger), [
+        "0.8.28",
+      ]);
+    });
+  });
+
+  describe("reading a cache that isn't usable", () => {
+    it("should return nothing when the file is absent", async () => {
+      assert.deepStrictEqual(
+        await readRememberedVersions(storageDir, logger),
+        []
+      );
+    });
+
+    it("should return nothing when the file is corrupt", async () => {
+      await fs.writeFile(
+        path.join(storageDir, "solc-versions.json"),
+        "{not json",
+        "utf8"
+      );
+
+      assert.deepStrictEqual(
+        await readRememberedVersions(storageDir, logger),
+        []
+      );
+    });
+
+    it("should discard entries that aren't valid versions", async () => {
+      await fs.writeFile(
+        path.join(storageDir, "solc-versions.json"),
+        JSON.stringify({ versions: ["0.8.28", "nonsense", 42, null] }),
+        "utf8"
+      );
+
+      assert.deepStrictEqual(await readRememberedVersions(storageDir, logger), [
+        "0.8.28",
+      ]);
+    });
+
+    it("should tolerate a versions field of the wrong shape", async () => {
+      await fs.writeFile(
+        path.join(storageDir, "solc-versions.json"),
+        JSON.stringify({ versions: "0.8.28" }),
+        "utf8"
+      );
+
+      assert.deepStrictEqual(
+        await readRememberedVersions(storageDir, logger),
+        []
+      );
+    });
+  });
+
+  describe("persisting is best effort", () => {
+    it("should not throw when the storage dir cannot be created", async () => {
+      // A path under a regular file can never be created as a directory.
+      const filePath = path.join(storageDir, "a-file");
+      await fs.writeFile(filePath, "", "utf8");
+
+      let threw = false;
+      try {
+        await rememberVersions(
+          path.join(filePath, "nested"),
+          ["0.8.28"],
+          logger
+        );
+      } catch {
+        threw = true;
+      }
+
+      assert.isFalse(threw, "persisting must never break validation");
+    });
+  });
+
+  describe("onlyValidVersions", () => {
+    it("should keep valid semver versions only", () => {
+      assert.deepStrictEqual(
+        onlyValidVersions(["0.8.28", "", "v", "0.8", "1.2.3"]),
+        ["0.8.28", "1.2.3"]
+      );
+    });
+
+    it("should return an empty list for non-arrays", () => {
+      assert.deepStrictEqual(onlyValidVersions(undefined), []);
+      assert.deepStrictEqual(onlyValidVersions("0.8.28"), []);
+    });
+
+    // semver.valid accepts these, but hardhat looks compilers up by exact
+    // string match, so the un-normalized form would win maxSatisfying and then
+    // resolve to no build at all.
+    it("should normalize a leading v and surrounding whitespace", () => {
+      assert.deepStrictEqual(onlyValidVersions(["v0.8.28", "  0.8.29  "]), [
+        "0.8.28",
+        "0.8.29",
+      ]);
+    });
+  });
+
+  describe("readHardhatCompilerVersions", () => {
+    async function writeList(
+      cacheRoot: string,
+      generation: string,
+      platform: string,
+      builds: unknown[]
+    ) {
+      const dir = path.join(cacheRoot, generation, platform);
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(
+        path.join(dir, "list.json"),
+        JSON.stringify({ builds }),
+        "utf8"
+      );
+    }
+
+    it("should read hardhat 2's compilers-v2 directory", async () => {
+      await writeList(storageDir, "compilers-v2", "linux-amd64", [
+        { version: "0.8.20" },
+      ]);
+
+      assert.deepStrictEqual(
+        await readHardhatCompilerVersions(logger, storageDir),
+        ["0.8.20"]
+      );
+    });
+
+    // Hardhat 3 uses a different directory. Reading only v2 made this source a
+    // silent no-op for anyone who has only ever used hardhat 3.
+    it("should read hardhat 3's compilers-v3 directory", async () => {
+      await writeList(storageDir, "compilers-v3", "wasm", [
+        { version: "0.8.30" },
+      ]);
+
+      assert.deepStrictEqual(
+        await readHardhatCompilerVersions(logger, storageDir),
+        ["0.8.30"]
+      );
+    });
+
+    it("should union both generations and all platforms", async () => {
+      await writeList(storageDir, "compilers-v2", "linux-amd64", [
+        { version: "0.8.20" },
+      ]);
+      await writeList(storageDir, "compilers-v3", "wasm", [
+        { version: "0.8.30" },
+      ]);
+      await writeList(storageDir, "compilers-v3", "linux-amd64", [
+        { version: "0.8.31" },
+      ]);
+
+      const versions = await readHardhatCompilerVersions(logger, storageDir);
+
+      assert.sameMembers(versions, ["0.8.20", "0.8.30", "0.8.31"]);
+    });
+
+    it("should exclude pre-release builds", async () => {
+      await writeList(storageDir, "compilers-v2", "linux-amd64", [
+        { version: "0.8.30" },
+        { version: "0.8.31", prerelease: "pre.1" },
+      ]);
+
+      assert.deepStrictEqual(
+        await readHardhatCompilerVersions(logger, storageDir),
+        ["0.8.30"]
+      );
+    });
+
+    it("should return nothing when no hardhat cache exists", async () => {
+      assert.deepStrictEqual(
+        await readHardhatCompilerVersions(
+          logger,
+          path.join(storageDir, "absent")
+        ),
+        []
+      );
+    });
+  });
+});

--- a/server/test/services/initialization/updateAvailableSolcVersions.ts
+++ b/server/test/services/initialization/updateAvailableSolcVersions.ts
@@ -1,0 +1,205 @@
+import { assert } from "chai";
+import fs from "fs/promises";
+import got from "got";
+import os from "os";
+import path from "path";
+import * as sinon from "sinon";
+import {
+  availableVersions,
+  loadKnownSolcVersions,
+  refreshSolcVersions,
+  releasedVersionsFrom,
+} from "@services/initialization/updateAvailableSolcVersions";
+import { readRememberedVersions } from "@services/initialization/solcVersionsCache";
+import { ServerState } from "../../../src/types";
+import { setupMockLogger } from "../../helpers/setupMockLogger";
+import { setupMockTelemetry } from "../../helpers/setupMockTelemetry";
+
+const NEWEST_BUNDLED = availableVersions[availableVersions.length - 1];
+
+// A version the bundled list does not contain. The whole point of remembering
+// and fetching is to learn about releases newer than the bundle, so asserting
+// on a version that is already bundled would pass without exercising anything.
+const FUTURE_VERSION = "0.9.99";
+
+describe("update available solc versions", () => {
+  let storageDir: string;
+  let state: ServerState;
+
+  it("guards the fixture: the future version must not be bundled", () => {
+    // If the bundled list ever grows past this, the tests below would start
+    // passing for the wrong reason.
+    assert.notInclude(availableVersions, FUTURE_VERSION);
+  });
+
+  beforeEach(async () => {
+    storageDir = await fs.mkdtemp(path.join(os.tmpdir(), "solc-versions-"));
+
+    state = {
+      logger: setupMockLogger(),
+      telemetry: setupMockTelemetry(),
+      solcVersions: availableVersions,
+      globalStoragePath: storageDir,
+    } as unknown as ServerState;
+  });
+
+  afterEach(async () => {
+    sinon.restore();
+    await fs.rm(storageDir, { recursive: true, force: true });
+  });
+
+  describe("loadKnownSolcVersions", () => {
+    it("should include versions remembered from an earlier session", async () => {
+      await fs.writeFile(
+        path.join(storageDir, "solc-versions.json"),
+        JSON.stringify({ versions: [FUTURE_VERSION] }),
+        "utf8"
+      );
+
+      await loadKnownSolcVersions(state);
+
+      // This is the regression: whatever the bundled list ends at, a project
+      // requiring something newer could not be validated at all once the
+      // network fetch failed.
+      assert.include(state.solcVersions, FUTURE_VERSION);
+      assert.include(state.solcVersions, NEWEST_BUNDLED);
+    });
+  });
+
+  // A pre-release build carries the version it is a pre-release *of*, so
+  // solc-bin lists 0.8.31-pre.1 as `{version: "0.8.31", prerelease: "pre.1"}`
+  // before 0.8.31 exists. Offering that version makes hardhat resolve the
+  // pre-release binary, whose diagnostics carry no sourceLocation.
+  describe("releasedVersionsFrom", () => {
+    it("should prefer the releases map", () => {
+      const versions = releasedVersionsFrom({
+        builds: [{ version: "0.8.31", prerelease: "pre.1" }],
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        releases: { "0.8.30": "soljson-v0.8.30.js" },
+      });
+
+      assert.deepStrictEqual(versions, ["0.8.30"]);
+    });
+
+    it("should exclude pre-release builds when falling back to builds", () => {
+      const versions = releasedVersionsFrom({
+        builds: [
+          { version: "0.8.30" },
+          { version: "0.8.31", prerelease: "pre.1" },
+        ],
+      });
+
+      assert.deepStrictEqual(versions, ["0.8.30"]);
+    });
+
+    it("should treat null and empty prerelease fields as pre-release-free", () => {
+      const versions = releasedVersionsFrom({
+        builds: [
+          { version: "0.8.29", prerelease: null },
+          { version: "0.8.30", prerelease: "" },
+        ],
+      });
+
+      assert.deepStrictEqual(versions, ["0.8.29", "0.8.30"]);
+    });
+
+    it("should tolerate a malformed payload", () => {
+      assert.deepStrictEqual(releasedVersionsFrom({}), []);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      assert.deepStrictEqual(releasedVersionsFrom({ builds: "x" } as any), []);
+    });
+  });
+
+  describe("refreshSolcVersions", () => {
+    function stubFetch(released: string[], prereleaseOnly: string[] = []) {
+      return sinon.stub(got, "get").returns({
+        json: async () => ({
+          builds: [
+            ...released.map((version) => ({ version })),
+            ...prereleaseOnly.map((version) => ({
+              version,
+              prerelease: "pre.1",
+            })),
+          ],
+          releases: Object.fromEntries(
+            released.map((version) => [version, `soljson-v${version}.js`])
+          ),
+        }),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+    }
+
+    it("should not offer or persist a version that is only a pre-release", async () => {
+      stubFetch([], [FUTURE_VERSION]);
+
+      await refreshSolcVersions(state);
+
+      assert.notInclude(state.solcVersions, FUTURE_VERSION);
+      assert.notInclude(
+        await readRememberedVersions(storageDir, state.logger),
+        FUTURE_VERSION,
+        "an unreleased version must not be remembered across restarts"
+      );
+    });
+
+    it("should union fetched versions into the known set", async () => {
+      stubFetch([FUTURE_VERSION]);
+
+      await refreshSolcVersions(state);
+
+      assert.include(state.solcVersions, FUTURE_VERSION);
+      assert.include(state.solcVersions, NEWEST_BUNDLED);
+    });
+
+    it("should persist what it fetched", async () => {
+      stubFetch([FUTURE_VERSION]);
+
+      await refreshSolcVersions(state);
+
+      const remembered = await readRememberedVersions(storageDir, state.logger);
+
+      assert.include(remembered, FUTURE_VERSION);
+    });
+
+    it("should keep the known set when the fetch fails", async () => {
+      sinon.stub(got, "get").throws(new Error("ENOTFOUND"));
+
+      await refreshSolcVersions(state);
+
+      assert.includeMembers(state.solcVersions, availableVersions);
+    });
+
+    it("should not persist anything when the fetch fails", async () => {
+      sinon.stub(got, "get").throws(new Error("ENOTFOUND"));
+
+      await refreshSolcVersions(state);
+
+      assert.deepStrictEqual(
+        await readRememberedVersions(storageDir, state.logger),
+        []
+      );
+    });
+
+    it("should not lose previously remembered versions on a later failure", async () => {
+      stubFetch([FUTURE_VERSION]);
+      await refreshSolcVersions(state);
+      sinon.restore();
+
+      // A second session that can't reach the network.
+      const offlineState = {
+        logger: setupMockLogger(),
+        telemetry: setupMockTelemetry(),
+        solcVersions: availableVersions,
+        globalStoragePath: storageDir,
+      } as unknown as ServerState;
+
+      await loadKnownSolcVersions(offlineState);
+
+      assert.include(
+        offlineState.solcVersions,
+        FUTURE_VERSION,
+        "a failed fetch must not undo what we already learned"
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes #711

The reported issue is a solc version being unavailable, even though then the thread develops into a separate issue (sourceLocation `file` undefined on foundry projects).

This PR addresses the version issue. The list of supported solc versions was updated, and the mechanism that keeps it up to date was improved. When new solc versions are seen in the registry, they are stored in local cache so subsequent sessions can find them even if the registry request fails. Additionally, the `list.json` file from Hardhat is read in a best-effort way to further enrich the version list.

When a suitable version that can satisfy all the pragmas is not found , the error message is more legible now.

Additionally, several test cases were added.