### PR TITLE
fix: prettier formatter import

### DIFF
--- a/server/src/utils/PrettyPrinter.ts
+++ b/server/src/utils/PrettyPrinter.ts
@@ -1,5 +1,5 @@
 import * as prettier from "prettier";
-import * as prettierPluginSolidity from "prettier-plugin-solidity";
+import prettierPluginSolidity from "prettier-plugin-solidity";
 import { ASTNode, TextDocument } from "@common/types";
 import { URI } from "vscode-uri";
 


### PR DESCRIPTION
The import switched from CJS to ESM. We switch to the default import to
avoid the confusion.