### PR TITLE
drop node 20

### DIFF
--- a/.changeset/drop-node-20-support.md
+++ b/.changeset/drop-node-20-support.md
@@ -1,0 +1,7 @@
+---
+"@nomicfoundation/solidity-language-server": minor
+"@nomicfoundation/coc-solidity": minor
+"hardhat-solidity": minor
+---
+
+Drop Node 20 support, the extension now requires VS Code 1.101.0.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        node: [22.15.1, 22]
+        node: [22.15.1, 24.x]
 
     steps:
       - name: Clone repository

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
           cache-name: cache-vscode
         with:
           path: .vscode-test
-          key: ${{ runner.os }}-vscode-1.90.0
+          key: ${{ runner.os }}-vscode-1.101.0
 
       - name: Run E2E tests
         uses: coactions/setup-xvfb@v1.0.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        node: [20.18.0, 20.19.0, 22.15.0]
+        node: [22.15.1, 22]
 
     steps:
       - name: Clone repository

--- a/client/package.json
+++ b/client/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/NomicFoundation/hardhat-vscode/issues"
   },
   "engines": {
-    "vscode": "^1.99.0"
+    "vscode": "^1.101.0"
   },
   "activationEvents": [
     "workspaceContains:**/hardhat.config.{ts,js}",

--- a/client/package.json
+++ b/client/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@types/prettier": "2.6.0",
-    "@types/vscode": "^1.90",
+    "@types/vscode": "~1.101.0",
     "rimraf": "3.0.2",
     "prettier": "2.5.1"
   },

--- a/coc/package.json
+++ b/coc/package.json
@@ -37,7 +37,7 @@
   },
   "engines": {
     "coc": "^0.0.80",
-    "node": ">=20.9.0"
+    "node": ">=22.15.1"
   },
   "activationEvents": [
     "onLanguage:solidity"

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
       },
       "engines": {
         "coc": "^0.0.80",
-        "node": ">=20.9.0"
+        "node": ">=22.15.1"
       }
     },
     "coc/node_modules/@types/node": {
@@ -15020,7 +15020,7 @@
         "yaml": "^2.2.1"
       },
       "engines": {
-        "node": ">=20.9.0"
+        "node": ">=22.15.1"
       }
     },
     "server/node_modules/@cspotcode/source-map-support": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",
         "@types/module-alias": "2.0.1",
-        "@types/vscode": "^1.90",
+        "@types/vscode": "~1.101.0",
         "@typescript-eslint/eslint-plugin": "^7.7.1",
         "@typescript-eslint/parser": "^7.7.1",
         "@vscode/test-electron": "2.3.8",
@@ -48,12 +48,12 @@
       },
       "devDependencies": {
         "@types/prettier": "2.6.0",
-        "@types/vscode": "^1.90",
+        "@types/vscode": "~1.101.0",
         "prettier": "2.5.1",
         "rimraf": "3.0.2"
       },
       "engines": {
-        "vscode": "^1.99.0"
+        "vscode": "^1.101.0"
       }
     },
     "coc": {
@@ -4161,9 +4161,9 @@
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.98.0.tgz",
-      "integrity": "sha512-+KuiWhpbKBaG2egF+51KjbGWatTH5BbmWQjSLMDCssb4xF8FJnW4nGH4nuAdOOfMbpD0QlHtI+C3tPq+DoKElg==",
+      "version": "1.101.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.101.0.tgz",
+      "integrity": "sha512-ZWf0IWa+NGegdW3iU42AcDTFHWW7fApLdkdnBqwYEtHVIBGbTu0ZNQKP/kX3Ds/uMJXIMQNAojHR4vexCEEz5Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/glob": "^7.1.3",
     "@types/mocha": "^8.2.2",
     "@types/module-alias": "2.0.1",
-    "@types/vscode": "^1.90",
+    "@types/vscode": "~1.101.0",
     "@typescript-eslint/eslint-plugin": "^7.7.1",
     "@typescript-eslint/parser": "^7.7.1",
     "@vscode/test-electron": "2.3.8",

--- a/server/.mocharc.js
+++ b/server/.mocharc.js
@@ -1,7 +1,18 @@
+// Node 22.18 and later strip type annotations from `.ts` files before
+// `ts-node` sees them, which leaves ts-node compiling annotation-free source
+// and reporting spurious implicit-any errors. Turn stripping off where it is
+// on by default; older versions do not know the flag.
+const [nodeMajor, nodeMinor] = process.versions.node.split(".").map(Number);
+const stripsTypesByDefault =
+  nodeMajor > 22 || (nodeMajor === 22 && nodeMinor >= 18);
+
 module.exports = {
   file: ["./test/setup.ts"],
   require: "ts-node/register",
   spec: "test/**/*.ts",
   timeout: 5000,
   exit: true,
+  ...(stripsTypesByDefault
+    ? { "node-option": ["no-experimental-strip-types"] }
+    : {}),
 };

--- a/server/package.json
+++ b/server/package.json
@@ -24,7 +24,7 @@
     "nomicfoundation-solidity-language-server": "./out/index.js"
   },
   "engines": {
-    "node": ">=20.9.0"
+    "node": ">=22.15.1"
   },
   "scripts": {
     "build": "tsc -b tsconfig.build.json",

--- a/test/e2e/src/runTests.ts
+++ b/test/e2e/src/runTests.ts
@@ -21,7 +21,7 @@ const main = async () => {
 
     // Download VS Code, unzip it and run the e2e test
     await runTests({
-      version: "1.99.0",
+      version: "1.101.0",
       extensionDevelopmentPath,
       extensionTestsPath,
 

--- a/test/protocol/.mocharc.js
+++ b/test/protocol/.mocharc.js
@@ -1,6 +1,17 @@
+// Node 22.18 and later strip type annotations from `.ts` files before
+// `ts-node` sees them, which leaves ts-node compiling annotation-free source
+// and reporting spurious implicit-any errors. Turn stripping off where it is
+// on by default; older versions do not know the flag.
+const [nodeMajor, nodeMinor] = process.versions.node.split(".").map(Number);
+const stripsTypesByDefault =
+  nodeMajor > 22 || (nodeMajor === 22 && nodeMinor >= 18);
+
 module.exports = {
   require: 'ts-node/register',
   spec: 'test/**/*.ts',
   timeout: 30000,
   exit: true,
+  ...(stripsTypesByDefault
+    ? { 'node-option': ['no-experimental-strip-types'] }
+    : {}),
 }


### PR DESCRIPTION
Our Node 20 support is out of date now that cursor has moved to Node 22. Currently Node 24 is the Node version used in the latest vscode releases.

## Review

> [!TIP]
> Review a commit at a time

The first commits fix up some prettier issues. We then update the version numbers. There is a final fix to let us run the mocha test suites against Node 24 (turn off experimental type stripping).