### PR TITLE
chore: add types hoist ban

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,9 @@ allowBuilds:
   keytar: false
   secp256k1: false
 
+hoistPattern:
+  - "!@types/*"
+
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - hardhat


### PR DESCRIPTION
Immitate the Hardhat types hoist ban, this is to avoid cases where the typescript compilation is against the wrong version of types due to hoisting.
