### PR TITLE
chore: bump slang

### DIFF
--- a/.changeset/bump-slang.md
+++ b/.changeset/bump-slang.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/solidity-language-server": patch
+---
+
+Update Slang to 1.3.8, so that document symbols and semantic highlighting parse Solidity up to 0.8.36.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,8 +113,8 @@ importers:
   server:
     dependencies:
       '@nomicfoundation/slang':
-        specifier: 1.0.0
-        version: 1.0.0
+        specifier: 1.3.8
+        version: 1.3.8
       '@nomicfoundation/solidity-analyzer':
         specifier: 0.1.1
         version: 0.1.1
@@ -410,8 +410,8 @@ packages:
     resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@bytecodealliance/preview2-shim@0.17.2':
-    resolution: {integrity: sha512-mNm/lblgES8UkVle8rGImXOz4TtL3eU3inHay/7TVchkKrb/lgcVvTK0+VAw8p5zQ0rgQsXm1j5dOlAAd+MeoA==}
+  '@bytecodealliance/preview2-shim@0.19.0':
+    resolution: {integrity: sha512-OSUlcM62fXLuzYP0DjBn/SwjKMZ/y/2PMXZ8v5cRiiFcroauntlPRl/oCnx0xYjYiqdYvE0PY50VCNutll0xOw==}
 
   '@changesets/apply-release-plan@5.0.5':
     resolution: {integrity: sha512-CxL9dkhzjHiVmXCyHgsLCQj7i/coFTMv/Yy0v6BC5cIWZkQml+lf7zvQqAcFXwY7b54HxRWZPku02XFB53Q0Uw==}
@@ -1061,8 +1061,8 @@ packages:
     peerDependencies:
       zod: ^3.23.8
 
-  '@nomicfoundation/slang@1.0.0':
-    resolution: {integrity: sha512-dnfv/+84/+iTSLBvqNQDA4/OZuq0tvJgFFwvnMwIdnMvn8QDcdouPTgF/nOwEuDtcIw5KWFzEf++UqpfwXCRpw==}
+  '@nomicfoundation/slang@1.3.8':
+    resolution: {integrity: sha512-it0o2vGb56kqOEUiIreLTqEwiWitWDDOiUCWCO3PfzBXD3kkIFLQ3Ly/4xNgCo0LF5xqGECr+DcCNbfspSClPA==}
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.1':
     resolution: {integrity: sha512-KcTodaQw8ivDZyF+D76FokN/HdpgGpfjc/gFCImdLUyqB6eSWVaZPazMbeAjmfhx3R0zm/NYVzxwAokFKgrc0w==}
@@ -4618,7 +4618,7 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@bytecodealliance/preview2-shim@0.17.2': {}
+  '@bytecodealliance/preview2-shim@0.19.0': {}
 
   '@changesets/apply-release-plan@5.0.5':
     dependencies:
@@ -5314,9 +5314,9 @@ snapshots:
       '@nomicfoundation/hardhat-utils': 4.1.7
       zod: 3.25.76
 
-  '@nomicfoundation/slang@1.0.0':
+  '@nomicfoundation/slang@1.3.8':
     dependencies:
-      '@bytecodealliance/preview2-shim': 0.17.2
+      '@bytecodealliance/preview2-shim': 0.19.0
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.1':
     optional: true

--- a/server/package.json
+++ b/server/package.json
@@ -88,7 +88,7 @@
     "yaml": "^2.2.1"
   },
   "dependencies": {
-    "@nomicfoundation/slang": "1.0.0",
+    "@nomicfoundation/slang": "1.3.8",
     "@nomicfoundation/solidity-analyzer": "0.1.1",
     "es-iterator-helpers": "^1.2.1"
   }


### PR DESCRIPTION
`@nomicfoundation/slang@1.0.0` knows Solidity up to 0.8.28, while the solc version list the extension bundles runs to 0.8.36.

No source changes were needed.
