### PR TITLE
chore: notify during publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,18 +164,120 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: node scripts/release/main.ts review
 
+  notify-deploy:
+    name: Notify pre-deploy to Slack
+    needs: [pack, review]
+    if: needs.pack.outputs.hasPackages == 'true'
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    permissions: {} # Slack webhook only, no GitHub API calls
+    steps:
+      - name: Notify pre-deploy
+        continue-on-error: true
+        timeout-minutes: 1
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+        with:
+          webhook: ${{ secrets.PUBLISHING_NOTIFICATIONS_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "Deployment review requested by ${{ github.actor }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Deployment review requested by ${{ github.actor }}*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} #${{ github.run_number }}> / Publish packages"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "`publish` waiting for review — v${{ needs.pack.outputs.version }}"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "${{ github.repository }}"
+                    }
+                  ]
+                }
+              ]
+            }
+
   publish:
     name: Publish packages
-    needs: [pack, review]
+    needs: [pack, review, notify-deploy]
     if: needs.pack.outputs.hasPackages == 'true'
     timeout-minutes: 60
     runs-on: ubuntu-latest
     environment: publish
     permissions:
-      actions: read # To download the artifacts to publish
+      actions: read # To download the artifacts, and to read who approved the deployment
       id-token: write # Needed for npm Trusted Publishing (OIDC)
       contents: read # For the scripts these steps run
     steps:
+      - name: Get approver
+        id: approver
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          approver=$(gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals" --jq '.[0].user.login // empty') || true
+
+          if [[ -z "$approver" ]]; then
+            echo "::warning::No approver from the approvals API; using github.actor"
+          fi
+
+          echo "login=${approver:-$GITHUB_ACTOR}" >> "$GITHUB_OUTPUT"
+
+      - name: Notify deployment approved
+        continue-on-error: true
+        timeout-minutes: 1
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+        with:
+          webhook: ${{ secrets.PUBLISHING_NOTIFICATIONS_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "Deployment review approved by ${{ steps.approver.outputs.login }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Deployment review approved by ${{ steps.approver.outputs.login }}*\n:rocket: Publishing v${{ needs.pack.outputs.version }} now"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} #${{ github.run_number }}>"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "${{ github.repository }}"
+                    }
+                  ]
+                }
+              ]
+            }
+
       - name: Checkout Repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/docs/publish-extension.md
+++ b/docs/publish-extension.md
@@ -17,7 +17,7 @@ Name **all three** packages with the same bump, `patch` or `minor` — they are 
 ## Cutting a release
 
 1. **Merge the Version Packages PR.** The release workflow keeps it open and up to date while changesets accumulate on `main`. It applies them, moves all three packages to the next version, and writes the changelogs. Merging it is the decision to release.
-2. **Approve the deployment.** Merging that PR starts a run that builds the tarballs and the vsix, diffs them against what is already published, and then waits on the `publish` environment. Approving is what says a release was intended — you can download the vsix from the run and try it first, but that is optional.
+2. **Approve the deployment.** Merging that PR starts a run that builds the tarballs and the vsix, diffs them against what is already published, posts to Slack that a review is waiting, and then waits on the `publish` environment. Approving is what says a release was intended — you can download the vsix from the run and try it first, but that is optional.
 3. **Announce it** in the Discord announcements channel, linking the release and saying what is worth knowing about it.
 
 That is the whole flow. The run then publishes both npm packages, uploads the vsix to the Visual Studio Marketplace and Open VSX, tags `vX.Y.Z`, and creates the GitHub release with the vsix attached.
@@ -52,6 +52,7 @@ Held by the repository, not by people:
 
 - `SOLIDITY_GA_SECRET`, `SOLIDITY_GOOGLE_TRACKING_ID`, `SOLIDITY_SENTRY_DSN` — inlined into the bundle when the artifacts are built.
 - `VSCE_TOKEN`, `OVSX_TOKEN` — on the `publish` environment, so they are only reachable after the approval.
+- `PUBLISHING_NOTIFICATIONS_SLACK_WEBHOOK_URL` — the channel that is told a release is waiting for review, and that it was approved.
 - `RELEASE_GITHUB_TOKEN` — lets the Version Packages PR trigger its own checks.
 
 npm needs no token: publishing uses Trusted Publishing, which authenticates the workflow itself.


### PR DESCRIPTION
Pull across the notification infrastructure from Hardhat.

We use this in the CI GitHub Actions to announce a publishing review is required, and that one has been approved.
